### PR TITLE
Add smoke test for reffy-reports integration

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -5628,7 +5628,7 @@
       }
     },
     "reffy-reports": {
-      "version": "git://github.com/foolip/reffy-reports.git#73bbd1a19dcb1542be400649d652de4de8bdcf07",
+      "version": "git://github.com/foolip/reffy-reports.git#772275ba912b67ee116eb557a255a80ae69e3810",
       "from": "git://github.com/foolip/reffy-reports.git#mdn-bcd-updater-fixes"
     },
     "regex-not": {

--- a/test/integration/reffy-reports.js
+++ b/test/integration/reffy-reports.js
@@ -1,0 +1,36 @@
+// Copyright 2019 Google LLC
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//     https://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+'use strict';
+
+const assert = require('assert');
+
+describe('reffy-reports', () => {
+  let reffy;
+
+  it('require module', () => {
+    reffy = require('../../reffy-reports');
+  });
+
+  it('has some CSS data', () => {
+    assert('white-space' in reffy.css['css-text'].properties);
+  });
+
+  it('has some IDL data', () => {
+    const iface = reffy.idl.dom.find((node) => node.name === 'Attr');
+    assert(iface);
+    const member = iface.members.find((m) => m.name === 'specified');
+    assert(member);
+  });
+});


### PR DESCRIPTION
This depends on the real data scraped from specs and would fail if
specs are reorganized, so the picked examples are ones which are very
unlikely to change.