### PR TITLE
Split push and pull_request workflows in GitHub Actions

### DIFF
--- a/.github/workflows/pull_request.yml
+++ b/.github/workflows/pull_request.yml
@@ -1,0 +1,37 @@
+on: pull_request
+name: Lint & Test
+jobs:
+  lint:
+    name: Lint
+    runs-on: ubuntu-latest
+    steps:
+    - name: Install
+      uses: actions/npm@master
+      with:
+        args: install
+    - name: Lint
+      uses: actions/npm@master
+      with:
+        args: run lint
+  test:
+    name: Test
+    runs-on: ubuntu-latest
+    steps:
+    - name: Install
+      uses: actions/npm@master
+      with:
+        args: install
+    - name: Build
+      uses: actions/npm@master
+      with:
+        args: run build
+    - name: Test
+      uses: actions/npm@master
+      with:
+        args: run coverage
+    - name: Coverage
+      uses: actions/npm@master
+      env:
+        CODECOV_TOKEN: ${{ secrets.CODECOV_TOKEN }}
+      with:
+        args: run report-coverage

--- a/.github/workflows/push.yml
+++ b/.github/workflows/push.yml
@@ -1,11 +1,17 @@
-on: push
-name: Lint, Test & Deploy
+on:
+  push:
+    branches:
+    - master
+name: Test & Deploy
 jobs:
-  build:
-    name: Build
+  test:
+    name: Test
     runs-on: ubuntu-latest
     steps:
-    - uses: actions/checkout@master
+    - name: Install
+      uses: actions/npm@master
+      with:
+        args: install
     - name: Build
       uses: actions/npm@master
       with:
@@ -14,24 +20,17 @@ jobs:
       uses: actions/npm@master
       with:
         args: run coverage
-    - name: Install
-      uses: actions/npm@master
-      with:
-        args: install
     - name: Coverage
       uses: actions/npm@master
       env:
         CODECOV_TOKEN: ${{ secrets.CODECOV_TOKEN }}
       with:
         args: run report-coverage
-    - name: Lint
-      uses: actions/npm@master
-      with:
-        args: run lint
-    - name: Master
-      uses: actions/bin/filter@master
-      with:
-        args: branch master
+  deploy:
+    name: Deploy
+    needs: test
+    runs-on: ubuntu-latest
+    steps:
     - name: Secrets
       uses: actions/bin/sh@master
       env:


### PR DESCRIPTION
No need to have deploy blocked on lint, or to have deploy listed in
PRs at all. Presumably there's a template system coming to share
steps.