### PR TITLE
Update harness.js to catch pre-Chromium Edge errors for constructors

### DIFF
--- a/static/resources/harness.js
+++ b/static/resources/harness.js
@@ -106,12 +106,16 @@
             eval('new '+iface+'()');
             result.result = true;
           } catch (err) {
-            if (stringIncludes(err.message, 'Illegal constructor')) {
+            if (
+              stringIncludes(err.message, 'Illegal constructor') ||
+              stringIncludes(err.message, 'Function expected')
+            ) {
               result.result = false;
             } else if (
               stringIncludes(err.message, 'Not enough arguments') ||
               stringIncludes(err.message, 'argument required') ||
-              stringIncludes(err.message, 'arguments required')
+              stringIncludes(err.message, 'arguments required') ||
+              stringIncludes(err.message, 'Argument not optional')
             ) {
               // If it failed to construct and it's not illegal or just needs
               // more arguments, the constructor's good


### PR DESCRIPTION
This PR adds some lines to harness.js to catch the error messages generated by pre-Chromium Edge for constructor issues.

<img width="348" alt="Screen Shot 2020-08-29 at 14 29 14" src="https://user-images.githubusercontent.com/5179191/91646433-03a2ef80-ea04-11ea-8791-e9bea6df2483.png">
<img width="372" alt="Screen Shot 2020-08-29 at 14 29 48" src="https://user-images.githubusercontent.com/5179191/91646439-19181980-ea04-11ea-8572-73ac05036862.png">
