### PR TITLE
Improve service worker tests

### DIFF
--- a/static/resources/harness.js
+++ b/static/resources/harness.js
@@ -300,10 +300,10 @@
                   }
 
                   var broadcast = new window.BroadcastChannel2(
-                    pending[i].name, {
-                      type: 'BroadcastChannel' in self ? 'native' : 'idb',
-                      webWorkerSupport: true
-                    }
+                      pending[i].name, {
+                        type: 'BroadcastChannel' in self ? 'native' : 'idb',
+                        webWorkerSupport: true
+                      }
                   );
 
                   reg.active.postMessage(pending[i]);

--- a/static/resources/harness.js
+++ b/static/resources/harness.js
@@ -282,11 +282,14 @@
 
     if ('serviceWorker' in navigator) {
       window.__workerCleanup().then(function() {
+        console.log('Starting registration');
         navigator.serviceWorker.register('/resources/serviceworker.js')
             .then(function(reg) {
+              console.log('Registered, waiting for activation');
               return window.__waitForSWState(reg, 'activated');
             })
             .then(function(reg) {
+              console.log('Activated');
               var promises = [];
 
               var length = pending.length;
@@ -311,9 +314,11 @@
               }
 
               Promise.allSettled(promises).then(function() {
+                console.log('All tests done');
                 pending = [];
 
                 window.__workerCleanup().then(function() {
+                  console.log('Cleaning up');
                   done(results);
                 });
               });

--- a/static/resources/harness.js
+++ b/static/resources/harness.js
@@ -418,9 +418,8 @@
       });
     };
 
-
     window.__workerCleanup = function() {
-      function unregisterSW() {
+      if ('getRegistrations' in navigator.serviceWorker) {
         return navigator.serviceWorker.getRegistrations()
             .then(function(registrations) {
               var unregisterPromise = registrations.map(function(registration) {
@@ -428,21 +427,14 @@
               });
               return Promise.all(unregisterPromise);
             });
-      }
-
-      function clearCaches() {
-        return window.caches.keys()
-            .then(function(cacheNames) {
-              return Promise.all(cacheNames.map(function(cacheName) {
-                return window.caches.delete(cacheName);
-              }));
+      } else {
+        return navigator.serviceWorker.getRegistration()
+            .then(function(registration) {
+              if (registration) {
+                return registration.unregister();
+              }
             });
       }
-
-      return Promise.all([
-        unregisterSW(),
-        clearCaches()
-      ]);
     };
   }
 

--- a/static/resources/harness.js
+++ b/static/resources/harness.js
@@ -299,10 +299,12 @@
                     statusElement.innerHTML = 'Testing ' + pending[i].name;
                   }
 
-                  var broadcast = new window.BroadcastChannel2(pending[i].name, {
-                    type: 'BroadcastChannel' in self ? 'native' : 'idb',
-                    webWorkerSupport: true
-                  });
+                  var broadcast = new window.BroadcastChannel2(
+                    pending[i].name, {
+                      type: 'BroadcastChannel' in self ? 'native' : 'idb',
+                      webWorkerSupport: true
+                    }
+                  );
 
                   reg.active.postMessage(pending[i]);
 

--- a/static/resources/harness.js
+++ b/static/resources/harness.js
@@ -281,44 +281,47 @@
     var results = [];
 
     if ('serviceWorker' in navigator) {
-      window.__workerCleanup();
+      window.__workerCleanup().then(function() {
+        navigator.serviceWorker.register('/resources/serviceworker.js')
+            .then(function(reg) {
+              return window.__waitForSWState(reg, 'activated');
+            })
+            .then(function(reg) {
+              var promises = [];
 
-      navigator.serviceWorker.register('/resources/serviceworker.js')
-          .then(function(reg) {
-            return window.__waitForSWState(reg, 'activated');
-          })
-          .then(function(reg) {
-            var promises = [];
+              var length = pending.length;
+              for (var i = 0; i < length; i++) {
+                promises.push(new Promise(function(resolve) {
+                  if (statusElement) {
+                    statusElement.innerHTML = 'Testing ' + pending[i].name;
+                  }
 
-            var length = pending.length;
-            for (var i = 0; i < length; i++) {
-              promises.push(new Promise(function(resolve) {
-                if (statusElement) {
-                  statusElement.innerHTML = 'Testing ' + pending[i].name;
-                }
+                  var broadcast = new window.BroadcastChannel2(pending[i].name, {
+                    type: 'BroadcastChannel' in self ? 'native' : 'idb',
+                    webWorkerSupport: true
+                  });
 
-                var broadcast = new window.BroadcastChannel2(pending[i].name, {
-                  type: 'BroadcastChannel' in self ? 'native' : 'idb',
-                  webWorkerSupport: true
+                  reg.active.postMessage(pending[i]);
+
+                  broadcast.onmessage = function(message) {
+                    results.push(message);
+                    resolve();
+                  };
+                }));
+              }
+
+              Promise.allSettled(promises).then(function() {
+                pending = [];
+
+                window.__workerCleanup().then(function() {
+                  done(results);
                 });
-
-                reg.active.postMessage(pending[i]);
-
-                broadcast.onmessage = function(message) {
-                  results.push(message);
-                  resolve();
-                };
-              }));
-            }
-
-            Promise.allSettled(promises).then(function() {
-              pending = [];
-
-              window.__workerCleanup().then(function() {
-                done(results);
               });
+            })
+            .catch(function(error) {
+              console.error(error);
             });
-          });
+      });
     } else {
       console.log('No service worker support');
       if (statusElement) {


### PR DESCRIPTION
This PR introduces some improvements to service worker tests, including simplification of the `__workerCleanup` function and awaiting the promise completion of the initial cleanup (which may have been causing async timing issues causing #357).  This also adds some logging statements to test the issues in production (a bit hard to test on local due to lack of HTTPS).