### PR TITLE
Catch and log errors in build.js

### DIFF
--- a/build.js
+++ b/build.js
@@ -381,5 +381,8 @@ if (process.env.NODE_ENV === 'test') {
 } else {
   const bcd = require('mdn-browser-compat-data');
   const reffy = require('./reffy-reports');
-  build(bcd, reffy);
+  build(bcd, reffy).catch((reason) => {
+    console.error(reason);
+    process.exit(1);
+  });
 }

--- a/package.json
+++ b/package.json
@@ -13,7 +13,7 @@
   },
   "scripts": {
     "lint": "eslint .",
-    "build": "node --throw-deprecation build.js",
+    "build": "node build.js",
     "gcp-build": "npm run build",
     "deploy": "gcloud app deploy",
     "start": "node app.js",


### PR DESCRIPTION
Unhandled promise rejections don't have the error stack, so
`--throw-deprecation` isn't very helpful for debugging.