### PR TITLE
Add more unittests for build.js

### DIFF
--- a/build.js
+++ b/build.js
@@ -506,9 +506,7 @@ function validateIDL(ast) {
     validationError = true;
   }
 
-  if (validationError) {
-    process.exit(1);
-  }
+  return !validationError;
 }
 
 function buildIDLWindow(ast) {
@@ -606,7 +604,9 @@ function buildIDLServiceWorker(ast) {
 
 function buildIDL(_, reffy) {
   const ast = flattenIDL(reffy.idl, collectExtraIDL());
-  validateIDL(ast);
+  if (!validateIDL(ast)) {
+    process.exit(1);
+  }
   let testpaths = [];
   for (const buildFunc of [
     buildIDLWindow, buildIDLWorker, buildIDLServiceWorker

--- a/build.js
+++ b/build.js
@@ -470,7 +470,7 @@ function validateIDL(ast) {
 
   // Monkey-patching support for https://github.com/w3c/webidl2.js/issues/484
   for (const dfn of ast) {
-    if (!dfn.members) {
+    if (!dfn.members || dfn.members.length == 0) {
       continue;
     }
     const names = new Set();

--- a/build.js
+++ b/build.js
@@ -445,6 +445,7 @@ function buildIDLTests(ast, scope = 'Window') {
   return tests;
 }
 
+/* istanbul ignore next: this is a safeguard to resolve spec-side issues */
 function allowDuplicates(dfn, member) {
   switch (dfn.name) {
     // TODO: sort this out spec-side

--- a/build.js
+++ b/build.js
@@ -496,16 +496,19 @@ function validateIDL(ast) {
     }
   }
 
-  let validationError = false;
+  let validationErrors = [];
   for (const {ruleName, message} of validations) {
     if (ignoreRules.has(ruleName)) {
       continue;
     }
-    console.error(`${message}\n`);
-    validationError = true;
+    validationErrors.push(message);
   }
 
-  return !validationError;
+  if (validationErrors.length) {
+    throw new Error(`Validation errors:\n\n${validationErrors.join('\n')}`);
+  }
+
+  return true;
 }
 
 function buildIDLWindow(ast) {
@@ -603,9 +606,7 @@ function buildIDLServiceWorker(ast) {
 
 function buildIDL(_, reffy) {
   const ast = flattenIDL(reffy.idl, collectExtraIDL());
-  if (!validateIDL(ast)) {
-    process.exit(1);
-  }
+  validateIDL(ast);
   let testpaths = [];
   for (const buildFunc of [
     buildIDLWindow, buildIDLWorker, buildIDLServiceWorker

--- a/build.js
+++ b/build.js
@@ -697,6 +697,8 @@ if (process.env.NODE_ENV === 'test') {
     collectCSSPropertiesFromReffy,
     cssPropertyToIDLAttribute,
     flattenIDL,
+    getExposureSet,
+    isWithinScope,
     buildIDLTests
   };
 } else {

--- a/build.js
+++ b/build.js
@@ -176,6 +176,7 @@ function buildCSS(bcd, reffy) {
   ];
 }
 
+/* istanbul ignore next */
 function collectExtraIDL() {
   const idl = fs.readFileSync('./non-standard.idl', 'utf8');
   return WebIDL2.parse(idl);

--- a/build.js
+++ b/build.js
@@ -340,8 +340,8 @@ function buildIDLTests(ast, scope = 'Window') {
     ]);
 
     // members
-    // TODO: iterable<>, maplike<>, setlike<> declarations are excluded
-    // by filtering to things with names.
+    // TODO: iterable<>, maplike<>, setlike<>, and constructor declarations are
+    // excluded by filtering to things with names.
     const members = iface.members.filter((member) => member.name);
     members.sort((a, b) => a.name.localeCompare(b.name));
 
@@ -394,13 +394,8 @@ function buildIDLTests(ast, scope = 'Window') {
         }
       }
 
-      if (expr) {
-        tests.push([`${iface.name}.${member.name}`, expr]);
-        handledMemberNames.add(member.name);
-      } else {
-        // eslint-disable-next-line max-len
-        console.warn(`Interface ${iface.name} member type ${member.type} not handled`);
-      }
+      tests.push([`${iface.name}.${member.name}`, expr]);
+      handledMemberNames.add(member.name);
     }
   }
 

--- a/build.js
+++ b/build.js
@@ -496,7 +496,7 @@ function validateIDL(ast) {
     }
   }
 
-  let validationErrors = [];
+  const validationErrors = [];
   for (const {ruleName, message} of validations) {
     if (ignoreRules.has(ruleName)) {
       continue;

--- a/build.js
+++ b/build.js
@@ -445,7 +445,6 @@ function buildIDLTests(ast, scope = 'Window') {
   return tests;
 }
 
-/* istanbul ignore next: this is a safeguard to resolve spec-side issues */
 function allowDuplicates(dfn, member) {
   switch (dfn.name) {
     // TODO: sort this out spec-side
@@ -696,7 +695,8 @@ if (process.env.NODE_ENV === 'test') {
     flattenIDL,
     getExposureSet,
     isWithinScope,
-    buildIDLTests
+    buildIDLTests,
+    validateIDL
   };
 } else {
   const bcd = require('mdn-browser-compat-data');

--- a/test/unit/build.js
+++ b/test/unit/build.js
@@ -752,12 +752,16 @@ describe('build', () => {
       const ast = WebIDL2.parse(`interface Node {
         boolean contains(Node otherNode);
       };`);
-      expect(() => {validateIDL(ast)}).to.not.throw();
+      expect(() => {
+        validateIDL(ast);
+      }).to.not.throw();
     });
 
     it('no members', () => {
       const ast = WebIDL2.parse(`interface Node {};`);
-      expect(() => {validateIDL(ast)}).to.not.throw();
+      expect(() => {
+        validateIDL(ast);
+      }).to.not.throw();
     });
 
     it('overloaded operator', () => {
@@ -765,14 +769,18 @@ describe('build', () => {
         boolean contains(Node otherNode);
         boolean contains(Node otherNode, boolean deepEqual);
       };`);
-      expect(() => {validateIDL(ast)}).to.not.throw();
+      expect(() => {
+        validateIDL(ast);
+      }).to.not.throw();
     });
 
     it('nameless member', () => {
       const ast = WebIDL2.parse(`interface Node {
         iterable<Node>;
       };`);
-      expect(() => {validateIDL(ast)}).to.not.throw();
+      expect(() => {
+        validateIDL(ast);
+      }).to.not.throw();
     });
 
     /* Remove when issues are resolved spec-side */
@@ -791,7 +799,9 @@ describe('build', () => {
         attribute Canvas canvas;
         attribute Canvas canvas;
       };`);
-      expect(() => {validateIDL(ast)}).to.not.throw();
+      expect(() => {
+        validateIDL(ast);
+      }).to.not.throw();
     });
 
     it('disallowed duplicates', () => {
@@ -799,7 +809,9 @@ describe('build', () => {
         attribute DOMString type;
         attribute DOMString type;
       };`);
-      expect(() => {validateIDL(ast)}).to.throw();
+      expect(() => {
+        validateIDL(ast);
+      }).to.throw();
     });
   });
 });

--- a/test/unit/build.js
+++ b/test/unit/build.js
@@ -34,7 +34,8 @@ const {
   flattenIDL,
   getExposureSet,
   isWithinScope,
-  buildIDLTests
+  buildIDLTests,
+  validateIDL
 } = require('../../build');
 
 describe('build', () => {
@@ -731,6 +732,54 @@ describe('build', () => {
         // eslint-disable-next-line max-len
         ['CSS.paintWorklet', '(function() {var css = CSS;return css && \'paintWorklet\' in css;})()']
       ]);
+    });
+  });
+
+  describe('validateIDL', () => {
+    it('valid idl', () => {
+      const ast = WebIDL2.parse(`interface Node {
+        boolean contains(Node otherNode);
+      };`);
+      assert.equal(validateIDL(ast), true);
+    });
+
+    it('no members', () => {
+      const ast = WebIDL2.parse(`interface Node {};`);
+      assert.equal(validateIDL(ast), true);
+    });
+
+    it('overloaded operator', () => {
+      const ast = WebIDL2.parse(`interface Node {
+        boolean contains(Node otherNode);
+        boolean contains(Node otherNode, boolean deepEqual);
+      };`);
+      assert.equal(validateIDL(ast), true);
+    });
+
+    it('nameless member', () => {
+      const ast = WebIDL2.parse(`interface Node {
+        iterable<Node>;
+      };`);
+      assert.equal(validateIDL(ast), true);
+    });
+
+    /* Remove when issues are resolved spec-side */
+    it('allow duplicates', () => {
+      const ast = WebIDL2.parse(`interface SVGAElement {
+        attribute DOMString href;
+        attribute DOMString href;
+      };
+
+      interface WebGLRenderingContext {
+        attribute Canvas canvas;
+        attribute Canvas canvas;
+      };
+
+      interface WebGLRenderingContext2 {
+        attribute Canvas canvas;
+        attribute Canvas canvas;
+      };`);
+      assert.equal(validateIDL(ast), true);
     });
   });
 });

--- a/test/unit/build.js
+++ b/test/unit/build.js
@@ -321,7 +321,6 @@ describe('build', () => {
       assert.lengthOf(interfaces, 2);
 
       assert.equal(interfaces[0].name, 'DummyError');
-      console.log(interfaces[0].members);
       assert.lengthOf(interfaces[0].members, 2);
       assert.containSubset(interfaces[0].members[0], {
         type: 'attribute',

--- a/test/unit/build.js
+++ b/test/unit/build.js
@@ -471,13 +471,13 @@ describe('build', () => {
         window: WebIDL2.parse(`[Exposed=Window] interface DummyOne {};`),
         webworker: WebIDL2.parse(`[Exposed=Worker] interface DummyTwo {};`),
         serviceworker: WebIDL2.parse(
-          `[Exposed=ServiceWorker] interface DummyThree {};`
+            `[Exposed=ServiceWorker] interface DummyThree {};`
         ),
         bothworkers: WebIDL2.parse(
-          `[Exposed=(Worker,ServiceWorker)] interface DummyFour {};`
+            `[Exposed=(Worker,ServiceWorker)] interface DummyFour {};`
         ),
         windowandworker: WebIDL2.parse(
-          `[Exposed=(Window,Worker)] interface DummyFive {};`
+            `[Exposed=(Window,Worker)] interface DummyFive {};`
         )
       };
       const historicalIDL = WebIDL2.parse(`interface DOMError {};`);
@@ -495,9 +495,18 @@ describe('build', () => {
 
       for (const iface of interfaces) {
         const exposureSet = getExposureSet(iface);
-        assert.equal(isWithinScope('Window', exposureSet), interfaceScopes[iface.name] === 'Window');
-        assert.equal(isWithinScope('Worker', exposureSet), interfaceScopes[iface.name] === 'Worker');
-        assert.equal(isWithinScope('ServiceWorker', exposureSet), interfaceScopes[iface.name] === 'ServiceWorker');
+        assert.equal(
+            isWithinScope('Window', exposureSet),
+            interfaceScopes[iface.name] === 'Window'
+        );
+        assert.equal(
+            isWithinScope('Worker', exposureSet),
+            interfaceScopes[iface.name] === 'Worker'
+        );
+        assert.equal(
+            isWithinScope('ServiceWorker', exposureSet),
+            interfaceScopes[iface.name] === 'ServiceWorker'
+        );
       }
     });
 
@@ -508,9 +517,11 @@ describe('build', () => {
       const historicalIDL = WebIDL2.parse(`interface DOMError {};`);
       const ast = flattenIDL(specIDLs, historicalIDL);
       const interfaces = ast.filter((dfn) => dfn.type === 'interface');
-      
-      expect(() => {getExposureSet(interfaces[0])})
-        .to.throw('Unexpected RHS for Exposed extended attribute');
+
+      expect(() => {
+        getExposureSet(interfaces[0]);
+      })
+          .to.throw('Unexpected RHS for Exposed extended attribute');
     });
   });
 
@@ -604,30 +615,31 @@ describe('build', () => {
     });
 
     it('global interface', () => {
-      const ast = WebIDL2.parse(`[Global=(Window,Worker)] interface WindowOrWorkerGlobalScope {
+      const ast = WebIDL2.parse(`[Global=(Window,Worker)]
+      interface WindowOrWorkerGlobalScope {
         attribute boolean isLoaded;
         const boolean active = true;
       };`);
       assert.deepEqual(buildIDLTests(ast), [
         [
-          "WindowOrWorkerGlobalScope",
+          'WindowOrWorkerGlobalScope',
           {
-            "property": "WindowOrWorkerGlobalScope",
-            "scope": "self",
+            'property': 'WindowOrWorkerGlobalScope',
+            'scope': 'self'
           }
         ],
         [
-          "WindowOrWorkerGlobalScope.active",
+          'WindowOrWorkerGlobalScope.active',
           {
-            "property": "active",
-            "scope": "self"
+            'property': 'active',
+            'scope': 'self'
           }
         ],
         [
-          "WindowOrWorkerGlobalScope.isLoaded",
+          'WindowOrWorkerGlobalScope.isLoaded',
           {
-            "property": "isLoaded",
-            "scope": "self"
+            'property': 'isLoaded',
+            'scope': 'self'
           }
         ]
       ]);
@@ -639,10 +651,10 @@ describe('build', () => {
       };`);
       assert.deepEqual(buildIDLTests(ast), [
         [
-          "DoubleList",
+          'DoubleList',
           {
-            "property": "DoubleList",
-            "scope": "self",
+            'property': 'DoubleList',
+            'scope': 'self'
           }
         ]
       ]);
@@ -660,10 +672,10 @@ describe('build', () => {
         ['Worker', {property: 'Worker', scope: 'self'}],
         ['CSS', {property: 'CSS', scope: 'self'}]
       ]);
-      assert.deepEqual(buildIDLTests(ast, "Worker"), [
-        ['WorkerSync', {property: 'WorkerSync', scope: 'self'}],
+      assert.deepEqual(buildIDLTests(ast, 'Worker'), [
+        ['WorkerSync', {property: 'WorkerSync', scope: 'self'}]
       ]);
-      assert.deepEqual(buildIDLTests(ast, "ServiceWorker"), []);
+      assert.deepEqual(buildIDLTests(ast, 'ServiceWorker'), []);
     });
 
     it('operator variations', () => {

--- a/test/unit/build.js
+++ b/test/unit/build.js
@@ -787,7 +787,7 @@ describe('build', () => {
         attribute Canvas canvas;
       };
 
-      interface WebGLRenderingContext2 {
+      interface WebGL2RenderingContext {
         attribute Canvas canvas;
         attribute Canvas canvas;
       };`);

--- a/test/unit/build.js
+++ b/test/unit/build.js
@@ -752,12 +752,12 @@ describe('build', () => {
       const ast = WebIDL2.parse(`interface Node {
         boolean contains(Node otherNode);
       };`);
-      assert.equal(validateIDL(ast), true);
+      expect(() => {validateIDL(ast)}).to.not.throw();
     });
 
     it('no members', () => {
       const ast = WebIDL2.parse(`interface Node {};`);
-      assert.equal(validateIDL(ast), true);
+      expect(() => {validateIDL(ast)}).to.not.throw();
     });
 
     it('overloaded operator', () => {
@@ -765,18 +765,18 @@ describe('build', () => {
         boolean contains(Node otherNode);
         boolean contains(Node otherNode, boolean deepEqual);
       };`);
-      assert.equal(validateIDL(ast), true);
+      expect(() => {validateIDL(ast)}).to.not.throw();
     });
 
     it('nameless member', () => {
       const ast = WebIDL2.parse(`interface Node {
         iterable<Node>;
       };`);
-      assert.equal(validateIDL(ast), true);
+      expect(() => {validateIDL(ast)}).to.not.throw();
     });
 
     /* Remove when issues are resolved spec-side */
-    it('allow duplicates', () => {
+    it('allowed duplicates', () => {
       const ast = WebIDL2.parse(`interface SVGAElement {
         attribute DOMString href;
         attribute DOMString href;
@@ -791,7 +791,15 @@ describe('build', () => {
         attribute Canvas canvas;
         attribute Canvas canvas;
       };`);
-      assert.equal(validateIDL(ast), true);
+      expect(() => {validateIDL(ast)}).to.not.throw();
+    });
+
+    it('disallowed duplicates', () => {
+      const ast = WebIDL2.parse(`interface Node {
+        attribute DOMString type;
+        attribute DOMString type;
+      };`);
+      expect(() => {validateIDL(ast)}).to.throw();
     });
   });
 });


### PR DESCRIPTION
This PR adds numerous unittests to cover more lines within build.js, leaving only the file generation functions untested.

Before:

File              | % Stmts | % Branch | % Funcs | % Lines
------------------|---------|----------|---------|---------
All files         |    66.9 |    65.96 |   68.75 |   67.22
 build.js         |   51.03 |    61.74 |   52.38 |   50.72

After:

File              | % Stmts | % Branch | % Funcs | % Lines
------------------|---------|----------|---------|---------
All files         | 79.58 (+12.68) |    87.23 (+21.27) |   77.78 (+9.03) |   79.62 (+12.4)
 build.js         |   69.93 (+18.9) |    88.59 (+26.85) |   65.85 (+13.47) |   69.49 (+18.77)