### PR TITLE
Create custom CSS property test support

### DIFF
--- a/DESIGN.md
+++ b/DESIGN.md
@@ -69,7 +69,38 @@ Tips: make sure that all return statements will return a boolean, and implement 
 
 #### CSS
 
-To be planned...
+Each CSS property is written in the following structure:
+
+```json
+"PROPERTY_NAME": "CODE_TO_TEST_THE_PROPERTY"
+```
+
+Each test will compile into a function as follows: `function() {CODE}`
+
+Example:
+
+The following JSON...
+
+```json
+{
+  "api": {
+
+  },
+  "css": {
+    "properties": {
+      "custom-property": "return CSS.supports('color', 'var(--foo)') || CSS.supports('color', 'env(--foo)');"
+    }
+  }
+}
+```
+
+...will compile into...
+
+```javascript
+bcd.addTest('css.properties.custom-property', "(function() {return CSS.supports('color', 'var(--foo)') || CSS.supports('color', 'env(--foo)');})()", 'CSS');
+```
+
+Tips: make sure that all return statements will return a boolean, and implement thorough feature checking.
 
 ## API
 

--- a/build.js
+++ b/build.js
@@ -75,7 +75,7 @@ function getCustomTestAPI(name, member) {
 function getCustomTestCSS(name) {
   return 'properties' in customTests.css &&
       name in customTests.css.properties &&
-      customTests.css.properties[name];
+      `(function() {${customTests.css.properties[name]}})()`;
 }
 
 function collectCSSPropertiesFromBCD(bcd, propertySet) {

--- a/build.js
+++ b/build.js
@@ -164,7 +164,9 @@ function buildCSSPropertyTest(propertyNames, method, basename) {
       } else if (method === 'CSS.supports') {
         expr = {property: name, scope: 'CSS.supports'};
       }
-      lines.push(`bcd.addTest("${ident}", ${JSON.stringify(expr)}, 'CSS');`);
+      if (expr) {
+        lines.push(`bcd.addTest("${ident}", ${JSON.stringify(expr)}, 'CSS');`);
+      }
     }
   }
   lines.push('bcd.run("CSS");', '</script>', '</body>', '</html>');

--- a/build.js
+++ b/build.js
@@ -706,6 +706,7 @@ if (process.env.NODE_ENV === 'test') {
     writeText,
     loadCustomTests,
     getCustomTestAPI,
+    getCustomTestCSS,
     collectCSSPropertiesFromBCD,
     collectCSSPropertiesFromReffy,
     cssPropertyToIDLAttribute,

--- a/test/unit/build.js
+++ b/test/unit/build.js
@@ -178,11 +178,9 @@ describe('build', () => {
   });
 
   describe('getCustomTestCSS', () => {
-    describe('no custom tests', () => {
-      it('no custom tests', () => {
-        loadCustomTests({api: {}, css: {}});
-        assert.equal(getCustomTestCSS('foo'), false);
-      });
+    it('no custom tests', () => {
+      loadCustomTests({api: {}, css: {}});
+      assert.equal(getCustomTestCSS('foo'), false);
     });
 
     it('custom test for property', () => {
@@ -195,10 +193,7 @@ describe('build', () => {
         }
       });
 
-      assert.equal(
-          getCustomTestCSS('foo'),
-          '(function() {return 1;})()'
-      );
+      assert.equal(getCustomTestCSS('foo'), '(function() {return 1;})()');
     });
   });
 

--- a/test/unit/build.js
+++ b/test/unit/build.js
@@ -28,6 +28,7 @@ const {
   writeText,
   loadCustomTests,
   getCustomTestAPI,
+  getCustomTestCSS,
   collectCSSPropertiesFromBCD,
   collectCSSPropertiesFromReffy,
   cssPropertyToIDLAttribute,
@@ -173,6 +174,31 @@ describe('build', () => {
             '(function() {var a = 1;return a + 1;})()'
         );
       });
+    });
+  });
+
+  describe('getCustomTestCSS', () => {
+    describe('no custom tests', () => {
+      it('no custom tests', () => {
+        loadCustomTests({api: {}, css: {}});
+        assert.equal(getCustomTestCSS('foo'), false);
+      });
+    });
+
+    it('custom test for property', () => {
+      loadCustomTests({
+        api: {},
+        css: {
+          properties: {
+            foo: 'return 1;'
+          }
+        }
+      });
+
+      assert.equal(
+          getCustomTestCSS('foo'),
+          '(function() {return 1;})()'
+      );
     });
   });
 


### PR DESCRIPTION
Part of work for #333.  This PR introduces support for implementing custom tests for CSS properties.  If a custom test is implemented, it disables the default tests.