### PR TITLE
Update the BCD updater

### DIFF
--- a/update-bcd.js
+++ b/update-bcd.js
@@ -4,7 +4,6 @@ const compareVersions = require('compare-versions');
 const fs = require('fs');
 const path = require('path');
 const uaParser = require('ua-parser-js');
-const bcd = require('mdn-browser-compat-data');
 
 const overrides = require('./overrides').filter(Array.isArray);
 

--- a/update-bcd.js
+++ b/update-bcd.js
@@ -134,6 +134,7 @@ function getSupportMap(report) {
 // Load all reports and build a map from BCD path to browser + version
 // and test result (null/true/false) for that version.
 function getSupportMatrix(bcd, reports) {
+  // TODO catch prefixed support
   const supportMatrix = new Map;
 
   for (const report of reports) {
@@ -191,8 +192,8 @@ function getSupportMatrix(bcd, reports) {
 }
 
 function inferSupportStatements(versionMap) {
-  const versions = Array.from(versionMap.keys());
-  versions.sort(compareVersions);
+  const versions = Array.from(versionMap.keys()).sort(compareVersions);
+  console.log(versions);
 
   const statements = [];
   const lastKnown = {version: null, support: null, prefix: ""};
@@ -283,7 +284,15 @@ function update(bcd, supportMatrix) {
         // is not supported. So only update in case new data contracts that.
         if (inferredStatments.some((statement) => statement.version_added)) {
           supportStatement.unshift(...inferredStatments);
-          entry.__compat.support[browser] = supportStatement;
+          supportStatement = supportStatement.filter(
+            (item, pos, self) => (pos === self.findIndex((el) => (
+              el.version_added == item.version_added &&
+              el.version_removed == item.version_removed &&
+              el.prefix == item.prefix
+            )))
+          );
+          entry.__compat.support[browser] = supportStatement.length === 1 ?
+            supportStatement[0] : supportStatement;
         }
         continue;
       }

--- a/update-bcd.js
+++ b/update-bcd.js
@@ -138,7 +138,7 @@ function getSupportMap(report) {
         supported = {result: result, prefix: prefix};
         continue;
       }
-      if (supported !== result) {
+      if (supported.result !== result) {
         // This will happen for [SecureContext] APIs and APIs under multiple
         // scopes.
         // console.log(`Contradictory results for ${name}: ${JSON.stringify(

--- a/update-bcd.js
+++ b/update-bcd.js
@@ -25,6 +25,30 @@ function isDirectory(fp) {
   }
 }
 
+function isEquivalent(a, b) {
+    // Create arrays of property names
+    const aProps = Object.getOwnPropertyNames(a);
+    const bProps = Object.getOwnPropertyNames(b);
+
+    // If number of properties is different,
+    // objects are not equivalent
+    if (aProps.length != bProps.length) {
+        return false;
+    }
+
+    for (const propName of aProps) {
+        // If values of same property are not equal,
+        // objects are not equivalent
+        if (a[propName] !== b[propName]) {
+            return false;
+        }
+    }
+
+    // If we made it this far, objects
+    // are considered equivalent
+    return true;
+}
+
 // https://github.com/mdn/browser-compat-data/issues/3617
 function save(bcd, bcdDir) {
   function processObject(object, keypath) {
@@ -285,9 +309,7 @@ function update(bcd, supportMatrix) {
           supportStatement.unshift(...inferredStatments);
           supportStatement = supportStatement.filter(
             (item, pos, self) => (pos === self.findIndex((el) => (
-              el.version_added == item.version_added &&
-              el.version_removed == item.version_removed &&
-              el.prefix == item.prefix
+              isEquivalent(el, item)
             )))
           );
           entry.__compat.support[browser] = supportStatement.length === 1 ?

--- a/update-bcd.js
+++ b/update-bcd.js
@@ -193,7 +193,6 @@ function getSupportMatrix(bcd, reports) {
 
 function inferSupportStatements(versionMap) {
   const versions = Array.from(versionMap.keys()).sort(compareVersions);
-  console.log(versions);
 
   const statements = [];
   const lastKnown = {version: null, support: null, prefix: ""};

--- a/update-bcd.js
+++ b/update-bcd.js
@@ -25,27 +25,27 @@ function isDirectory(fp) {
 }
 
 function isEquivalent(a, b) {
-    // Create arrays of property names
-    const aProps = Object.getOwnPropertyNames(a);
-    const bProps = Object.getOwnPropertyNames(b);
+  // Create arrays of property names
+  const aProps = Object.getOwnPropertyNames(a);
+  const bProps = Object.getOwnPropertyNames(b);
 
-    // If number of properties is different,
+  // If number of properties is different,
+  // objects are not equivalent
+  if (aProps.length != bProps.length) {
+    return false;
+  }
+
+  for (const propName of aProps) {
+    // If values of same property are not equal,
     // objects are not equivalent
-    if (aProps.length != bProps.length) {
-        return false;
+    if (a[propName] !== b[propName]) {
+      return false;
     }
+  }
 
-    for (const propName of aProps) {
-        // If values of same property are not equal,
-        // objects are not equivalent
-        if (a[propName] !== b[propName]) {
-            return false;
-        }
-    }
-
-    // If we made it this far, objects
-    // are considered equivalent
-    return true;
+  // If we made it this far, objects
+  // are considered equivalent
+  return true;
 }
 
 // https://github.com/mdn/browser-compat-data/issues/3617
@@ -127,7 +127,7 @@ function getSupportMap(report) {
   // Transform `testMap` to map from test name (BCD path) to flattened support.
   const supportMap = new Map;
   for (const [name, results] of testMap.entries()) {
-    let supported = {result: null, prefix: ""};
+    let supported = {result: null, prefix: ''};
     // eslint-disable-next-line no-unused-vars
     for (const {url, result, prefix} of results) {
       if (result === null) {
@@ -182,10 +182,10 @@ function getSupportMatrix(bcd, reports) {
       let versionMap = browserMap.get(browser);
       if (!versionMap) {
         versionMap = new Map;
-        for (let browserVersion of 
+        for (const browserVersion of
           Object.keys(bcd.browsers[browser].releases)
         ) {
-          versionMap.set(browserVersion, {result: null, prefix: ""});
+          versionMap.set(browserVersion, {result: null, prefix: ''});
         }
         browserMap.set(browser, versionMap);
       }
@@ -224,7 +224,7 @@ function inferSupportStatements(versionMap) {
   const versions = Array.from(versionMap.keys()).sort(compareVersions);
 
   const statements = [];
-  const lastKnown = {version: null, support: null, prefix: ""};
+  const lastKnown = {version: null, support: null, prefix: ''};
   let lastWasNull = false;
 
   for (const [i, version] of versions.entries()) {
@@ -234,9 +234,9 @@ function inferSupportStatements(versionMap) {
     if (supported === true) {
       if (!lastStatement) {
         statements.push({
-          version_added: (i === 0 || lastKnown.support === false)
-            ? version
-            : true,
+          version_added: (i === 0 || lastKnown.support === false) ?
+            version :
+            true,
           ...(prefix && {prefix: prefix})
         });
       } else if (!lastStatement.version_added) {
@@ -257,7 +257,7 @@ function inferSupportStatements(versionMap) {
 
       lastKnown.version = version;
       lastKnown.support = true;
-      lastKnown.prefix = ""; // TODO hook up with real prefixes
+      lastKnown.prefix = ''; // TODO hook up with real prefixes
       lastWasNull = false;
     } else if (supported === false) {
       if (
@@ -265,7 +265,7 @@ function inferSupportStatements(versionMap) {
         lastStatement.version_added &&
         !lastStatement.version_removed
       ) {
-        lastStatement.version_removed = 
+        lastStatement.version_removed =
           (!lastWasNull || lastKnown.support === false) ? version : true;
       } else if (!lastStatement) {
         statements.push({version_added: false});
@@ -273,7 +273,7 @@ function inferSupportStatements(versionMap) {
 
       lastKnown.version = version;
       lastKnown.support = false;
-      lastKnown.prefix = "";
+      lastKnown.prefix = '';
       lastWasNull = false;
     } else if (supported === null) {
       lastWasNull = true;
@@ -323,9 +323,9 @@ function update(bcd, supportMatrix) {
         if (inferredStatments.some((statement) => statement.version_added)) {
           supportStatement.unshift(...inferredStatments);
           supportStatement = supportStatement.filter(
-            (item, pos, self) => (pos === self.findIndex((el) => (
-              isEquivalent(el, item)
-            )))
+              (item, pos, self) => (pos === self.findIndex((el) => (
+                isEquivalent(el, item)
+              )))
           );
           entry.__compat.support[browser] = supportStatement.length === 1 ?
             supportStatement[0] : supportStatement;


### PR DESCRIPTION
This PR updates the BCD update script with a few things, namely the following:

- Initialize support matrix with all browsers in BCD data -- this allows us to better determine version numbers, due to the improvement listed right below
- Improved null value handling -- if support changes between versions and there are null/unknown values in between, do not determine a version number
- Make sure there are no duplicate statements -- when adding a statement including `version_removed`, sometimes it will add a duplicate; this was resolved
- Add prefix support -- account for prefixed support in browsers