### PR TITLE
Fix and test IDL static operations after webidl2.js upgrade

### DIFF
--- a/build.js
+++ b/build.js
@@ -248,7 +248,7 @@ function buildIDLTests(ast) {
     members.sort((a, b) => a.name.localeCompare(b.name));
 
     for (const member of members) {
-      const isStatic = member.special && member.special.value === 'static';
+      const isStatic = member.special === 'static';
       let expr;
       switch (member.type) {
         case 'attribute':

--- a/test/unit/build.js
+++ b/test/unit/build.js
@@ -79,6 +79,17 @@ describe('build', () => {
       ]);
     });
 
+    it('interface with static method', () => {
+      const ast = WebIDL2.parse(
+          `interface MediaSource {
+             static boolean isTypeSupported(DOMString type);
+           };`);
+      assert.deepEqual(buildIDLTests(ast), [
+        ['MediaSource', '\'MediaSource\' in self'],
+        ['MediaSource.isTypeSupported', '\'isTypeSupported\' in MediaSource'],
+      ]);
+    });
+
     it('namespace with attribute', () => {
       const ast = WebIDL2.parse(
           `namespace CSS {


### PR DESCRIPTION
Broken by https://github.com/foolip/mdn-bcd-collector/pull/28 and not
noticed because there were no tests.