### PR TITLE
Add appversion to filenames sent to results repo

### DIFF
--- a/github.js
+++ b/github.js
@@ -20,6 +20,8 @@ const slugify = require('slugify');
 const stringify = require('json-stable-stringify');
 const uaParser = require('ua-parser-js');
 
+const appversion = require('./package.json').version;
+
 module.exports = (options) => {
   const octokit = new Octokit(options);
 
@@ -36,7 +38,7 @@ module.exports = (options) => {
     const desc = `${browser} / ${os}`;
     const slug = slugify(desc, {lower: true});
 
-    const name = `${slug}-${digest}`;
+    const name = `${appversion}-${slug}-${digest}`;
     const branch = `collector/${name}`;
 
     if ((await octokit.auth()).type == 'unauthenticated') {

--- a/test/unit/github.js
+++ b/test/unit/github.js
@@ -19,6 +19,8 @@ const proxyquire = require('proxyquire');
 const sinon = require('sinon');
 const {Octokit} = require('@octokit/rest');
 
+const appversion = require('../../package.json').version;
+
 const REPORT = {
   results: {},
   // eslint-disable-next-line max-len
@@ -55,7 +57,7 @@ describe('GitHub export', () => {
 
     mock.git.expects('createRef').once().withArgs({
       owner: 'foolip',
-      ref: 'refs/heads/collector/safari-12.0-mac-os-10.14-afd516a15d',
+      ref: `refs/heads/collector/${appversion}-safari-12.0-mac-os-10.14-afd516a15d`,
       repo: 'mdn-bcd-results',
       sha: '753c6ed8e991e9729353a63d650ff0f5bd902b69'
     });
@@ -64,17 +66,17 @@ describe('GitHub export', () => {
         .once().withArgs(sinon.match({
           owner: 'foolip',
           repo: 'mdn-bcd-results',
-          path: 'safari-12.0-mac-os-10.14-afd516a15d.json',
+          path: `${appversion}-safari-12.0-mac-os-10.14-afd516a15d.json`,
           message: 'Results from Safari 12.0 / Mac OS 10.14',
           content: sinon.match.string,
-          branch: 'collector/safari-12.0-mac-os-10.14-afd516a15d'
+          branch: `collector/${appversion}-safari-12.0-mac-os-10.14-afd516a15d`
         }));
 
     mock.pulls.expects('create').once().withArgs({
       owner: 'foolip',
       repo: 'mdn-bcd-results',
       title: 'Results from Safari 12.0 / Mac OS 10.14',
-      head: 'collector/safari-12.0-mac-os-10.14-afd516a15d',
+      head: `collector/${appversion}-safari-12.0-mac-os-10.14-afd516a15d`,
       base: 'main'
     }).resolves({data: RESULT});
 

--- a/test/unit/github.js
+++ b/test/unit/github.js
@@ -57,8 +57,8 @@ describe('GitHub export', () => {
 
     mock.git.expects('createRef').once().withArgs({
       owner: 'foolip',
-      ref:
-        `refs/heads/collector/${appversion}-safari-12.0-mac-os-10.14-afd516a15d`,
+      // eslint-disable-next-line max-len
+      ref: `refs/heads/collector/${appversion}-safari-12.0-mac-os-10.14-afd516a15d`,
       repo: 'mdn-bcd-results',
       sha: '753c6ed8e991e9729353a63d650ff0f5bd902b69'
     });

--- a/test/unit/github.js
+++ b/test/unit/github.js
@@ -57,7 +57,8 @@ describe('GitHub export', () => {
 
     mock.git.expects('createRef').once().withArgs({
       owner: 'foolip',
-      ref: `refs/heads/collector/${appversion}-safari-12.0-mac-os-10.14-afd516a15d`,
+      ref:
+        `refs/heads/collector/${appversion}-safari-12.0-mac-os-10.14-afd516a15d`,
       repo: 'mdn-bcd-results',
       sha: '753c6ed8e991e9729353a63d650ff0f5bd902b69'
     });


### PR DESCRIPTION
This PR prepends the app version to the filenames sent to the results repository, allowing for easier organization.