### PR TITLE
Limit browsers tested via Selenium

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -1,6 +1,6 @@
 {
   "name": "mdn-bcd-collector",
-  "version": "0.0.3",
+  "version": "0.0.4",
   "lockfileVersion": 1,
   "requires": true,
   "dependencies": {

--- a/test/selenium/selenium.js
+++ b/test/selenium/selenium.js
@@ -37,14 +37,13 @@ const filterVersions = (data, earliestVersion) => {
   return versions;
 };
 
-// TODO: define target browsers
 // TODO: IE and pre-Blink Edge have issues with automated runtime
 let browsersToTest = {
-  'chrome': filterVersions(bcd.browsers.chrome.releases, 26),
+  'chrome': filterVersions(bcd.browsers.chrome.releases, 40),
   'edge': filterVersions(bcd.browsers.edge.releases, 13),
-  'firefox': filterVersions(bcd.browsers.firefox.releases, 4),
-  'ie': filterVersions(bcd.browsers.ie.releases, 9),
-  'safari': filterVersions(bcd.browsers.safari.releases, 8)
+  'firefox': filterVersions(bcd.browsers.firefox.releases, 35),
+  'ie': filterVersions(bcd.browsers.ie.releases, 11),
+  'safari': filterVersions(bcd.browsers.safari.releases, 9)
 };
 
 if (process.env.BROWSER) {

--- a/test/selenium/selenium.js
+++ b/test/selenium/selenium.js
@@ -40,7 +40,7 @@ const filterVersions = (data, earliestVersion) => {
 // TODO: IE and pre-Blink Edge have issues with automated runtime
 let browsersToTest = {
   'chrome': filterVersions(bcd.browsers.chrome.releases, 40),
-  'edge': filterVersions(bcd.browsers.edge.releases, 13),
+  'edge': filterVersions(bcd.browsers.edge.releases, 12),
   'firefox': filterVersions(bcd.browsers.firefox.releases, 35),
   'ie': filterVersions(bcd.browsers.ie.releases, 11),
   'safari': filterVersions(bcd.browsers.safari.releases, 9)


### PR DESCRIPTION
This limits the browser versions tested via Selenium to those released on/after Jan. 1st, 2015 (with the exception of IE/Edge, which is set to IE 11 and all versions of Edge).