### PR TITLE
Fix service worker tests on older browsers

### DIFF
--- a/build.js
+++ b/build.js
@@ -592,7 +592,6 @@ function buildIDLServiceWorker(ast) {
     '<meta charset="utf-8">',
     '<script src="/resources/json3.min.js"></script>',
     '<script src="/resources/harness.js"></script>',
-    '<script src="/resources/broadcastchannel.js"></script>',
     '<script src="/resources/core.js"></script>',
     '</head>',
     '<body>',
@@ -636,11 +635,6 @@ async function writeManifest(manifest) {
 function copyResources() {
   const resources = [
     ['json3/lib/json3.min.js', 'resources'],
-    [
-      'broadcast-channel/dist/lib/browser.min.js',
-      'resources',
-      'broadcastchannel.js'
-    ],
     ['core-js-bundle/minified.js', 'resources', 'core.js'],
     ['core-js-bundle/minified.js.map', 'resources', 'core.js.map'],
     ['chai/chai.js', 'test'],

--- a/package-lock.json
+++ b/package-lock.json
@@ -197,14 +197,6 @@
       "integrity": "sha512-8jHII4hf+YVDsskTF6WuMB3X4Eh+PsUkC2ljq22so5rHvH+T8BzyL94VOdyFLNR8tBSVXOTbNHOKpR4TfRxVtA==",
       "dev": true
     },
-    "@babel/runtime": {
-      "version": "7.10.5",
-      "resolved": "https://registry.npmjs.org/@babel/runtime/-/runtime-7.10.5.tgz",
-      "integrity": "sha512-otddXKhdNn7d0ptoFRHtMLa8LqDxLYwTjB4nYgM1yy5N6gU/MUf8zqyyLltCH3yAVitBzmwK4us+DD0l/MauAg==",
-      "requires": {
-        "regenerator-runtime": "^0.13.4"
-      }
-    },
     "@babel/template": {
       "version": "7.10.4",
       "resolved": "https://registry.npmjs.org/@babel/template/-/template-7.10.4.tgz",
@@ -1132,7 +1124,8 @@
     "balanced-match": {
       "version": "1.0.0",
       "resolved": "https://registry.npmjs.org/balanced-match/-/balanced-match-1.0.0.tgz",
-      "integrity": "sha1-ibTRmasr7kneFk6gK4nORi1xt2c="
+      "integrity": "sha1-ibTRmasr7kneFk6gK4nORi1xt2c=",
+      "dev": true
     },
     "base64-js": {
       "version": "1.3.1",
@@ -1143,11 +1136,6 @@
       "version": "2.1.0",
       "resolved": "https://registry.npmjs.org/before-after-hook/-/before-after-hook-2.1.0.tgz",
       "integrity": "sha512-IWIbu7pMqyw3EAJHzzHbWa85b6oud/yfKYg5rqB5hNE8CeMi3nX+2C2sj0HswfblST86hpVEOAb9x34NZd6P7A=="
-    },
-    "big-integer": {
-      "version": "1.6.48",
-      "resolved": "https://registry.npmjs.org/big-integer/-/big-integer-1.6.48.tgz",
-      "integrity": "sha512-j51egjPa7/i+RdiRuJbPdJ2FIUYYPhvYLjzoYbcMMm62ooO6F94fETG4MTs46zPAF9Brs04OajboA/qTGuz78w=="
     },
     "bignumber.js": {
       "version": "9.0.0",
@@ -1229,6 +1217,7 @@
       "version": "1.1.11",
       "resolved": "https://registry.npmjs.org/brace-expansion/-/brace-expansion-1.1.11.tgz",
       "integrity": "sha512-iCuPHDFgrHX7H2vEI/5xpz07zSHB00TpugqhmYtVmMO6518mCuRMoOYFldEBl0g187ufozdaHgWKcYFb61qGiA==",
+      "dev": true,
       "requires": {
         "balanced-match": "^1.0.0",
         "concat-map": "0.0.1"
@@ -1241,30 +1230,6 @@
       "dev": true,
       "requires": {
         "fill-range": "^7.0.1"
-      }
-    },
-    "broadcast-channel": {
-      "version": "3.1.0",
-      "resolved": "https://registry.npmjs.org/broadcast-channel/-/broadcast-channel-3.1.0.tgz",
-      "integrity": "sha512-zrjTunJRva1aFW9UlLtoMnB05tu8hbb7qbv3PxXXGnxp3t9VA/KcTIwcC0+u7oLBdlXSnv0yy7pB+UemLjANyQ==",
-      "requires": {
-        "@babel/runtime": "^7.7.2",
-        "detect-node": "^2.0.4",
-        "js-sha3": "0.8.0",
-        "microseconds": "0.2.0",
-        "nano-time": "1.0.0",
-        "rimraf": "3.0.2",
-        "unload": "2.2.0"
-      },
-      "dependencies": {
-        "rimraf": {
-          "version": "3.0.2",
-          "resolved": "https://registry.npmjs.org/rimraf/-/rimraf-3.0.2.tgz",
-          "integrity": "sha512-JZkJMZkAGFFPP2YqXZXPbMlMBgsxzE8ILs4lMIX/2o0L9UBw9O/Y3o6wFw/i9YLapcUJWwqbi3kdxIPdC62TIA==",
-          "requires": {
-            "glob": "^7.1.3"
-          }
-        }
       }
     },
     "browser-stdout": {
@@ -1570,7 +1535,8 @@
     "concat-map": {
       "version": "0.0.1",
       "resolved": "https://registry.npmjs.org/concat-map/-/concat-map-0.0.1.tgz",
-      "integrity": "sha1-2Klr13/Wjfd5OnMDajug1UBdR3s="
+      "integrity": "sha1-2Klr13/Wjfd5OnMDajug1UBdR3s=",
+      "dev": true
     },
     "concat-stream": {
       "version": "2.0.0",
@@ -1767,11 +1733,6 @@
       "version": "1.0.4",
       "resolved": "https://registry.npmjs.org/destroy/-/destroy-1.0.4.tgz",
       "integrity": "sha1-l4hXRCxEdJ5CBmE+N5RiBYJqvYA="
-    },
-    "detect-node": {
-      "version": "2.0.4",
-      "resolved": "https://registry.npmjs.org/detect-node/-/detect-node-2.0.4.tgz",
-      "integrity": "sha512-ZIzRpLJrOj7jjP2miAtgqIfmzbxa4ZOr5jJc601zklsfEx9oTzmmj2nVpIPRpNlRTIh8lc1kyViIY7BWSGNmKw=="
     },
     "devtools-protocol": {
       "version": "0.0.781568",
@@ -2469,7 +2430,8 @@
     "fs.realpath": {
       "version": "1.0.0",
       "resolved": "https://registry.npmjs.org/fs.realpath/-/fs.realpath-1.0.0.tgz",
-      "integrity": "sha1-FQStJSMVjKpA20onh8sBQRmU6k8="
+      "integrity": "sha1-FQStJSMVjKpA20onh8sBQRmU6k8=",
+      "dev": true
     },
     "fsevents": {
       "version": "2.1.3",
@@ -2641,6 +2603,7 @@
       "version": "7.1.6",
       "resolved": "https://registry.npmjs.org/glob/-/glob-7.1.6.tgz",
       "integrity": "sha512-LwaxwyZ72Lk7vZINtNNrywX0ZuLyStrdDtabefZKAY5ZGJhVtgdznluResxNmPitE0SAO+O26sWTHeKSI2wMBA==",
+      "dev": true,
       "requires": {
         "fs.realpath": "^1.0.0",
         "inflight": "^1.0.4",
@@ -2976,6 +2939,7 @@
       "version": "1.0.6",
       "resolved": "https://registry.npmjs.org/inflight/-/inflight-1.0.6.tgz",
       "integrity": "sha1-Sb1jMdfQLQwJvJEKEHW6gWW1bfk=",
+      "dev": true,
       "requires": {
         "once": "^1.3.0",
         "wrappy": "1"
@@ -3339,11 +3303,6 @@
         "iterate-iterator": "^1.0.1"
       }
     },
-    "js-sha3": {
-      "version": "0.8.0",
-      "resolved": "https://registry.npmjs.org/js-sha3/-/js-sha3-0.8.0.tgz",
-      "integrity": "sha512-gF1cRrHhIzNfToc802P800N8PpXS+evLLXfsVpowqmAFR9uwbi89WvXg2QspOmXL8QL86J4T1EpFu+yUkwJY3Q=="
-    },
     "js-tokens": {
       "version": "4.0.0",
       "resolved": "https://registry.npmjs.org/js-tokens/-/js-tokens-4.0.0.tgz",
@@ -3618,11 +3577,6 @@
       "resolved": "https://registry.npmjs.org/methods/-/methods-1.1.2.tgz",
       "integrity": "sha1-VSmk1nZUE07cxSZmVoNbD4Ua/O4="
     },
-    "microseconds": {
-      "version": "0.2.0",
-      "resolved": "https://registry.npmjs.org/microseconds/-/microseconds-0.2.0.tgz",
-      "integrity": "sha512-n7DHHMjR1avBbSpsTBj6fmMGh2AGrifVV4e+WYc3Q9lO+xnSZ3NyhcBND3vzzatt05LFhoKFRxrIyklmLlUtyA=="
-    },
     "mime": {
       "version": "2.4.6",
       "resolved": "https://registry.npmjs.org/mime/-/mime-2.4.6.tgz",
@@ -3650,6 +3604,7 @@
       "version": "3.0.4",
       "resolved": "https://registry.npmjs.org/minimatch/-/minimatch-3.0.4.tgz",
       "integrity": "sha512-yJHVQEhyqPLUTgt9B83PXu6W3rx4MvvHvSUvToogpwoGDOUQ+yDrR0HRot+yOCdCO7u4hX3pWft6kWBBcqh0UA==",
+      "dev": true,
       "requires": {
         "brace-expansion": "^1.1.7"
       }
@@ -3750,14 +3705,6 @@
       "version": "2.1.2",
       "resolved": "https://registry.npmjs.org/ms/-/ms-2.1.2.tgz",
       "integrity": "sha512-sGkPx+VjMtmA6MX27oA4FBFELFCZZ4S4XqeGOXCv68tT+jb3vk/RyaKWP0PTKyWtmLSM0b+adUTEvbs1PEaH2w=="
-    },
-    "nano-time": {
-      "version": "1.0.0",
-      "resolved": "https://registry.npmjs.org/nano-time/-/nano-time-1.0.0.tgz",
-      "integrity": "sha1-sFVPaa2J4i0JB/ehKwmTpdlhN+8=",
-      "requires": {
-        "big-integer": "^1.6.16"
-      }
     },
     "natural-compare": {
       "version": "1.4.0",
@@ -4135,7 +4082,8 @@
     "path-is-absolute": {
       "version": "1.0.1",
       "resolved": "https://registry.npmjs.org/path-is-absolute/-/path-is-absolute-1.0.1.tgz",
-      "integrity": "sha1-F0uSaHNVNP+8es5r9TpanhtcX18="
+      "integrity": "sha1-F0uSaHNVNP+8es5r9TpanhtcX18=",
+      "dev": true
     },
     "path-key": {
       "version": "3.1.1",
@@ -4443,11 +4391,6 @@
     "reffy-reports": {
       "version": "git://github.com/foolip/reffy-reports.git#53e0d36e7ea56ed2be469f0b497654b1a5f682a0",
       "from": "git://github.com/foolip/reffy-reports.git#mdn-bcd-updater-fixes"
-    },
-    "regenerator-runtime": {
-      "version": "0.13.7",
-      "resolved": "https://registry.npmjs.org/regenerator-runtime/-/regenerator-runtime-0.13.7.tgz",
-      "integrity": "sha512-a54FxoJDIr27pgf7IgeQGxmqUNYrcV338lf/6gH456HZ/PhX+5BcwHXG9ajESmwe6WRO0tAzRUrRmNONWgkrew=="
     },
     "regexpp": {
       "version": "3.1.0",
@@ -5150,15 +5093,6 @@
       "version": "1.0.0",
       "resolved": "https://registry.npmjs.org/universalify/-/universalify-1.0.0.tgz",
       "integrity": "sha512-rb6X1W158d7pRQBg5gkR8uPaSfiids68LTJQYOtEUhoJUWBdaQHsuT/EUduxXYxcrt4r5PJ4fuHW1MHT6p0qug=="
-    },
-    "unload": {
-      "version": "2.2.0",
-      "resolved": "https://registry.npmjs.org/unload/-/unload-2.2.0.tgz",
-      "integrity": "sha512-B60uB5TNBLtN6/LsgAf3udH9saB5p7gqJwcFfbOEZ8BcBHnGwCf6G/TGiEqkRAxX7zAFIUtzdrXQSdL3Q/wqNA==",
-      "requires": {
-        "@babel/runtime": "^7.6.2",
-        "detect-node": "^2.0.4"
-      }
     },
     "unpipe": {
       "version": "1.0.0",

--- a/package.json
+++ b/package.json
@@ -28,7 +28,6 @@
     "@google-cloud/logging-winston": "4.0.0",
     "@google-cloud/storage": "5.1.2",
     "@octokit/rest": "18.0.3",
-    "broadcast-channel": "^3.1.0",
     "cookie-parser": "1.4.5",
     "core-js-bundle": "^3.6.5",
     "express": "4.17.1",

--- a/static/resources/harness.js
+++ b/static/resources/harness.js
@@ -432,7 +432,7 @@
               return Promise.all(unregisterPromise);
             });
       } else {
-        return navigator.serviceWorker.getRegistration()
+        return navigator.serviceWorker.getRegistration('/resources/')
             .then(function(registration) {
               if (registration) {
                 return registration.unregister();

--- a/static/resources/harness.js
+++ b/static/resources/harness.js
@@ -282,14 +282,11 @@
 
     if ('serviceWorker' in navigator) {
       window.__workerCleanup().then(function() {
-        console.log('Starting registration');
         navigator.serviceWorker.register('/resources/serviceworker.js', {
           scope: '/resources/'
         }).then(function(reg) {
-          console.log('Registered, waiting for activation');
           return window.__waitForSWState(reg, 'activated');
         }).then(function(reg) {
-          console.log('Activated');
           var promises = [];
 
           var length = pending.length;
@@ -316,11 +313,9 @@
           }
 
           Promise.allSettled(promises).then(function() {
-            console.log('All tests done');
             pending = [];
 
             window.__workerCleanup().then(function() {
-              console.log('Cleaning up');
               done(results);
             });
           });

--- a/static/resources/harness.js
+++ b/static/resources/harness.js
@@ -303,12 +303,12 @@
                   }
               );
 
-              reg.active.postMessage(pending[i]);
-
               broadcast.onmessage = function(message) {
                 results.push(message);
                 resolve();
               };
+
+              reg.active.postMessage(pending[i]);
             }));
           }
 

--- a/static/resources/serviceworker.js
+++ b/static/resources/serviceworker.js
@@ -29,6 +29,5 @@ self.addEventListener('install', function(event) {
 });
 
 self.addEventListener('message', function(event) {
-  var result = bcd.test(event.data);
-  event.source.postMessage(event.data);
+  event.source.postMessage(bcd.test(event.data));
 });

--- a/static/resources/serviceworker.js
+++ b/static/resources/serviceworker.js
@@ -15,9 +15,6 @@
 /* global self, caches, Request, Response */
 /* global bcd */
 
-var window = {}; // Needed for the BroadcastChannel polyfill
-
-self.importScripts('broadcastchannel.js');
 self.importScripts('harness.js');
 
 self.addEventListener('install', function(event) {
@@ -33,10 +30,5 @@ self.addEventListener('install', function(event) {
 
 self.addEventListener('message', function(event) {
   var result = bcd.test(event.data);
-
-  var broadcast = new window.BroadcastChannel2(result.name, {
-    type: 'BroadcastChannel' in self ? 'native' : 'idb',
-    webWorkerSupport: true
-  });
-  broadcast.postMessage(result);
+  event.source.postMessage(event.data);
 });


### PR DESCRIPTION
This PR fixes issues with service worker based tests on older browsers (such as Chrome 40).  By eliminating the use of the BroadcastChannel "polyfill" and switching to the same methods used for web workers (global `onmessage` which routes the data to a function made within the promise to resolve said promise).