### PR TITLE
Improve version omitting in update-bcd

### DIFF
--- a/.eslintrc.json
+++ b/.eslintrc.json
@@ -7,7 +7,8 @@
     },
     "rules": {
         "comma-dangle": ["error", "never"],
-        "require-jsdoc": "off"
+        "require-jsdoc": "off",
+        "no-unused-vars": ["error", {"varsIgnorePattern": "^_$"}]
     },
     "env": {
         "es6": true,

--- a/update-bcd.js
+++ b/update-bcd.js
@@ -234,9 +234,7 @@ function inferSupportStatements(versionMap) {
     if (supported === true) {
       if (!lastStatement) {
         statements.push({
-          version_added: (i === 0 || lastKnown.support === false) ?
-            version :
-            true,
+          version_added: (lastWasNull && lastKnown.support === false) ? true : version,
           ...(prefix && {prefix: prefix})
         });
       } else if (!lastStatement.version_added) {

--- a/update-bcd.js
+++ b/update-bcd.js
@@ -227,14 +227,15 @@ function inferSupportStatements(versionMap) {
   const lastKnown = {version: null, support: null, prefix: ''};
   let lastWasNull = false;
 
-  for (const [i, version] of versions.entries()) {
+  for (const [_, version] of versions.entries()) {
     const {result: supported, prefix} = versionMap.get(version);
     const lastStatement = statements[statements.length - 1];
 
     if (supported === true) {
       if (!lastStatement) {
         statements.push({
-          version_added: (lastWasNull && lastKnown.support === false) ? true : version,
+          version_added: (lastWasNull && lastKnown.support === false) ?
+              true : version,
           ...(prefix && {prefix: prefix})
         });
       } else if (!lastStatement.version_added) {

--- a/update-bcd.js
+++ b/update-bcd.js
@@ -257,7 +257,7 @@ function inferSupportStatements(versionMap) {
 
       lastKnown.version = version;
       lastKnown.support = true;
-      lastKnown.prefix = ''; // TODO hook up with real prefixes
+      lastKnown.prefix = prefix;
       lastWasNull = false;
     } else if (supported === false) {
       if (
@@ -273,7 +273,7 @@ function inferSupportStatements(versionMap) {
 
       lastKnown.version = version;
       lastKnown.support = false;
-      lastKnown.prefix = '';
+      lastKnown.prefix = prefix;
       lastWasNull = false;
     } else if (supported === null) {
       lastWasNull = true;


### PR DESCRIPTION
This PR improves the version omission when there are null gaps in `update-bcd`.