### PR TITLE
Fix issues in results generated by 0.0.2

### DIFF
--- a/build.js
+++ b/build.js
@@ -51,9 +51,9 @@ function collectCSSPropertiesFromBCD(bcd, propertySet) {
       if (statement.alternative_name) {
         propertySet.add(statement.alternative_name);
       }
-      if (statement.prefix) {
-        propertySet.add(`${statement.prefix}${prop}`);
-      }
+      // if (statement.prefix) {
+      //   propertySet.add(`${statement.prefix}${prop}`);
+      // }
     }
     for (const statement of Object.values(support)) {
       process(statement);
@@ -73,6 +73,8 @@ function collectCSSPropertiesFromReffy(reffy, propertySet) {
 // `propertySet` during iteration of the same and this is safe, see
 // https://stackoverflow.com/a/28306768
 function expandCSSProperties(propertySet) {
+  return; // XXX Moving prefix tests into the harness
+
   for (const prop of propertySet) {
     const unprefixedProp = prop.replace(/^-[^-]+-/, '');
     if (unprefixedProp !== prop) {
@@ -142,7 +144,7 @@ function buildCSS(bcd, reffy) {
   const propertySet = new Set;
   collectCSSPropertiesFromBCD(bcd, propertySet);
   collectCSSPropertiesFromReffy(reffy, propertySet);
-  expandCSSProperties(propertySet);
+  // expandCSSProperties(propertySet);
 
   const propertyNames = Array.from(propertySet);
   propertyNames.sort();

--- a/build.js
+++ b/build.js
@@ -51,9 +51,6 @@ function collectCSSPropertiesFromBCD(bcd, propertySet) {
       if (statement.alternative_name) {
         propertySet.add(statement.alternative_name);
       }
-      // if (statement.prefix) {
-      //   propertySet.add(`${statement.prefix}${prop}`);
-      // }
     }
     for (const statement of Object.values(support)) {
       process(statement);
@@ -65,24 +62,6 @@ function collectCSSPropertiesFromReffy(reffy, propertySet) {
   for (const data of Object.values(reffy.css)) {
     for (const prop of Object.keys(data.properties)) {
       propertySet.add(prop);
-    }
-  }
-}
-
-// Add prefixed forms from unprefixed and vice versa. Items are added to
-// `propertySet` during iteration of the same and this is safe, see
-// https://stackoverflow.com/a/28306768
-function expandCSSProperties(propertySet) {
-  return; // XXX Moving prefix tests into the harness
-
-  for (const prop of propertySet) {
-    const unprefixedProp = prop.replace(/^-[^-]+-/, '');
-    if (unprefixedProp !== prop) {
-      propertySet.add(unprefixedProp);
-      // fall through to add other prefixed forms
-    }
-    for (const prefix of ['moz', 'ms', 'webkit']) {
-      propertySet.add(`-${prefix}-${unprefixedProp}`);
     }
   }
 }
@@ -144,7 +123,6 @@ function buildCSS(bcd, reffy) {
   const propertySet = new Set;
   collectCSSPropertiesFromBCD(bcd, propertySet);
   collectCSSPropertiesFromReffy(reffy, propertySet);
-  // expandCSSProperties(propertySet);
 
   const propertyNames = Array.from(propertySet);
   propertyNames.sort();
@@ -650,7 +628,6 @@ if (process.env.NODE_ENV === 'test') {
     cssPropertyToIDLAttribute,
     collectCSSPropertiesFromBCD,
     collectCSSPropertiesFromReffy,
-    expandCSSProperties,
     flattenIDL
   };
 } else {

--- a/build.js
+++ b/build.js
@@ -561,7 +561,7 @@ function buildIDLServiceWorker(ast) {
   const pathname = path.join('api', 'serviceworkerinterfaces.html');
   const filename = path.join(generatedDir, pathname);
   writeText(filename, lines);
-  return [['http', pathname], ['https', pathname]];
+  return [['https', pathname]];
 }
 
 function buildIDL(_, reffy) {

--- a/build.js
+++ b/build.js
@@ -328,6 +328,8 @@ function buildIDLTests(ast, scope = 'Window') {
     // Avoid generating duplicate tests for operations.
     const handledMemberNames = new Set();
 
+    // TODO: add test for API's constructor
+
     for (const member of members) {
       if (handledMemberNames.has(member.name)) {
         continue;

--- a/static/resources/harness.js
+++ b/static/resources/harness.js
@@ -69,7 +69,7 @@
 
         for (var i in data.code) {
           var subtest = data.code[i];
-          
+
           for (var j in prefixesToTest) {
             var prefix = prefixesToTest[j];
             var property = subtest.property;
@@ -227,7 +227,7 @@
           message: 'No worker support'
         };
 
-        if (info !== undefined) {
+        if (pending[i].info !== undefined) {
           result.info = pending[i].info;
         }
 
@@ -296,7 +296,7 @@
           message: 'No service worker support'
         };
 
-        if (info !== undefined) {
+        if (pending[i].info !== undefined) {
           result.info = pending[i].info;
         }
 

--- a/static/resources/harness.js
+++ b/static/resources/harness.js
@@ -217,13 +217,14 @@
       }
 
       for (i = 0; i < length; i++) {
-        var name = pending[i][0];
-        var info = pending[i][2];
-
-        var result = {name: name, result: false, message: 'No worker support'};
+        var result = {
+          name: pending[i].name,
+          result: false,
+          message: 'No worker support'
+        };
 
         if (info !== undefined) {
-          result.info = info;
+          result.info = pending[i].info;
         }
 
         results.push(result);
@@ -285,17 +286,14 @@
 
       var length = pending.length;
       for (var i = 0; i < length; i++) {
-        var name = pending[i][0];
-        var info = pending[i][2];
-
         var result = {
-          name: name,
+          name: pending[i].name,
           result: false,
           message: 'No service worker support'
         };
 
         if (info !== undefined) {
-          result.info = info;
+          result.info = pending[i].info;
         }
 
         results.push(result);

--- a/static/resources/harness.js
+++ b/static/resources/harness.js
@@ -103,7 +103,11 @@
             result.result = value;
             if (value === true) {
               if (subtest.scope === 'CSS.supports') {
-                parentPrefix = '-' + prefix + '-';
+                if (prefix) {
+                  parentPrefix = '-' + prefix + '-';
+                } else {
+                  parentPrefix = '';
+                }
               } else {
                 parentPrefix = prefix;
               }

--- a/static/resources/harness.js
+++ b/static/resources/harness.js
@@ -69,6 +69,7 @@
 
         for (var i in data.code) {
           var subtest = data.code[i];
+          
           for (var j in prefixesToTest) {
             var prefix = prefixesToTest[j];
             var property = subtest.property;

--- a/static/resources/harness.js
+++ b/static/resources/harness.js
@@ -102,7 +102,7 @@
 
             result.result = value;
             if (value === true) {
-              if (subtest.scope === 'CSS.supports') {
+              if (subtest.scope.startsWith('CSS')) {
                 if (prefix) {
                   parentPrefix = '-' + prefix + '-';
                 } else {

--- a/static/resources/harness.js
+++ b/static/resources/harness.js
@@ -77,7 +77,11 @@
             if (subtest.scope === 'CSS.supports') {
               if ('CSS' in self) {
                 if (prefix) {
-                  property = '-' + prefix + '-' + property;
+                  var prefixToAdd = '-' + prefix;
+                  if (!property.startsWith('-')) {
+                    prefixToAdd += '-';
+                  }
+                  property = prefixToAdd + property;
                 }
 
                 value = CSS.supports(property, 'inherit');

--- a/test/unit/build.js
+++ b/test/unit/build.js
@@ -25,7 +25,6 @@ const {
   cssPropertyToIDLAttribute,
   collectCSSPropertiesFromBCD,
   collectCSSPropertiesFromReffy,
-  expandCSSProperties,
   flattenIDL
 } = require('../../build');
 
@@ -47,28 +46,6 @@ describe('build', () => {
       collectCSSPropertiesFromBCD(bcd, propertySet);
       const properties = Array.from(propertySet);
       assert.deepEqual(properties, ['appearance']);
-    });
-
-    it('prefixed support', () => {
-      const bcd = {
-        css: {
-          properties: {
-            appearance: {
-              __compat: {
-                support: {
-                  safari: {
-                    prefix: '-webkit-'
-                  }
-                }
-              }
-            }
-          }
-        }
-      };
-      const propertySet = new Set();
-      collectCSSPropertiesFromBCD(bcd, propertySet);
-      const properties = Array.from(propertySet);
-      assert.deepEqual(properties, ['appearance', '-webkit-appearance']);
     });
 
     it('aliased support', () => {
@@ -114,32 +91,6 @@ describe('build', () => {
     collectCSSPropertiesFromReffy(reffy, propertySet);
     const properties = Array.from(propertySet);
     assert.deepEqual(properties, ['font-family', 'font-weight', 'grid']);
-  });
-
-  describe('expandCSSProperties', () => {
-    it('unprefixed input', () => {
-      const propertySet = new Set(['foo']);
-      expandCSSProperties(propertySet);
-      const properties = Array.from(propertySet);
-      assert.deepEqual(properties,
-          ['foo', '-moz-foo', '-ms-foo', '-webkit-foo']);
-    });
-
-    it('unprefixed + prefixed input', () => {
-      const propertySet = new Set(['foo', '-webkit-foo']);
-      expandCSSProperties(propertySet);
-      const properties = Array.from(propertySet);
-      assert.deepEqual(properties,
-          ['foo', '-webkit-foo', '-moz-foo', '-ms-foo']);
-    });
-
-    it('prefixed input', () => {
-      const propertySet = new Set(['-moz-foo']);
-      expandCSSProperties(propertySet);
-      const properties = Array.from(propertySet);
-      assert.deepEqual(properties,
-          ['-moz-foo', 'foo', '-ms-foo', '-webkit-foo']);
-    });
   });
 
   it('cssPropertyToIDLAttribute', () => {


### PR DESCRIPTION
This PR fixes a number of issues in the 0.0.2 commit just before, namely:
- Service workers require secure contexts
- Web workers and service workers generated odd results if they weren't supported
- Fix CSS prefix reports
- Disable CSS prefix generation in build.js