### PR TITLE
Split push and pull_request workflows in GitHub Actions

### DIFF
--- a/.github/workflows/pull_request.yml
+++ b/.github/workflows/pull_request.yml
@@ -1,0 +1,21 @@
+on: pull_request
+name: PR
+jobs:
+  lint:
+    name: Lint
+    runs-on: ubuntu-latest
+    steps:
+    - uses: actions/checkout@v1
+    - run: npm install
+    - run: npm run lint
+  test:
+    name: Test
+    runs-on: ubuntu-latest
+    steps:
+    - uses: actions/checkout@v1
+    - run: npm install
+    - run: npm run build
+    - run: npm run coverage
+    - run: npm run report-coverage
+      env:
+        CODECOV_TOKEN: ${{ secrets.CODECOV_TOKEN }}

--- a/.github/workflows/push.yml
+++ b/.github/workflows/push.yml
@@ -1,13 +1,9 @@
-on: push
-name: Lint, Test & Deploy
+on:
+  push:
+    branches:
+    - master
+name: master
 jobs:
-  lint:
-    name: Lint
-    runs-on: ubuntu-latest
-    steps:
-    - uses: actions/checkout@v1
-    - run: npm install
-    - run: npm run lint
   test:
     name: Test
     runs-on: ubuntu-latest
@@ -33,4 +29,3 @@ jobs:
     - uses: actions/gcloud/cli@master
       with:
         args: app deploy --project=mdn-bcd-collector
-      if: github.branch == 'master'


### PR DESCRIPTION
No need to have deploy blocked on lint, or to have deploy listed in
PRs at all. Presumably there's a template system coming to share
steps.