### PR TITLE
Constructor, iterable/maplike/setlike, and dictionary tests + more non-standard APIs

### DIFF
--- a/build.js
+++ b/build.js
@@ -308,7 +308,7 @@ function getExposureSet(node) {
 function buildIDLTests(ast, scope = 'Window') {
   const tests = [];
 
-  const interfaces = ast.filter((dfn) => 
+  const interfaces = ast.filter((dfn) =>
     dfn.type === 'interface' ||
     dfn.type === 'namespace' ||
     dfn.type === 'dictionary'

--- a/build.js
+++ b/build.js
@@ -436,6 +436,7 @@ function buildIDLTests(ast, scope = 'Window') {
         switch (member.type) {
           case 'attribute':
           case 'operation':
+          case 'field':
             if (isGlobal) {
               expr = {property: member.name, scope: 'self'};
             } else if (isStatic) {

--- a/build.js
+++ b/build.js
@@ -306,28 +306,12 @@ function getExposureSet(node) {
 }
 
 function isWithinScope(scope, exposureSet) {
-  // This function checks for a scope in the exposureSet whilst ignoring
-  // interfaces exposed on previous scopes, preventing duplication
-  if (scope == 'Window' && !exposureSet.has('Window')) {
-    return false;
-  }
-  if (
-    scope == 'Worker' &&
-    (exposureSet.has('Window') || !exposureSet.has('Worker'))
-  ) {
-    return false;
-  }
-  if (
-    scope == 'ServiceWorker' &&
-    (
-      (exposureSet.has('Window') || exposureSet.has('Worker')) ||
-      !exposureSet.has('ServiceWorker')
-    )
-  ) {
-    return false;
-  }
   // TODO: any other exposure scopes we need to worry about?
-  return true;
+  return (
+    (scope == 'Window' && exposureSet.has('Window')) ||
+    (scope == 'Worker' && exposureSet.has('Worker')) ||
+    (scope == 'ServiceWorker' && exposureSet.has('ServiceWorker'))
+  );
 }
 
 function buildIDLTests(ast, scope = 'Window') {

--- a/build.js
+++ b/build.js
@@ -335,7 +335,8 @@ function buildIDLTests(ast, scope = 'Window') {
 
   const interfaces = ast.filter((dfn) => 
     dfn.type === 'interface' ||
-    dfn.type === 'namespace'
+    dfn.type === 'namespace' ||
+    dfn.type === 'dictionary'
   );
   interfaces.sort((a, b) => a.name.localeCompare(b.name));
 
@@ -429,7 +430,8 @@ function buildIDLTests(ast, scope = 'Window') {
       } else {
         const isStatic = (
           member.special === 'static' ||
-          iface.type === 'namespace'
+          iface.type === 'namespace' ||
+          iface.type === 'dictionary'
         );
         switch (member.type) {
           case 'attribute':

--- a/build.js
+++ b/build.js
@@ -305,15 +305,6 @@ function getExposureSet(node) {
   return globals;
 }
 
-function isWithinScope(scope, exposureSet) {
-  // TODO: any other exposure scopes we need to worry about?
-  return (
-    (scope == 'Window' && exposureSet.has('Window')) ||
-    (scope == 'Worker' && exposureSet.has('Worker')) ||
-    (scope == 'ServiceWorker' && exposureSet.has('ServiceWorker'))
-  );
-}
-
 function buildIDLTests(ast, scope = 'Window') {
   const tests = [];
 
@@ -333,7 +324,7 @@ function buildIDLTests(ast, scope = 'Window') {
     }
 
     const exposureSet = getExposureSet(iface);
-    if (!isWithinScope(scope, exposureSet)) {
+    if (!exposureSet.has(scope)) {
       continue;
     }
 
@@ -713,7 +704,6 @@ if (process.env.NODE_ENV === 'test') {
     cssPropertyToIDLAttribute,
     flattenIDL,
     getExposureSet,
-    isWithinScope,
     buildIDLTests,
     validateIDL
   };

--- a/build.js
+++ b/build.js
@@ -300,6 +300,7 @@ function getExposureSet(node) {
       }
       break;
     default:
+      /* istanbul ignore next */
       throw new Error(`Unexpected RHS for Exposed extended attribute`);
   }
   return globals;

--- a/custom-tests.json
+++ b/custom-tests.json
@@ -10,6 +10,8 @@
     }
   },
   "css": {
-
+    "properties": {
+      "custom-property": "return CSS.supports('color', 'var(--foo)') || CSS.supports('color', 'env(--foo)');"
+    }
   }
 }

--- a/custom-tests.json
+++ b/custom-tests.json
@@ -1,6 +1,13 @@
 {
   "api": {
-    
+    "ANGLE_instanced_arrays": {
+      "__base": "var canvas = document.createElement('canvas'); var gl = canvas.getContext('webgl'); var a = gl.getExtension('ANGLE_instanced_arrays');",
+      "__test": "return !!a;",
+      "drawArraysInstancedANGLE": "return a && 'drawArraysInstancedANGLE' in a;",
+      "drawElementsInstancedANGLE": "return a && 'drawElementsInstancedANGLE' in a;",
+      "vertexAttribDivisorANGLE": "return a && 'vertexAttribDivisorANGLE' in a;",
+      "VERTEX_ATTRIB_ARRAY_DIVISOR_ANGLE": "return a && 'VERTEX_ATTRIB_ARRAY_DIVISOR_ANGLE' in a;"
+    }
   },
   "css": {
 

--- a/non-standard.idl
+++ b/non-standard.idl
@@ -197,6 +197,12 @@ partial interface CompositionEvent {
   attribute DOMString locale;
 };
 
+partial namespace console {
+  void exception(any msg);
+  void profile(optional DOMString profileName);
+  void profileEnd(optional DOMString profileName);
+};
+
 // https://source.chromium.org/chromium/chromium/src/+/master:third_party/blink/renderer/modules/payments/abort_payment_event.idl;drc=c2e7d4f0b24814b0d1c51a964db34ec5b4930756
 // https://github.com/w3c/payment-handler/pull/170
 [
@@ -242,3 +248,22 @@ interface BudgetState {
   readonly attribute double budgetAt;
   readonly attribute DOMTimeStamp time;
 };
+
+// https://webaudio.github.io/web-audio-api/#AudioScheduledSourceNode
+// Modified to extend ConstantSourceNode w/out mixin stuff
+
+[Exposed=Window]
+partial interface ConstantSourceNode {
+  attribute EventHandler onended;
+  void start(optional double when = 0);
+  void stop(optional double when = 0);
+};
+
+
+// https://w3c.github.io/mediacapture-main/#dom-constrainboolean
+
+typedef (boolean or ConstrainBooleanParameters) ConstrainBoolean;
+typedef (DOMString or sequence<DOMString> or ConstrainDOMStringParameters) ConstrainDOMString;
+typedef (double or ConstrainDoubleRange) ConstrainDouble;
+typedef (long or ConstrainLongRange) ConstrainLong;
+typedef ([Clamp] unsigned long or ConstrainULongRange) ConstrainULong;

--- a/non-standard.idl
+++ b/non-standard.idl
@@ -206,41 +206,41 @@ partial namespace console {
 // https://source.chromium.org/chromium/chromium/src/+/master:third_party/blink/renderer/modules/payments/abort_payment_event.idl;drc=c2e7d4f0b24814b0d1c51a964db34ec5b4930756
 // https://github.com/w3c/payment-handler/pull/170
 [
-    Constructor=Image(DOMString type, optional ExtendableEventInit eventInitDict),
-    Exposed=ServiceWorker
+  Constructor=Image(DOMString type, optional ExtendableEventInit eventInitDict),
+  Exposed=ServiceWorker
 ] interface AbortPaymentEvent : ExtendableEvent {
-    [CallWith=ScriptState, RaisesException] void respondWith(Promise<boolean> paymentAbortedResponse);
+  [CallWith=ScriptState, RaisesException] void respondWith(Promise<boolean> paymentAbortedResponse);
 };
 
 // https://www.khronos.org/registry/webgl/extensions/ANGLE_instanced_arrays/
 
 interface ANGLE_instanced_arrays {
-    const GLenum VERTEX_ATTRIB_ARRAY_DIVISOR_ANGLE = 0x88FE;
-    void drawArraysInstancedANGLE(GLenum mode, GLint first, GLsizei count, GLsizei primcount);
-    void drawElementsInstancedANGLE(GLenum mode, GLsizei count, GLenum type, GLintptr offset, GLsizei primcount);
-    void vertexAttribDivisorANGLE(GLuint index, GLuint divisor); 
+  const GLenum VERTEX_ATTRIB_ARRAY_DIVISOR_ANGLE = 0x88FE;
+  void drawArraysInstancedANGLE(GLenum mode, GLint first, GLsizei count, GLsizei primcount);
+  void drawElementsInstancedANGLE(GLenum mode, GLsizei count, GLenum type, GLintptr offset, GLsizei primcount);
+  void vertexAttribDivisorANGLE(GLuint index, GLuint divisor); 
 };
 
 // https://source.chromium.org/chromium/chromium/src/+/master:third_party/blink/renderer/modules/app_banner/before_install_prompt_event.idl;drc=af69d93ec0d5334cdc03316058660a37116f32b3
 
 [
-    ActiveScriptWrappable,
-    Exposed=Window
+  ActiveScriptWrappable,
+  Exposed=Window
 ] interface BeforeInstallPromptEvent : Event {
-    [CallWith=ExecutionContext] constructor(DOMString type, optional BeforeInstallPromptEventInit eventInitDict = {});
-    readonly attribute FrozenArray<DOMString> platforms;
-    [CallWith=ScriptState, RaisesException] readonly attribute Promise<AppBannerPromptResult> userChoice;
-    [CallWith=ScriptState, RaisesException] Promise<void> prompt();
+  [CallWith=ExecutionContext] constructor(DOMString type, optional BeforeInstallPromptEventInit eventInitDict = {});
+  readonly attribute FrozenArray<DOMString> platforms;
+  [CallWith=ScriptState, RaisesException] readonly attribute Promise<AppBannerPromptResult> userChoice;
+  [CallWith=ScriptState, RaisesException] Promise<void> prompt();
 };
 
 // https://wicg.github.io/budget-api/#budget-service-interface
 
 [Exposed=(Window,Worker)]
 interface BudgetService {
-    Promise<double> getCost(OperationType operation);
-    Promise<sequence<BudgetState>> getBudget();
+  Promise<double> getCost(OperationType operation);
+  Promise<sequence<BudgetState>> getBudget();
 
-    Promise<boolean> reserve(OperationType operation);
+  Promise<boolean> reserve(OperationType operation);
 };
 
 [Exposed=(Window,Worker)]

--- a/non-standard.idl
+++ b/non-standard.idl
@@ -203,6 +203,18 @@ partial namespace console {
   void profileEnd(optional DOMString profileName);
 };
 
+partial interface DataTransfer {
+  attribute DOMString mozCursor;
+  readonly attribute Node mozSourceNode;
+  readonly attribute boolean mozUserCancelled;
+  readonly attribute number mozItemCount;
+
+  void mozClearDataAt(optional string type, unsigned long index);
+  nsIVariant mozGetDataAt(optional string type, unsigned long index);
+  void mozSetDataAt(optional string type, nsIVariant data, unsigned long index);
+  nsIVariant mozTypesAt(unsigned long index);
+};
+
 // https://source.chromium.org/chromium/chromium/src/+/master:third_party/blink/renderer/modules/payments/abort_payment_event.idl;drc=c2e7d4f0b24814b0d1c51a964db34ec5b4930756
 // https://github.com/w3c/payment-handler/pull/170
 [
@@ -259,11 +271,81 @@ partial interface ConstantSourceNode {
   void stop(optional double when = 0);
 };
 
+// https://source.chromium.org/chromium/chromium/src/+/master:third_party/blink/renderer/core/animation/css/css_animation.idl;drc=607fff17f2f1b469b94b3b31288f3bfb78fed648
 
-// https://w3c.github.io/mediacapture-main/#dom-constrainboolean
+[Exposed=Window, RuntimeEnabled=WebAnimationsAPI]
+interface CSSAnimation : Animation {
+  readonly attribute CSSOMString animationName;
+};
 
-typedef (boolean or ConstrainBooleanParameters) ConstrainBoolean;
-typedef (DOMString or sequence<DOMString> or ConstrainDOMStringParameters) ConstrainDOMString;
-typedef (double or ConstrainDoubleRange) ConstrainDouble;
-typedef (long or ConstrainLongRange) ConstrainLong;
-typedef ([Clamp] unsigned long or ConstrainULongRange) ConstrainULong;
+// https://source.chromium.org/chromium/chromium/src/+/master:third_party/blink/renderer/core/css/cssom/css_position_value.idl;drc=c2e7d4f0b24814b0d1c51a964db34ec5b4930756
+
+[
+  Exposed=(Window,LayoutWorklet,PaintWorklet)
+] interface CSSPositionValue : CSSStyleValue {
+  [RaisesException] constructor(CSSNumericValue x, CSSNumericValue y);
+  [RaisesException=Setter] attribute CSSNumericValue x;
+  [RaisesException=Setter] attribute CSSNumericValue y;
+};
+
+// https://www.w3.org/TR/DOM-Level-2-Style/css.html
+
+interface CSSPrimitiveValue : CSSValue {
+  const unsigned short CSS_UNKNOWN = 0;
+  const unsigned short CSS_NUMBER = 1;
+  const unsigned short CSS_PERCENTAGE = 2;
+  const unsigned short CSS_EMS = 3;
+  const unsigned short CSS_EXS = 4;
+  const unsigned short CSS_PX = 5;
+  const unsigned short CSS_CM = 6;
+  const unsigned short CSS_MM = 7;
+  const unsigned short CSS_IN = 8;
+  const unsigned short CSS_PT = 9;
+  const unsigned short CSS_PC = 10;
+  const unsigned short CSS_DEG = 11;
+  const unsigned short CSS_RAD = 12;
+  const unsigned short CSS_GRAD = 13;
+  const unsigned short CSS_MS = 14;
+  const unsigned short CSS_S = 15;
+  const unsigned short CSS_HZ = 16;
+  const unsigned short CSS_KHZ = 17;
+  const unsigned short CSS_DIMENSION = 18;
+  const unsigned short CSS_STRING = 19;
+  const unsigned short CSS_URI = 20;
+  const unsigned short CSS_IDENT = 21;
+  const unsigned short CSS_ATTR = 22;
+  const unsigned short CSS_COUNTER = 23;
+  const unsigned short CSS_RECT = 24;
+  const unsigned short CSS_RGBCOLOR = 25;
+
+  readonly attribute unsigned short primitiveType;
+  void setFloatValue(unsigned short unitType, float floatValue);
+  float getFloatValue(unsigned short unitType);
+  void setStringValue(unsigned short stringType, DOMString stringValue);
+  DOMString getStringValue();
+  Counter getCounterValue();
+  Rect getRectValue();
+  RGBColor getRGBColorValue();
+};
+
+interface CSSValue {
+  const unsigned short CSS_INHERIT = 0;
+  const unsigned short CSS_PRIMITIVE_VALUE = 1;
+  const unsigned short CSS_VALUE_LIST = 2;
+  const unsigned short CSS_CUSTOM = 3;
+
+  attribute DOMString cssText;
+  readonly attribute unsigned short cssValueType;
+};
+
+interface CSSValueList : CSSValue {
+  readonly attribute unsigned long length;
+  CSSValue item(unsigned long index);
+};
+
+// https://source.chromium.org/chromium/chromium/src/+/master:third_party/blink/renderer/core/animation/css/css_transition.idl;drc=d692c061c5a4f07611af04d53a032c8ac4dde7c5
+
+[Exposed=Window, RuntimeEnabled=WebAnimationsAPI]
+interface CSSTransition : Animation {
+  readonly attribute CSSOMString transitionProperty;
+};

--- a/non-standard.idl
+++ b/non-standard.idl
@@ -168,6 +168,10 @@ partial interface Window {
   attribute EventHandler onsearch;
 };
 
+partial interface AnimationEvent {
+  AnimationEvent initAnimationEvent(DOMString typeArg, boolean canBubbleArg, boolean cancelableArg, DOMString animationNameArg, float elapsedTimeArg);
+};
+
 partial interface AudioListener {
   attribute double dopplerFactor;
   attribute double speedOfSound;

--- a/non-standard.idl
+++ b/non-standard.idl
@@ -167,3 +167,26 @@ partial interface Window {
 
   attribute EventHandler onsearch;
 };
+
+partial interface AudioListener {
+  attribute double dopplerFactor;
+  attribute double speedOfSound;
+};
+
+// https://source.chromium.org/chromium/chromium/src/+/master:third_party/blink/renderer/modules/payments/abort_payment_event.idl;drc=c2e7d4f0b24814b0d1c51a964db34ec5b4930756
+// https://github.com/w3c/payment-handler/pull/170
+[
+    Constructor=Image(DOMString type, optional ExtendableEventInit eventInitDict),
+    Exposed=ServiceWorker
+] interface AbortPaymentEvent : ExtendableEvent {
+    [CallWith=ScriptState, RaisesException] void respondWith(Promise<boolean> paymentAbortedResponse);
+};
+
+// https://www.khronos.org/registry/webgl/extensions/ANGLE_instanced_arrays/
+
+interface ANGLE_instanced_arrays {
+    const GLenum VERTEX_ATTRIB_ARRAY_DIVISOR_ANGLE = 0x88FE;
+    void drawArraysInstancedANGLE(GLenum mode, GLint first, GLsizei count, GLsizei primcount);
+    void drawElementsInstancedANGLE(GLenum mode, GLsizei count, GLenum type, GLintptr offset, GLsizei primcount);
+    void vertexAttribDivisorANGLE(GLuint index, GLuint divisor); 
+};

--- a/non-standard.idl
+++ b/non-standard.idl
@@ -173,6 +173,30 @@ partial interface AudioListener {
   attribute double speedOfSound;
 };
 
+[NoInterfaceObject]
+interface mixin CanvasHitRegion {
+  void addHitRegion(optional HitRegionOptions options);
+  void removeHitRegion(DOMString id);
+  void clearHitRegions();
+};
+
+CanvasRenderingContext2D includes CanvasHitRegion;
+
+partial interface CanvasRenderingContext2D {
+  attribute DOMMatrix currentTransform;
+  void drawWidgetAsOnScreen(Window window);
+  void drawWindow(Window window, double x, double y, double w, double h, DOMString bgColor, optional byte flags);
+};
+
+partial interface CloseEvent {
+  CloseEvent initCloseEvent();
+};
+
+partial interface CompositionEvent {
+  CompositionEvent initCompositionEvent();
+  attribute DOMString locale;
+};
+
 // https://source.chromium.org/chromium/chromium/src/+/master:third_party/blink/renderer/modules/payments/abort_payment_event.idl;drc=c2e7d4f0b24814b0d1c51a964db34ec5b4930756
 // https://github.com/w3c/payment-handler/pull/170
 [
@@ -189,4 +213,32 @@ interface ANGLE_instanced_arrays {
     void drawArraysInstancedANGLE(GLenum mode, GLint first, GLsizei count, GLsizei primcount);
     void drawElementsInstancedANGLE(GLenum mode, GLsizei count, GLenum type, GLintptr offset, GLsizei primcount);
     void vertexAttribDivisorANGLE(GLuint index, GLuint divisor); 
+};
+
+// https://source.chromium.org/chromium/chromium/src/+/master:third_party/blink/renderer/modules/app_banner/before_install_prompt_event.idl;drc=af69d93ec0d5334cdc03316058660a37116f32b3
+
+[
+    ActiveScriptWrappable,
+    Exposed=Window
+] interface BeforeInstallPromptEvent : Event {
+    [CallWith=ExecutionContext] constructor(DOMString type, optional BeforeInstallPromptEventInit eventInitDict = {});
+    readonly attribute FrozenArray<DOMString> platforms;
+    [CallWith=ScriptState, RaisesException] readonly attribute Promise<AppBannerPromptResult> userChoice;
+    [CallWith=ScriptState, RaisesException] Promise<void> prompt();
+};
+
+// https://wicg.github.io/budget-api/#budget-service-interface
+
+[Exposed=(Window,Worker)]
+interface BudgetService {
+    Promise<double> getCost(OperationType operation);
+    Promise<sequence<BudgetState>> getBudget();
+
+    Promise<boolean> reserve(OperationType operation);
+};
+
+[Exposed=(Window,Worker)]
+interface BudgetState {
+  readonly attribute double budgetAt;
+  readonly attribute DOMTimeStamp time;
 };

--- a/package.json
+++ b/package.json
@@ -1,7 +1,7 @@
 {
   "name": "mdn-bcd-collector",
   "description": "Data collection service for mdn/browser-compat-data",
-  "version": "0.0.3",
+  "version": "0.0.4",
   "private": true,
   "license": "Apache-2.0",
   "repository": {

--- a/static/resources/harness.js
+++ b/static/resources/harness.js
@@ -86,21 +86,24 @@
           }
         } else if (subtest.property == 'constructor') {
           var iface = parentPrefix+subtest.scope;
-          var args = "";
-          for (var i = 0; i < eval(iface+".constructor.length"); i++) {
-            if (i == 0) {
-              args = args + "'" + i + "'";
+          var args = '';
+          for (var a = 0; a < eval(iface+'.constructor.length'); a++) {
+            if (a == 0) {
+              args = args + '\'' + a + '\'';
             } else {
-              args = args + "," + "'" + i + "'";
+              args = args + ',' + '\'' + a + '\'';
             }
           }
 
           try {
-            result.code = "new "+iface+"("+args+")";
-            eval("new "+iface+"("+args+")");
+            result.code = 'new '+iface+'('+args+')';
+            eval('new '+iface+'('+args+')');
             result.result = true;
-          } catch(err) {
-            if (err.name == 'TypeError' && err.message == 'Illegal constructor') {
+          } catch (err) {
+            if (
+              err.name == 'TypeError' &&
+              err.message == 'Illegal constructor'
+            ) {
               result.result = false;
             } else if (err.message.includes('Failed to construct')) {
               // If it failed to construct, and not illegal, there's a

--- a/static/resources/harness.js
+++ b/static/resources/harness.js
@@ -84,6 +84,34 @@
             result.result = null;
             result.message = 'returned ' + stringify(value);
           }
+        } else if (subtest.property == 'constructor') {
+          var iface = parentPrefix+subtest.scope;
+          var args = "";
+          for (var i = 0; i < eval(iface+".constructor.length"); i++) {
+            if (i == 0) {
+              args = args + "'" + i + "'";
+            } else {
+              args = args + "," + "'" + i + "'";
+            }
+          }
+
+          try {
+            result.code = "new "+iface+"("+args+")";
+            eval("new "+iface+"("+args+")");
+            result.result = true;
+          } catch(err) {
+            if (err.name == 'TypeError' && err.message == 'Illegal constructor') {
+              result.result = false;
+            } else if (err.message.includes('Failed to construct')) {
+              // If it failed to construct, and not illegal, there's a
+              // constructor
+              result.result = true;
+            } else {
+              result.result = null;
+            }
+
+            result.message = 'threw ' + stringify(err);
+          }
         } else {
           for (var j in prefixesToTest) {
             var prefix = prefixesToTest[j];

--- a/test/unit/build.js
+++ b/test/unit/build.js
@@ -1088,7 +1088,9 @@ describe('build', () => {
               DOMString? extends = null;
            };`);
       assert.deepEqual(buildIDLTests(ast), [
-        ['ElementRegistrationOptions', {property: 'ElementRegistrationOptions', scope: 'self'}],
+        ['ElementRegistrationOptions',
+          {property: 'ElementRegistrationOptions', scope: 'self'}
+        ],
         ['ElementRegistrationOptions.extends', [
           {property: 'ElementRegistrationOptions', scope: 'self'},
           {property: 'extends', scope: 'ElementRegistrationOptions'}

--- a/test/unit/build.js
+++ b/test/unit/build.js
@@ -1063,9 +1063,9 @@ describe('build', () => {
         namespace CSS {};
       `);
       assert.deepEqual(buildIDLTests(ast), [
+        ['CSS', {property: 'CSS', scope: 'self'}],
         ['MessageChannel', {property: 'MessageChannel', scope: 'self'}],
-        ['Worker', {property: 'Worker', scope: 'self'}],
-        ['CSS', {property: 'CSS', scope: 'self'}]
+        ['Worker', {property: 'Worker', scope: 'self'}]
       ]);
       assert.deepEqual(buildIDLTests(ast, 'Worker'), [
         ['WorkerSync', {property: 'WorkerSync', scope: 'self'}]

--- a/test/unit/build.js
+++ b/test/unit/build.js
@@ -486,7 +486,7 @@ describe('build', () => {
     });
   });
 
-  describe('getExposureSet', () => {
+  describe('isWithinScope', () => {
     it('basic tests', () => {
       const specIDLs = {
         window: WebIDL2.parse(`[Exposed=Window] interface DummyOne {};`),

--- a/test/unit/build.js
+++ b/test/unit/build.js
@@ -1140,6 +1140,52 @@ describe('build', () => {
         ['CSS.paintWorklet', '(function() {var css = CSS;return css && \'paintWorklet\' in css;})()']
       ]);
     });
+
+    it('dictionary', () => {
+      const ast = WebIDL2.parse(
+          `dictionary ElementRegistrationOptions {
+              object? prototype = null;
+              DOMString? extends = null;
+           };`);
+      assert.deepEqual(buildIDLTests(ast), [
+        ['ElementRegistrationOptions', {property: 'ElementRegistrationOptions', scope: 'self'}],
+        ['ElementRegistrationOptions.extends', [
+          {property: 'ElementRegistrationOptions', scope: 'self'},
+          {property: 'extends', scope: 'ElementRegistrationOptions'}
+        ]],
+        ['ElementRegistrationOptions.prototype', [
+          {property: 'ElementRegistrationOptions', scope: 'self'},
+          {property: 'prototype', scope: 'ElementRegistrationOptions'}
+        ]]
+      ]);
+    });
+
+    it('dictionary with custom test', () => {
+      const ast = WebIDL2.parse(
+          `dictionary ElementRegistrationOptions {
+              object? prototype = null;
+              DOMString? extends = null;
+           };`);
+      loadCustomTests({
+        'api': {
+          'ElementRegistrationOptions': {
+            '__base': 'var ers = ElementRegistrationOptions;',
+            '__test': 'return !!ers;',
+            'extends': 'return ers && \'extends\' in ers;',
+            'prototype': 'return ers && \'prototype\' in ers;'
+          }
+        },
+        'css': {}
+      });
+      assert.deepEqual(buildIDLTests(ast), [
+        // eslint-disable-next-line max-len
+        ['ElementRegistrationOptions', '(function() {var ers = ElementRegistrationOptions;return !!ers;})()'],
+        // eslint-disable-next-line max-len
+        ['ElementRegistrationOptions.extends', '(function() {var ers = ElementRegistrationOptions;return ers && \'extends\' in ers;})()'],
+        // eslint-disable-next-line max-len
+        ['ElementRegistrationOptions.prototype', '(function() {var ers = ElementRegistrationOptions;return ers && \'prototype\' in ers;})()']
+      ]);
+    });
   });
 
   describe('validateIDL', () => {


### PR DESCRIPTION
This PR introduces some new testing additions.  Specifically:

- Support for testing constructors
- Support for iterable/maplike/setlike APIs
- Support for testing dictionaries
- Add more non-standard APIs
- Add test for CSS custom variables