### PR TITLE
Fix check for illegal constructor

### DIFF
--- a/static/resources/harness.js
+++ b/static/resources/harness.js
@@ -106,10 +106,7 @@
             eval('new '+iface+'()');
             result.result = true;
           } catch (err) {
-            if (
-              err.name == 'TypeError' &&
-              err.message == 'Illegal constructor'
-            ) {
+            if (stringIncludes(err.message, 'Illegal constructor')) {
               result.result = false;
             } else if (
               stringIncludes(err.message, 'Not enough arguments') ||


### PR DESCRIPTION
This PR fixes the illegal constructor check, by checking for "Illegal constructor" anywhere in the string, not if just an equal match, as well as accepts any error type (in case a browser doesn't return a TypeError for illegal constructors).