### PR TITLE
Add reports section to DESIGN.md

### DIFF
--- a/DESIGN.md
+++ b/DESIGN.md
@@ -197,4 +197,4 @@ entirely static.
 
 ## Reports
 
-A `bcd_report.json` is written somewhere. TODO: where?
+A JSON report file is automatically generated and submitted to https://github.com/foolip/mdn-bcd-results as a pull request.  A user can also download the JSON report by visiting `/api/results` (of which is linked at the end of the tests).


### PR DESCRIPTION
It appears the reports section in `DESIGN.md` wasn't updated to mention where the reports are being stored.  This fixes that, adding content to the section.