### PR TITLE
Generate individual API/CSS tests

### DIFF
--- a/app.js
+++ b/app.js
@@ -74,7 +74,8 @@ app.use(express.static('generated'));
 app.get('/api/tests', (req, res) => {
   const {after, limit} = req.query;
   const list = tests.list(after, limit ? +limit : 0);
-  res.json(list);
+  const individualList = tests.listIndividual(after, limit ? +limit : 0);
+  res.json([list, individualList]);
 });
 
 app.post('/api/results', (req, res) => {

--- a/build.js
+++ b/build.js
@@ -37,6 +37,29 @@ function writeText(filename, content) {
   fs.writeFileSync(filename, content, 'utf8');
 }
 
+function writeTestFile(filename, lines) {
+  const content = [
+    '<!DOCTYPE html>',
+    '<html>',
+    '<head>',
+    ...copyright,
+    '<meta charset="utf-8">',
+    '<script src="/resources/json3.min.js"></script>',
+    '<script src="/resources/harness.js"></script>',
+    '<script src="/resources/core.js"></script>',
+    '</head>',
+    '<body>',
+    '<p id="status">Running tests...</p>',
+    '<script>',
+    ...lines,
+    '</script>',
+    '</body>',
+    '</html>'
+  ];
+
+  writeText(filename, content);
+}
+
 function loadCustomTests(newTests) {
   customTests = newTests ? newTests : require('./custom-tests.json');
 }
@@ -136,19 +159,7 @@ function cssPropertyToIDLAttribute(property, lowercaseFirst) {
 }
 
 function buildCSSPropertyTest(propertyNames, method, basename) {
-  const lines = [
-    '<!DOCTYPE html>',
-    '<html>',
-    '<head>',
-    ...copyright,
-    '<meta charset="utf-8">',
-    '<script src="/resources/json3.min.js"></script>',
-    '<script src="/resources/harness.js"></script>',
-    '</head>',
-    '<body>',
-    '<p id="status">Running test...</p>',
-    '<script>'
-  ];
+  const lines = [];
 
   for (const name of propertyNames) {
     const ident = `css.properties.${name}`;
@@ -171,10 +182,10 @@ function buildCSSPropertyTest(propertyNames, method, basename) {
       }
     }
   }
-  lines.push('bcd.run("CSS");', '</script>', '</body>', '</html>');
+  lines.push('bcd.run("CSS");');
   const pathname = path.join('css', 'properties', basename);
   const filename = path.join(generatedDir, pathname);
-  writeText(filename, lines);
+  writeTestFile(filename, lines);
   return pathname;
 }
 
@@ -532,19 +543,7 @@ function validateIDL(ast) {
 }
 
 function buildIDLWindow(tests) {
-  const lines = [
-    '<!DOCTYPE html>',
-    '<html>',
-    '<head>',
-    ...copyright,
-    '<meta charset="utf-8">',
-    '<script src="/resources/json3.min.js"></script>',
-    '<script src="/resources/harness.js"></script>',
-    '</head>',
-    '<body>',
-    '<p id="status">Running test...</p>',
-    '<script>'
-  ];
+  const lines = [];
 
   for (const [name, expr, exposureSet] of tests) {
     if (!exposureSet.has('Window')) {
@@ -555,28 +554,15 @@ function buildIDLWindow(tests) {
     );
   }
 
-  lines.push('bcd.run("Window");', '</script>', '</body>', '</html>');
+  lines.push('bcd.run("Window");');
   const pathname = path.join('api', 'interfaces.html');
   const filename = path.join(generatedDir, pathname);
-  writeText(filename, lines);
+  writeTestFile(filename, lines);
   return [['http', pathname], ['https', pathname]];
 }
 
 function buildIDLWorker(tests) {
-  const lines = [
-    '<!DOCTYPE html>',
-    '<html>',
-    '<head>',
-    ...copyright,
-    '<meta charset="utf-8">',
-    '<script src="/resources/json3.min.js"></script>',
-    '<script src="/resources/harness.js"></script>',
-    '<script src="/resources/core.js"></script>',
-    '</head>',
-    '<body>',
-    '<p id="status">Running test...</p>',
-    '<script>'
-  ];
+  const lines = [];
 
   for (const [name, expr, exposureSet] of tests) {
     if (!exposureSet.has('Worker') || !exposureSet.has('DedicatedWorker')) {
@@ -587,28 +573,15 @@ function buildIDLWorker(tests) {
     );
   }
 
-  lines.push('bcd.run("Worker");', '</script>', '</body>', '</html>');
+  lines.push('bcd.run("Worker");');
   const pathname = path.join('api', 'workerinterfaces.html');
   const filename = path.join(generatedDir, pathname);
-  writeText(filename, lines);
+  writeTestFile(filename, lines);
   return [['http', pathname], ['https', pathname]];
 }
 
 function buildIDLServiceWorker(tests) {
-  const lines = [
-    '<!DOCTYPE html>',
-    '<html>',
-    '<head>',
-    ...copyright,
-    '<meta charset="utf-8">',
-    '<script src="/resources/json3.min.js"></script>',
-    '<script src="/resources/harness.js"></script>',
-    '<script src="/resources/core.js"></script>',
-    '</head>',
-    '<body>',
-    '<p id="status">Running test...</p>',
-    '<script>'
-  ];
+  const lines = [];
 
   for (const [name, expr, exposureSet] of tests) {
     if (!exposureSet.has('ServiceWorker')) {
@@ -619,10 +592,10 @@ function buildIDLServiceWorker(tests) {
     );
   }
 
-  lines.push('bcd.run("ServiceWorker");', '</script>', '</body>', '</html>');
+  lines.push('bcd.run("ServiceWorker");');
   const pathname = path.join('api', 'serviceworkerinterfaces.html');
   const filename = path.join(generatedDir, pathname);
-  writeText(filename, lines);
+  writeTestFile(filename, lines);
   return [['https', pathname]];
 }
 

--- a/build.js
+++ b/build.js
@@ -158,7 +158,7 @@ function cssPropertyToIDLAttribute(property, lowercaseFirst) {
   return output;
 }
 
-function buildCSSPropertyTest(propertyNames, method, basename) {
+function buildCSSTests(propertyNames, method, basename) {
   const lines = [];
 
   for (const name of propertyNames) {
@@ -197,14 +197,16 @@ function buildCSS(bcd, reffy) {
   const propertyNames = Array.from(propertySet);
   propertyNames.sort();
 
-  return [
-    ['http', buildCSSPropertyTest(propertyNames,
+  const mainTests = [
+    ['http', buildCSSTests(propertyNames,
         'CSSStyleDeclaration', 'in-style.html')],
-    ['http', buildCSSPropertyTest(propertyNames,
+    ['http', buildCSSTests(propertyNames,
         'CSS.supports', 'dot-supports.html')],
-    ['http', buildCSSPropertyTest(propertyNames,
+    ['http', buildCSSTests(propertyNames,
         'custom', 'custom-support-test.html')]
   ];
+
+  return [mainTests, null];
 }
 
 /* istanbul ignore next */

--- a/build.js
+++ b/build.js
@@ -571,6 +571,7 @@ function buildIDLWindow(tests) {
 
     for (const [memberName, memberExpr] of memberTests) {
       lines.push(
+          // eslint-disable-next-line max-len
           `bcd.addTest('api.${name}.${memberName}', ${JSON.stringify(memberExpr)}, 'Window');`
       );
     }
@@ -596,6 +597,7 @@ function buildIDLWorker(tests) {
 
     for (const [memberName, memberExpr] of memberTests) {
       lines.push(
+          // eslint-disable-next-line max-len
           `bcd.addTest('api.${name}.${memberName}', ${JSON.stringify(memberExpr)}, 'Worker');`
       );
     }
@@ -621,6 +623,7 @@ function buildIDLServiceWorker(tests) {
 
     for (const [memberName, memberExpr] of memberTests) {
       lines.push(
+          // eslint-disable-next-line max-len
           `bcd.addTest('api.${name}.${memberName}', ${JSON.stringify(memberExpr)}, 'ServiceWorker');`
       );
     }
@@ -650,6 +653,7 @@ function buildIDLIndividual(tests) {
 
     for (const [memberName, memberExpr] of memberTests) {
       handledIfaces.push(`api.${name}.${memberName}`);
+      // eslint-disable-next-line max-len
       const test = `bcd.addTest('api.${name}.${memberName}', ${JSON.stringify(memberExpr)}, '${scope}');`;
       lines.push(test);
 

--- a/build.js
+++ b/build.js
@@ -735,7 +735,7 @@ function copyResources() {
 async function build(bcd, reffy) {
   const manifest = {
     items: [],
-    individualItems: []
+    individualItems: {}
   };
 
   loadCustomTests();
@@ -748,7 +748,13 @@ async function build(bcd, reffy) {
       manifest.items.push({pathname, protocol});
     }
     if (individualItems) {
-      manifest.individualItems.push(...individualItems);
+      for (let item of individualItems) {
+        let url = item.replace(/\./g, '/');
+        if (item.split('.').length == 2 && item.startsWith('api')) {
+          url += '/index';
+        }
+        manifest.individualItems[item] = url + '.html';
+      }
     }
   }
   await writeManifest(manifest);

--- a/build.js
+++ b/build.js
@@ -748,7 +748,7 @@ async function build(bcd, reffy) {
       manifest.items.push({pathname, protocol});
     }
     if (individualItems) {
-      for (let item of individualItems) {
+      for (const item of individualItems) {
         let url = item.replace(/\./g, '/');
         if (item.split('.').length == 2 && item.startsWith('api')) {
           url += '/index';

--- a/build.js
+++ b/build.js
@@ -166,15 +166,15 @@ function buildCSSTests(propertyNames, method, basename) {
     const customExpr = getCustomTestCSS(name);
 
     if (customExpr) {
-      if (method === 'custom') {
+      if (method === 'custom' || method === 'all') {
         lines.push(`bcd.addTest("${ident}", "${customExpr}", 'CSS');`);
       }
     } else {
       let expr = '';
-      if (method === 'CSSStyleDeclaration') {
+      if (method === 'CSSStyleDeclaration' || method === 'all') {
         const attrName = cssPropertyToIDLAttribute(name, name.startsWith('-'));
         expr = {property: attrName, scope: 'document.body.style'};
-      } else if (method === 'CSS.supports') {
+      } else if (method === 'CSS.supports' || method === 'all') {
         expr = {property: name, scope: 'CSS.supports'};
       }
       if (expr) {
@@ -182,7 +182,13 @@ function buildCSSTests(propertyNames, method, basename) {
       }
     }
   }
-  lines.push('bcd.run("CSS");');
+
+  lines.push(
+    method === 'all' ?
+    'bcd.run("CSS", bcd.finishIndividual);' :
+    'bcd.run("CSS");'
+  );
+  
   const pathname = path.join('css', 'properties', basename);
   const filename = path.join(generatedDir, pathname);
   writeTestFile(filename, lines);
@@ -206,7 +212,14 @@ function buildCSS(bcd, reffy) {
         'custom', 'custom-support-test.html')]
   ];
 
-  return [mainTests, null];
+  const individualItems = [];
+
+  for (const property of propertyNames) {
+    buildCSSTests([property], 'all', `${property}.html`);
+    individualItems.push(property);
+  }
+
+  return [mainTests, {css: individualItems}];
 }
 
 /* istanbul ignore next */

--- a/build.js
+++ b/build.js
@@ -664,8 +664,8 @@ function buildIDL(_, reffy) {
   ]) {
     testpaths = testpaths.concat(buildFunc(tests));
   }
-  return testpaths;
   const handledIfaces = buildIDLIndividual(tests);
+  return [testpaths, handledIfaces];
 }
 
 async function writeManifest(manifest) {
@@ -715,17 +715,20 @@ function copyResources() {
 
 async function build(bcd, reffy) {
   const manifest = {
-    items: []
+    items: [],
+    individualItems: []
   };
+
   loadCustomTests();
   for (const buildFunc of [buildCSS, buildIDL]) {
-    const items = buildFunc(bcd, reffy);
+    const [items, individualItems] = buildFunc(bcd, reffy);
     for (let [protocol, pathname] of items) {
       if (!pathname.startsWith('/')) {
         pathname = `/${pathname}`;
       }
       manifest.items.push({pathname, protocol});
     }
+    manifest.individualItems += individualItems;
   }
   await writeManifest(manifest);
   copyResources();

--- a/build.js
+++ b/build.js
@@ -748,7 +748,7 @@ async function build(bcd, reffy) {
       manifest.items.push({pathname, protocol});
     }
     if (individualItems) {
-      manifest.individualItems += individualItems;
+      manifest.individualItems.push(...individualItems);
     }
   }
   await writeManifest(manifest);

--- a/build.js
+++ b/build.js
@@ -188,7 +188,7 @@ function buildCSSTests(propertyNames, method, basename) {
     'bcd.run("CSS", bcd.finishIndividual);' :
     'bcd.run("CSS");'
   );
-  
+
   const pathname = path.join('css', 'properties', basename);
   const filename = path.join(generatedDir, pathname);
   writeTestFile(filename, lines);
@@ -216,10 +216,10 @@ function buildCSS(bcd, reffy) {
 
   for (const property of propertyNames) {
     buildCSSTests([property], 'all', `${property}.html`);
-    individualItems.push(property);
+    individualItems.push(`css.properties.${property}`);
   }
 
-  return [mainTests, {css: individualItems}];
+  return [mainTests, individualItems];
 }
 
 /* istanbul ignore next */
@@ -680,7 +680,7 @@ function buildIDL(_, reffy) {
     testpaths = testpaths.concat(buildFunc(tests));
   }
   const handledIfaces = buildIDLIndividual(tests);
-  return [testpaths, {api: handledIfaces}];
+  return [testpaths, handledIfaces];
 }
 
 async function writeManifest(manifest) {
@@ -744,10 +744,7 @@ async function build(bcd, reffy) {
       manifest.items.push({pathname, protocol});
     }
     if (individualItems) {
-      manifest.individualItems = Object.assign(
-        manifest.individualItems,
-        individualItems
-      );
+      manifest.individualItems += individualItems;
     }
   }
   await writeManifest(manifest);

--- a/build.js
+++ b/build.js
@@ -735,7 +735,7 @@ function copyResources() {
 async function build(bcd, reffy) {
   const manifest = {
     items: [],
-    individualItems: {}
+    individualItems: []
   };
 
   loadCustomTests();

--- a/package-lock.json
+++ b/package-lock.json
@@ -1,6 +1,6 @@
 {
   "name": "mdn-bcd-collector",
-  "version": "0.0.5",
+  "version": "0.0.6",
   "lockfileVersion": 1,
   "requires": true,
   "dependencies": {

--- a/package.json
+++ b/package.json
@@ -1,7 +1,7 @@
 {
   "name": "mdn-bcd-collector",
   "description": "Data collection service for mdn/browser-compat-data",
-  "version": "0.0.5",
+  "version": "0.0.6",
   "private": true,
   "license": "Apache-2.0",
   "repository": {

--- a/static/index.html
+++ b/static/index.html
@@ -15,21 +15,53 @@ Unless required by applicable law or agreed to in writing, software distributed 
 <body>
 <div>
   <button id="start" disabled>Loading tests...</button>
+  <br /><br />
+  <select id="individualTests" disabled>
+    <option value="">Loading tests...</option>
+  </select>
+  <button id="individualStart" disabled>Loading tests...</button>
 </div>
 <script>
 function getTests() {
   var button = document.getElementById('start');
+  var dropdown = document.getElementById('individualTests');
+  var buttonIndividual = document.getElementById('individualStart');
   var client = new XMLHttpRequest();
   client.open('GET', '/api/tests', true);
   client.send();
   client.onreadystatechange = function() {
     if (client.readyState == 4) {
-      var tests = JSON.parse(client.responseText);
+      var response = JSON.parse(client.responseText);
+
+      var tests = response[0];
       button.removeAttribute('disabled');
       button.textContent = 'Run ' + tests.length + ' tests';
       button.onclick = function() {
         window.location = tests[0];
       };
+
+      var individualItems = response[1];
+      buttonIndividual.removeAttribute('disabled');
+      buttonIndividual.textContent = 'Run individual test';
+      
+      dropdown.removeAttribute('disabled');
+      dropdown.remove(0);
+      var c = document.createElement("option");
+      c.text = "Select individual test:";
+      c.value = "";
+      dropdown.add(c);
+      for (var i=0; i<individualItems.length; i++) {
+        var item = individualItems[i];
+        var option = document.createElement("option");
+        option.text = item[0];
+        option.value = item[1];
+        dropdown.add(option);
+      }
+
+      buttonIndividual.onclick = function() {
+        var newUrl = dropdown.options[dropdown.selectedIndex].value;
+        if (newUrl) window.location = newUrl;
+      }
     }
   }
 }

--- a/static/resources/harness.js
+++ b/static/resources/harness.js
@@ -204,7 +204,7 @@
       result.info = Object.assign({}, result.info, data.info);
     }
 
-    result.info.code = compiledCode;
+    result.info.code = compiledCode.join(' && ');
     result.info.scope = data.scope;
 
     return result;
@@ -415,8 +415,7 @@
       var result = results[i];
       response += result.name + ': <strong>' + result.result;
       if (result.prefix) response += ' (' + result.prefix + ' prefix)';
-      response += '</strong>\n<code>' +
-          result.info.code.join(' && ') + ';</code>\n\n';
+      response += '</strong>\n<code>' + result.info.code + ';</code>\n\n';
     }
     document.getElementById('status').innerHTML =
       response.replace(/\n/g, '<br />');

--- a/static/resources/harness.js
+++ b/static/resources/harness.js
@@ -82,6 +82,7 @@
     try {
       var parentPrefix = '';
       var code = data.code;
+      var compiledCode = [];
       if (!Array.isArray(code)) {
         code = [code];
       }
@@ -90,6 +91,7 @@
         var subtest = code[i];
 
         if (typeof(subtest) === 'string') {
+          compiledCode.push(subtest);
           value = eval(subtest);
           // TODO: allow callback and promise-vending funcs
           if (typeof value === 'boolean') {
@@ -100,9 +102,9 @@
           }
         } else if (subtest.property == 'constructor') {
           var iface = parentPrefix+subtest.scope;
+          compiledCode.push('new '+iface+'()');
 
           try {
-            result.code = 'new '+iface+'()';
             eval('new '+iface+'()');
             result.result = true;
           } catch (err) {
@@ -127,6 +129,8 @@
             result.message = 'threw ' + stringify(err);
           }
         } else {
+          var thisCompiled = "";
+
           for (var j in prefixesToTest) {
             var prefix = prefixesToTest[j];
             var property = subtest.property;
@@ -142,6 +146,7 @@
                   property = prefixToAdd + property;
                 }
 
+                thisCompiled = "CSS.supports('" + property + "', 'inherit');";
                 value = CSS.supports(property, 'inherit');
               } else {
                 value = null;
@@ -155,9 +160,11 @@
               }
 
               if (stringStartsWith(property, 'Symbol.')) {
-                value = eval(property+' in '+parentPrefix+subtest.scope);
+                thisCompiled = property+' in '+parentPrefix+subtest.scope;
+                value = eval(thisCompiled);
               } else {
-                value = eval('"'+property+'" in '+parentPrefix+subtest.scope);
+                thisCompiled = '"'+property+'" in '+parentPrefix+subtest.scope;
+                value = eval(thisCompiled);
               }
             }
 
@@ -175,6 +182,8 @@
               break;
             }
           }
+
+          compiledCode.push(thisCompiled);
         }
 
         if (result.result === false) {
@@ -194,7 +203,7 @@
       result.info = Object.assign({}, result.info, data.info);
     }
 
-    result.info.code = data.code;
+    result.info.code = compiledCode;
     result.info.scope = data.scope;
 
     return result;
@@ -400,8 +409,16 @@
   }
 
   function finishIndividual(results) {
-    console.log(results);
-    alert("XXX finishIndividual not implemented! XXX");
+    var response = "";
+    for (var i=0; i<results.length; i++) {
+      var result = results[i];
+      response += result.name + ": <strong>" + result.result;
+      if (result.prefix) response += " (" + result.prefix + " prefix)";
+      response += "</strong>\n<code>" +
+          result.info.code.join(" && ") + ";</code>\n\n";
+    }
+    document.getElementById('status').innerHTML =
+      response.replace(/\n/g, '<br />');
   }
 
   // Service Worker helpers

--- a/static/resources/harness.js
+++ b/static/resources/harness.js
@@ -399,6 +399,11 @@
     };
   }
 
+  function finishIndividual(results) {
+    console.log(results);
+    alert("XXX finishIndividual not implemented! XXX");
+  }
+
   // Service Worker helpers
   if ('serviceWorker' in navigator) {
     window.__waitForSWState = function(registration, desiredState) {
@@ -458,6 +463,7 @@
   global.bcd = {
     addTest: addTest,
     test: test,
-    run: run
+    run: run,
+    finishIndividual: finishIndividual
   };
 })(this);

--- a/static/resources/harness.js
+++ b/static/resources/harness.js
@@ -129,7 +129,7 @@
             result.message = 'threw ' + stringify(err);
           }
         } else {
-          var thisCompiled = "";
+          var thisCompiled = '';
 
           for (var j in prefixesToTest) {
             var prefix = prefixesToTest[j];
@@ -146,7 +146,8 @@
                   property = prefixToAdd + property;
                 }
 
-                thisCompiled = "CSS.supports('" + property + "', 'inherit');";
+                thisCompiled = 'CSS.supports(\'' +
+                    property + '\', \'inherit\');';
                 value = CSS.supports(property, 'inherit');
               } else {
                 value = null;
@@ -409,13 +410,13 @@
   }
 
   function finishIndividual(results) {
-    var response = "";
+    var response = '';
     for (var i=0; i<results.length; i++) {
       var result = results[i];
-      response += result.name + ": <strong>" + result.result;
-      if (result.prefix) response += " (" + result.prefix + " prefix)";
-      response += "</strong>\n<code>" +
-          result.info.code.join(" && ") + ";</code>\n\n";
+      response += result.name + ': <strong>' + result.result;
+      if (result.prefix) response += ' (' + result.prefix + ' prefix)';
+      response += '</strong>\n<code>' +
+          result.info.code.join(' && ') + ';</code>\n\n';
     }
     document.getElementById('status').innerHTML =
       response.replace(/\n/g, '<br />');

--- a/test/app/tests.js
+++ b/test/app/tests.js
@@ -27,7 +27,7 @@ describe('/api/tests', () => {
     const res = await agent.get('/api/tests?limit=1');
     assert.equal(res.status, 200);
     assert.isArray(res.body);
-    assert.equal(res.body.length, 1);
+    assert.equal(res.body[0].length, 1);
   });
 });
 

--- a/test/unit/build.js
+++ b/test/unit/build.js
@@ -522,7 +522,7 @@ describe('build', () => {
             {property: 'name', scope: 'Attr.prototype'}
           ]]
         ]
-      ]]);
+        ]]);
     });
 
     it('interface with method', () => {
@@ -537,7 +537,7 @@ describe('build', () => {
             {property: 'contains', scope: 'Node.prototype'}
           ]]
         ]
-      ]]);
+        ]]);
     });
 
     it('interface with static method', () => {
@@ -547,13 +547,13 @@ describe('build', () => {
            };`);
       assert.deepEqual(buildIDLTests(ast), [
         ['MediaSource', {property: 'MediaSource', scope: 'self'},
-        new Set(['Window']), [
-          ['isTypeSupported', [
-            {property: 'MediaSource', scope: 'self'},
-            {property: 'isTypeSupported', scope: 'MediaSource'}
-          ]]
-        ]
-      ]]);
+          new Set(['Window']), [
+            ['isTypeSupported', [
+              {property: 'MediaSource', scope: 'self'},
+              {property: 'isTypeSupported', scope: 'MediaSource'}
+            ]]
+          ]
+        ]]);
     });
 
     it('interface with const', () => {
@@ -568,7 +568,7 @@ describe('build', () => {
             {property: 'isWindow', scope: 'Window'}
           ]]
         ]
-      ]]);
+        ]]);
     });
 
     it('interface with custom test', () => {
@@ -607,8 +607,8 @@ describe('build', () => {
           ['drawArraysInstancedANGLE', '(function() {var canvas = document.createElement(\'canvas\'); var gl = canvas.getContext(\'webgl\'); var instance = gl.getExtension(\'ANGLE_instanced_arrays\');return instance && \'drawArraysInstancedANGLE\' in instance;})()'],
           // eslint-disable-next-line max-len
           ['drawElementsInstancedANGLE', '(function() {var canvas = document.createElement(\'canvas\'); var gl = canvas.getContext(\'webgl\'); var instance = gl.getExtension(\'ANGLE_instanced_arrays\');return instance && \'drawElementsInstancedANGLE\' in instance;})()']
-          ]
-      ]]);
+        ]
+        ]]);
     });
 
     it('interface with legacy namespace', () => {
@@ -1105,7 +1105,12 @@ describe('build', () => {
           new Set(['Window', 'Worker']),
           []
         ],
-        ['Worker', {property: 'Worker', scope: 'self'}, new Set(['Window']), []],
+        [
+          'Worker',
+          {property: 'Worker', scope: 'self'},
+          new Set(['Window']),
+          []
+        ],
         [
           'WorkerSync',
           {property: 'WorkerSync', scope: 'self'},
@@ -1124,13 +1129,18 @@ describe('build', () => {
         };
       `);
       assert.deepEqual(buildIDLTests(ast), [
-        ['AudioNode', {property: 'AudioNode', scope: 'self'}, new Set(['Window']), [
-        ['disconnect', [
+        [
+          'AudioNode',
           {property: 'AudioNode', scope: 'self'},
-          {property: 'disconnect', scope: 'AudioNode.prototype'}
-        ]]
+          new Set(['Window']),
+          [
+            ['disconnect', [
+              {property: 'AudioNode', scope: 'self'},
+              {property: 'disconnect', scope: 'AudioNode.prototype'}
+            ]]
+          ]
         ]
-      ]]);
+      ]);
     });
 
     it('namespace with attribute', () => {
@@ -1145,7 +1155,7 @@ describe('build', () => {
             {property: 'paintWorklet', scope: 'CSS'}
           ]]
         ]
-      ]]);
+        ]]);
     });
 
     it('namespace with method', () => {
@@ -1160,7 +1170,7 @@ describe('build', () => {
             {property: 'supports', scope: 'CSS'}
           ]]
         ]
-      ]]);
+        ]]);
     });
 
     it('namespace with custom test', () => {
@@ -1242,7 +1252,7 @@ describe('build', () => {
           // eslint-disable-next-line max-len
           ['prototype', '(function() {var ers = ElementRegistrationOptions;return ers && \'prototype\' in ers;})()']
         ]
-      ]]);
+        ]]);
     });
   });
 

--- a/test/unit/build.js
+++ b/test/unit/build.js
@@ -516,12 +516,13 @@ describe('build', () => {
     it('interface with attribute', () => {
       const ast = WebIDL2.parse(`interface Attr { attribute any name; };`);
       assert.deepEqual(buildIDLTests(ast), [
-        ['Attr', {property: 'Attr', scope: 'self'}],
-        ['Attr.name', [
-          {property: 'Attr', scope: 'self'},
-          {property: 'name', scope: 'Attr.prototype'}
-        ]]
-      ]);
+        ['Attr', {property: 'Attr', scope: 'self'}, new Set(['Window']), [
+          ['name', [
+            {property: 'Attr', scope: 'self'},
+            {property: 'name', scope: 'Attr.prototype'}
+          ]]
+        ]
+      ]]);
     });
 
     it('interface with method', () => {
@@ -530,12 +531,13 @@ describe('build', () => {
              boolean contains(Node? other);
            };`);
       assert.deepEqual(buildIDLTests(ast), [
-        ['Node', {property: 'Node', scope: 'self'}],
-        ['Node.contains', [
-          {property: 'Node', scope: 'self'},
-          {property: 'contains', scope: 'Node.prototype'}
-        ]]
-      ]);
+        ['Node', {property: 'Node', scope: 'self'}, new Set(['Window']), [
+          ['contains', [
+            {property: 'Node', scope: 'self'},
+            {property: 'contains', scope: 'Node.prototype'}
+          ]]
+        ]
+      ]]);
     });
 
     it('interface with static method', () => {
@@ -544,12 +546,14 @@ describe('build', () => {
              static boolean isTypeSupported(DOMString type);
            };`);
       assert.deepEqual(buildIDLTests(ast), [
-        ['MediaSource', {property: 'MediaSource', scope: 'self'}],
-        ['MediaSource.isTypeSupported', [
-          {property: 'MediaSource', scope: 'self'},
-          {property: 'isTypeSupported', scope: 'MediaSource'}
-        ]]
-      ]);
+        ['MediaSource', {property: 'MediaSource', scope: 'self'},
+        new Set(['Window']), [
+          ['isTypeSupported', [
+            {property: 'MediaSource', scope: 'self'},
+            {property: 'isTypeSupported', scope: 'MediaSource'}
+          ]]
+        ]
+      ]]);
     });
 
     it('interface with const', () => {
@@ -558,12 +562,13 @@ describe('build', () => {
              const boolean isWindow = true;
            };`);
       assert.deepEqual(buildIDLTests(ast), [
-        ['Window', {property: 'Window', scope: 'self'}],
-        ['Window.isWindow', [
-          {property: 'Window', scope: 'self'},
-          {property: 'isWindow', scope: 'Window'}
-        ]]
-      ]);
+        ['Window', {property: 'Window', scope: 'self'}, new Set(['Window']), [
+          ['isWindow', [
+            {property: 'Window', scope: 'self'},
+            {property: 'isWindow', scope: 'Window'}
+          ]]
+        ]
+      ]]);
     });
 
     it('interface with custom test', () => {
@@ -575,25 +580,35 @@ describe('build', () => {
               GLsizei count,
               GLsizei primcount
             );
+            void drawElementsInstancedANGLE(
+              GLenum mode,
+              GLsizei count,
+              GLenum type,
+              GLintptr offset,
+              GLsizei primcoun
+            );
           };`);
       loadCustomTests({
         'api': {
           'ANGLE_instanced_arrays': {
             // eslint-disable-next-line max-len
-            '__base': 'var canvas = document.createElement(\'canvas\'); var gl = canvas.getContext(\'webgl\'); var a = gl.getExtension(\'ANGLE_instanced_arrays\');',
-            '__test': 'return !!a;',
+            '__base': 'var canvas = document.createElement(\'canvas\'); var gl = canvas.getContext(\'webgl\'); var instance = gl.getExtension(\'ANGLE_instanced_arrays\');',
+            '__test': 'return !!instance;',
             // eslint-disable-next-line max-len
-            'drawArraysInstancedANGLE': 'return a && \'drawArraysInstancedANGLE\' in a;'
+            'drawArraysInstancedANGLE': 'return instance && \'drawArraysInstancedANGLE\' in instance;'
           }
         },
         'css': {}
       });
       assert.deepEqual(buildIDLTests(ast), [
         // eslint-disable-next-line max-len
-        ['ANGLE_instanced_arrays', '(function() {var canvas = document.createElement(\'canvas\'); var gl = canvas.getContext(\'webgl\'); var a = gl.getExtension(\'ANGLE_instanced_arrays\');return !!a;})()'],
-        // eslint-disable-next-line max-len
-        ['ANGLE_instanced_arrays.drawArraysInstancedANGLE', '(function() {var canvas = document.createElement(\'canvas\'); var gl = canvas.getContext(\'webgl\'); var a = gl.getExtension(\'ANGLE_instanced_arrays\');return a && \'drawArraysInstancedANGLE\' in a;})()']
-      ]);
+        ['ANGLE_instanced_arrays', '(function() {var canvas = document.createElement(\'canvas\'); var gl = canvas.getContext(\'webgl\'); var instance = gl.getExtension(\'ANGLE_instanced_arrays\');return !!instance;})()', new Set(['Window']), [
+          // eslint-disable-next-line max-len
+          ['drawArraysInstancedANGLE', '(function() {var canvas = document.createElement(\'canvas\'); var gl = canvas.getContext(\'webgl\'); var instance = gl.getExtension(\'ANGLE_instanced_arrays\');return instance && \'drawArraysInstancedANGLE\' in instance;})()'],
+          // eslint-disable-next-line max-len
+          ['drawElementsInstancedANGLE', '(function() {var canvas = document.createElement(\'canvas\'); var gl = canvas.getContext(\'webgl\'); var instance = gl.getExtension(\'ANGLE_instanced_arrays\');return instance && \'drawElementsInstancedANGLE\' in instance;})()']
+          ]
+      ]]);
     });
 
     it('interface with legacy namespace', () => {
@@ -613,21 +628,24 @@ describe('build', () => {
           {
             'property': 'WindowOrWorkerGlobalScope',
             'scope': 'self'
-          }
-        ],
-        [
-          'WindowOrWorkerGlobalScope.active',
-          {
-            'property': 'active',
-            'scope': 'self'
-          }
-        ],
-        [
-          'WindowOrWorkerGlobalScope.isLoaded',
-          {
-            'property': 'isLoaded',
-            'scope': 'self'
-          }
+          },
+          new Set(['Window']),
+          [
+            [
+              'active',
+              {
+                'property': 'active',
+                'scope': 'self'
+              }
+            ],
+            [
+              'isLoaded',
+              {
+                'property': 'isLoaded',
+                'scope': 'self'
+              }
+            ]
+          ]
         ]
       ]);
     });
@@ -642,19 +660,22 @@ describe('build', () => {
           {
             'property': 'Number',
             'scope': 'self'
-          }
-        ],
-        [
-          'Number.Number',
+          },
+          new Set(['Window']),
           [
-            {
-              'property': 'Number',
-              'scope': 'self'
-            },
-            {
-              'property': 'constructor',
-              'scope': 'Number'
-            }
+            [
+              'Number',
+              [
+                {
+                  'property': 'Number',
+                  'scope': 'self'
+                },
+                {
+                  'property': 'constructor',
+                  'scope': 'Number'
+                }
+              ]
+            ]
           ]
         ]
       ]);
@@ -669,19 +690,22 @@ describe('build', () => {
           {
             'property': 'Number',
             'scope': 'self'
-          }
-        ],
-        [
-          'Number.Number',
+          },
+          new Set(['Window']),
           [
-            {
-              'property': 'Number',
-              'scope': 'self'
-            },
-            {
-              'property': 'constructor',
-              'scope': 'Number'
-            }
+            [
+              'Number',
+              [
+                {
+                  'property': 'Number',
+                  'scope': 'self'
+                },
+                {
+                  'property': 'constructor',
+                  'scope': 'Number'
+                }
+              ]
+            ]
           ]
         ]
       ]);
@@ -697,79 +721,82 @@ describe('build', () => {
           {
             'property': 'DoubleList',
             'scope': 'self'
-          }
-        ],
-        [
-          'DoubleList.@@iterator',
+          },
+          new Set(['Window']),
           [
-            {
-              'property': 'DoubleList',
-              'scope': 'self'
-            },
-            {
-              'property': 'Symbol',
-              'scope': 'self'
-            },
-            {
-              'property': 'iterator',
-              'scope': 'Symbol'
-            },
-            {
-              'property': 'Symbol.iterator',
-              'scope': 'DoubleList.prototype'
-            }
-          ]
-        ],
-        [
-          'DoubleList.entries',
-          [
-            {
-              'property': 'DoubleList',
-              'scope': 'self'
-            },
-            {
-              'property': 'entries',
-              'scope': 'DoubleList.prototype'
-            }
-          ]
-        ],
-        [
-          'DoubleList.forEach',
-          [
-            {
-              'property': 'DoubleList',
-              'scope': 'self'
-            },
-            {
-              'property': 'forEach',
-              'scope': 'DoubleList.prototype'
-            }
-          ]
-        ],
-        [
-          'DoubleList.keys',
-          [
-            {
-              'property': 'DoubleList',
-              'scope': 'self'
-            },
-            {
-              'property': 'keys',
-              'scope': 'DoubleList.prototype'
-            }
-          ]
-        ],
-        [
-          'DoubleList.values',
-          [
-            {
-              'property': 'DoubleList',
-              'scope': 'self'
-            },
-            {
-              'property': 'values',
-              'scope': 'DoubleList.prototype'
-            }
+            [
+              '@@iterator',
+              [
+                {
+                  'property': 'DoubleList',
+                  'scope': 'self'
+                },
+                {
+                  'property': 'Symbol',
+                  'scope': 'self'
+                },
+                {
+                  'property': 'iterator',
+                  'scope': 'Symbol'
+                },
+                {
+                  'property': 'Symbol.iterator',
+                  'scope': 'DoubleList.prototype'
+                }
+              ]
+            ],
+            [
+              'entries',
+              [
+                {
+                  'property': 'DoubleList',
+                  'scope': 'self'
+                },
+                {
+                  'property': 'entries',
+                  'scope': 'DoubleList.prototype'
+                }
+              ]
+            ],
+            [
+              'forEach',
+              [
+                {
+                  'property': 'DoubleList',
+                  'scope': 'self'
+                },
+                {
+                  'property': 'forEach',
+                  'scope': 'DoubleList.prototype'
+                }
+              ]
+            ],
+            [
+              'keys',
+              [
+                {
+                  'property': 'DoubleList',
+                  'scope': 'self'
+                },
+                {
+                  'property': 'keys',
+                  'scope': 'DoubleList.prototype'
+                }
+              ]
+            ],
+            [
+              'values',
+              [
+                {
+                  'property': 'DoubleList',
+                  'scope': 'self'
+                },
+                {
+                  'property': 'values',
+                  'scope': 'DoubleList.prototype'
+                }
+              ]
+            ]
           ]
         ]
       ]);
@@ -785,136 +812,139 @@ describe('build', () => {
           {
             'property': 'DoubleMap',
             'scope': 'self'
-          }
-        ],
-        [
-          'DoubleMap.clear',
+          },
+          new Set(['Window']),
           [
-            {
-              'property': 'DoubleMap',
-              'scope': 'self'
-            },
-            {
-              'property': 'clear',
-              'scope': 'DoubleMap.prototype'
-            }
-          ]
-        ],
-        [
-          'DoubleMap.delete',
-          [
-            {
-              'property': 'DoubleMap',
-              'scope': 'self'
-            },
-            {
-              'property': 'delete',
-              'scope': 'DoubleMap.prototype'
-            }
-          ]
-        ],
-        [
-          'DoubleMap.entries',
-          [
-            {
-              'property': 'DoubleMap',
-              'scope': 'self'
-            },
-            {
-              'property': 'entries',
-              'scope': 'DoubleMap.prototype'
-            }
-          ]
-        ],
-        [
-          'DoubleMap.forEach',
-          [
-            {
-              'property': 'DoubleMap',
-              'scope': 'self'
-            },
-            {
-              'property': 'forEach',
-              'scope': 'DoubleMap.prototype'
-            }
-          ]
-        ],
-        [
-          'DoubleMap.get',
-          [
-            {
-              'property': 'DoubleMap',
-              'scope': 'self'
-            },
-            {
-              'property': 'get',
-              'scope': 'DoubleMap.prototype'
-            }
-          ]
-        ],
-        [
-          'DoubleMap.has',
-          [
-            {
-              'property': 'DoubleMap',
-              'scope': 'self'
-            },
-            {
-              'property': 'has',
-              'scope': 'DoubleMap.prototype'
-            }
-          ]
-        ],
-        [
-          'DoubleMap.keys',
-          [
-            {
-              'property': 'DoubleMap',
-              'scope': 'self'
-            },
-            {
-              'property': 'keys',
-              'scope': 'DoubleMap.prototype'
-            }
-          ]
-        ],
-        [
-          'DoubleMap.set',
-          [
-            {
-              'property': 'DoubleMap',
-              'scope': 'self'
-            },
-            {
-              'property': 'set',
-              'scope': 'DoubleMap.prototype'
-            }
-          ]
-        ],
-        [
-          'DoubleMap.size',
-          [
-            {
-              'property': 'DoubleMap',
-              'scope': 'self'
-            },
-            {
-              'property': 'size',
-              'scope': 'DoubleMap.prototype'
-            }
-          ]
-        ],
-        [
-          'DoubleMap.values',
-          [
-            {
-              'property': 'DoubleMap',
-              'scope': 'self'
-            },
-            {
-              'property': 'values',
-              'scope': 'DoubleMap.prototype'
-            }
+            [
+              'clear',
+              [
+                {
+                  'property': 'DoubleMap',
+                  'scope': 'self'
+                },
+                {
+                  'property': 'clear',
+                  'scope': 'DoubleMap.prototype'
+                }
+              ]
+            ],
+            [
+              'delete',
+              [
+                {
+                  'property': 'DoubleMap',
+                  'scope': 'self'
+                },
+                {
+                  'property': 'delete',
+                  'scope': 'DoubleMap.prototype'
+                }
+              ]
+            ],
+            [
+              'entries',
+              [
+                {
+                  'property': 'DoubleMap',
+                  'scope': 'self'
+                },
+                {
+                  'property': 'entries',
+                  'scope': 'DoubleMap.prototype'
+                }
+              ]
+            ],
+            [
+              'forEach',
+              [
+                {
+                  'property': 'DoubleMap',
+                  'scope': 'self'
+                },
+                {
+                  'property': 'forEach',
+                  'scope': 'DoubleMap.prototype'
+                }
+              ]
+            ],
+            [
+              'get',
+              [
+                {
+                  'property': 'DoubleMap',
+                  'scope': 'self'
+                },
+                {
+                  'property': 'get',
+                  'scope': 'DoubleMap.prototype'
+                }
+              ]
+            ],
+            [
+              'has',
+              [
+                {
+                  'property': 'DoubleMap',
+                  'scope': 'self'
+                },
+                {
+                  'property': 'has',
+                  'scope': 'DoubleMap.prototype'
+                }
+              ]
+            ],
+            [
+              'keys',
+              [
+                {
+                  'property': 'DoubleMap',
+                  'scope': 'self'
+                },
+                {
+                  'property': 'keys',
+                  'scope': 'DoubleMap.prototype'
+                }
+              ]
+            ],
+            [
+              'set',
+              [
+                {
+                  'property': 'DoubleMap',
+                  'scope': 'self'
+                },
+                {
+                  'property': 'set',
+                  'scope': 'DoubleMap.prototype'
+                }
+              ]
+            ],
+            [
+              'size',
+              [
+                {
+                  'property': 'DoubleMap',
+                  'scope': 'self'
+                },
+                {
+                  'property': 'size',
+                  'scope': 'DoubleMap.prototype'
+                }
+              ]
+            ],
+            [
+              'values',
+              [
+                {
+                  'property': 'DoubleMap',
+                  'scope': 'self'
+                },
+                {
+                  'property': 'values',
+                  'scope': 'DoubleMap.prototype'
+                }
+              ]
+            ]
           ]
         ]
       ]);
@@ -930,110 +960,113 @@ describe('build', () => {
           {
             'property': 'DoubleSet',
             'scope': 'self'
-          }
-        ],
-        [
-          'DoubleSet.add',
+          },
+          new Set(['Window']),
           [
-            {
-              'property': 'DoubleSet',
-              'scope': 'self'
-            },
-            {
-              'property': 'add',
-              'scope': 'DoubleSet.prototype'
-            }
-          ]
-        ],
-        [
-          'DoubleSet.clear',
-          [
-            {
-              'property': 'DoubleSet',
-              'scope': 'self'
-            },
-            {
-              'property': 'clear',
-              'scope': 'DoubleSet.prototype'
-            }
-          ]
-        ],
-        [
-          'DoubleSet.delete',
-          [
-            {
-              'property': 'DoubleSet',
-              'scope': 'self'
-            },
-            {
-              'property': 'delete',
-              'scope': 'DoubleSet.prototype'
-            }
-          ]
-        ],
-        [
-          'DoubleSet.entries',
-          [
-            {
-              'property': 'DoubleSet',
-              'scope': 'self'
-            },
-            {
-              'property': 'entries',
-              'scope': 'DoubleSet.prototype'
-            }
-          ]
-        ],
-        [
-          'DoubleSet.has',
-          [
-            {
-              'property': 'DoubleSet',
-              'scope': 'self'
-            },
-            {
-              'property': 'has',
-              'scope': 'DoubleSet.prototype'
-            }
-          ]
-        ],
-        [
-          'DoubleSet.keys',
-          [
-            {
-              'property': 'DoubleSet',
-              'scope': 'self'
-            },
-            {
-              'property': 'keys',
-              'scope': 'DoubleSet.prototype'
-            }
-          ]
-        ],
-        [
-          'DoubleSet.size',
-          [
-            {
-              'property': 'DoubleSet',
-              'scope': 'self'
-            },
-            {
-              'property': 'size',
-              'scope': 'DoubleSet.prototype'
-            }
-          ]
-        ],
-        [
-          'DoubleSet.values',
-          [
-            {
-              'property': 'DoubleSet',
-              'scope': 'self'
-            },
-            {
-              'property': 'values',
-              'scope': 'DoubleSet.prototype'
-            }
+            [
+              'add',
+              [
+                {
+                  'property': 'DoubleSet',
+                  'scope': 'self'
+                },
+                {
+                  'property': 'add',
+                  'scope': 'DoubleSet.prototype'
+                }
+              ]
+            ],
+            [
+              'clear',
+              [
+                {
+                  'property': 'DoubleSet',
+                  'scope': 'self'
+                },
+                {
+                  'property': 'clear',
+                  'scope': 'DoubleSet.prototype'
+                }
+              ]
+            ],
+            [
+              'delete',
+              [
+                {
+                  'property': 'DoubleSet',
+                  'scope': 'self'
+                },
+                {
+                  'property': 'delete',
+                  'scope': 'DoubleSet.prototype'
+                }
+              ]
+            ],
+            [
+              'entries',
+              [
+                {
+                  'property': 'DoubleSet',
+                  'scope': 'self'
+                },
+                {
+                  'property': 'entries',
+                  'scope': 'DoubleSet.prototype'
+                }
+              ]
+            ],
+            [
+              'has',
+              [
+                {
+                  'property': 'DoubleSet',
+                  'scope': 'self'
+                },
+                {
+                  'property': 'has',
+                  'scope': 'DoubleSet.prototype'
+                }
+              ]
+            ],
+            [
+              'keys',
+              [
+                {
+                  'property': 'DoubleSet',
+                  'scope': 'self'
+                },
+                {
+                  'property': 'keys',
+                  'scope': 'DoubleSet.prototype'
+                }
+              ]
+            ],
+            [
+              'size',
+              [
+                {
+                  'property': 'DoubleSet',
+                  'scope': 'self'
+                },
+                {
+                  'property': 'size',
+                  'scope': 'DoubleSet.prototype'
+                }
+              ]
+            ],
+            [
+              'values',
+              [
+                {
+                  'property': 'DoubleSet',
+                  'scope': 'self'
+                },
+                {
+                  'property': 'values',
+                  'scope': 'DoubleSet.prototype'
+                }
+              ]
+            ]
           ]
         ]
       ]);
@@ -1050,12 +1083,14 @@ describe('build', () => {
           {
             'property': 'GetMe',
             'scope': 'self'
-          }
+          },
+          new Set(['Window']),
+          []
         ]
       ]);
     });
 
-    it('limit scopes', () => {
+    it('varied scopes', () => {
       const ast = WebIDL2.parse(`
         [Exposed=Window] interface Worker {};
         [Exposed=Worker] interface WorkerSync {};
@@ -1063,15 +1098,21 @@ describe('build', () => {
         namespace CSS {};
       `);
       assert.deepEqual(buildIDLTests(ast), [
-        ['CSS', {property: 'CSS', scope: 'self'}],
-        ['MessageChannel', {property: 'MessageChannel', scope: 'self'}],
-        ['Worker', {property: 'Worker', scope: 'self'}]
+        ['CSS', {property: 'CSS', scope: 'self'}, new Set(['Window']), []],
+        [
+          'MessageChannel',
+          {property: 'MessageChannel', scope: 'self'},
+          new Set(['Window', 'Worker']),
+          []
+        ],
+        ['Worker', {property: 'Worker', scope: 'self'}, new Set(['Window']), []],
+        [
+          'WorkerSync',
+          {property: 'WorkerSync', scope: 'self'},
+          new Set(['Worker']),
+          []
+        ]
       ]);
-      assert.deepEqual(buildIDLTests(ast, 'Worker'), [
-        ['MessageChannel', {property: 'MessageChannel', scope: 'self'}],
-        ['WorkerSync', {property: 'WorkerSync', scope: 'self'}]
-      ]);
-      assert.deepEqual(buildIDLTests(ast, 'ServiceWorker'), []);
     });
 
     it('operator variations', () => {
@@ -1083,12 +1124,13 @@ describe('build', () => {
         };
       `);
       assert.deepEqual(buildIDLTests(ast), [
-        ['AudioNode', {property: 'AudioNode', scope: 'self'}],
-        ['AudioNode.disconnect', [
+        ['AudioNode', {property: 'AudioNode', scope: 'self'}, new Set(['Window']), [
+        ['disconnect', [
           {property: 'AudioNode', scope: 'self'},
           {property: 'disconnect', scope: 'AudioNode.prototype'}
         ]]
-      ]);
+        ]
+      ]]);
     });
 
     it('namespace with attribute', () => {
@@ -1097,12 +1139,13 @@ describe('build', () => {
              readonly attribute any paintWorklet;
            };`);
       assert.deepEqual(buildIDLTests(ast), [
-        ['CSS', {property: 'CSS', scope: 'self'}],
-        ['CSS.paintWorklet', [
-          {property: 'CSS', scope: 'self'},
-          {property: 'paintWorklet', scope: 'CSS'}
-        ]]
-      ]);
+        ['CSS', {property: 'CSS', scope: 'self'}, new Set(['Window']), [
+          ['paintWorklet', [
+            {property: 'CSS', scope: 'self'},
+            {property: 'paintWorklet', scope: 'CSS'}
+          ]]
+        ]
+      ]]);
     });
 
     it('namespace with method', () => {
@@ -1111,12 +1154,13 @@ describe('build', () => {
              boolean supports(CSSOMString property, CSSOMString value);
            };`);
       assert.deepEqual(buildIDLTests(ast), [
-        ['CSS', {property: 'CSS', scope: 'self'}],
-        ['CSS.supports', [
-          {property: 'CSS', scope: 'self'},
-          {property: 'supports', scope: 'CSS'}
-        ]]
-      ]);
+        ['CSS', {property: 'CSS', scope: 'self'}, new Set(['Window']), [
+          ['supports', [
+            {property: 'CSS', scope: 'self'},
+            {property: 'supports', scope: 'CSS'}
+          ]]
+        ]
+      ]]);
     });
 
     it('namespace with custom test', () => {
@@ -1136,9 +1180,15 @@ describe('build', () => {
       });
       assert.deepEqual(buildIDLTests(ast), [
         // eslint-disable-next-line max-len
-        ['CSS', '(function() {var css = CSS;return !!css;})()'],
-        // eslint-disable-next-line max-len
-        ['CSS.paintWorklet', '(function() {var css = CSS;return css && \'paintWorklet\' in css;})()']
+        [
+          'CSS',
+          '(function() {var css = CSS;return !!css;})()',
+          new Set(['Window']),
+          [
+            // eslint-disable-next-line max-len
+            ['paintWorklet', '(function() {var css = CSS;return css && \'paintWorklet\' in css;})()']
+          ]
+        ]
       ]);
     });
 
@@ -1149,17 +1199,21 @@ describe('build', () => {
               DOMString? extends = null;
            };`);
       assert.deepEqual(buildIDLTests(ast), [
-        ['ElementRegistrationOptions',
-          {property: 'ElementRegistrationOptions', scope: 'self'}
-        ],
-        ['ElementRegistrationOptions.extends', [
+        [
+          'ElementRegistrationOptions',
           {property: 'ElementRegistrationOptions', scope: 'self'},
-          {property: 'extends', scope: 'ElementRegistrationOptions'}
-        ]],
-        ['ElementRegistrationOptions.prototype', [
-          {property: 'ElementRegistrationOptions', scope: 'self'},
-          {property: 'prototype', scope: 'ElementRegistrationOptions'}
-        ]]
+          new Set(['Window']),
+          [
+            ['extends', [
+              {property: 'ElementRegistrationOptions', scope: 'self'},
+              {property: 'extends', scope: 'ElementRegistrationOptions'}
+            ]],
+            ['prototype', [
+              {property: 'ElementRegistrationOptions', scope: 'self'},
+              {property: 'prototype', scope: 'ElementRegistrationOptions'}
+            ]]
+          ]
+        ]
       ]);
     });
 
@@ -1182,12 +1236,13 @@ describe('build', () => {
       });
       assert.deepEqual(buildIDLTests(ast), [
         // eslint-disable-next-line max-len
-        ['ElementRegistrationOptions', '(function() {var ers = ElementRegistrationOptions;return !!ers;})()'],
-        // eslint-disable-next-line max-len
-        ['ElementRegistrationOptions.extends', '(function() {var ers = ElementRegistrationOptions;return ers && \'extends\' in ers;})()'],
-        // eslint-disable-next-line max-len
-        ['ElementRegistrationOptions.prototype', '(function() {var ers = ElementRegistrationOptions;return ers && \'prototype\' in ers;})()']
-      ]);
+        ['ElementRegistrationOptions', '(function() {var ers = ElementRegistrationOptions;return !!ers;})()', new Set(['Window']), [
+          // eslint-disable-next-line max-len
+          ['extends', '(function() {var ers = ElementRegistrationOptions;return ers && \'extends\' in ers;})()'],
+          // eslint-disable-next-line max-len
+          ['prototype', '(function() {var ers = ElementRegistrationOptions;return ers && \'prototype\' in ers;})()']
+        ]
+      ]]);
     });
   });
 

--- a/tests.js
+++ b/tests.js
@@ -18,6 +18,7 @@ class Tests {
   constructor(options) {
     this.items = options.manifest.items
         .filter((item) => !options.httpOnly || item.protocol === 'http');
+    this.individualItems = options.manifest.individualItems;
     this.host = options.host;
   }
 

--- a/tests.js
+++ b/tests.js
@@ -53,7 +53,8 @@ class Tests {
   }
 
   listIndividual() {
-    return Object.entries(this.individualItems).sort((a, b) => (a[0].localeCompare(b[0])));
+    return Object.entries(this.individualItems)
+        .sort((a, b) => (a[0].localeCompare(b[0])));
   }
 }
 

--- a/tests.js
+++ b/tests.js
@@ -51,6 +51,10 @@ class Tests {
       return `${item.protocol}://${this.host}${item.pathname}`;
     });
   }
+
+  listIndividual() {
+    return Object.entries(this.individualItems).sort((a, b) => (a[0].localeCompare(b[0])));
+  }
 }
 
 module.exports = Tests;


### PR DESCRIPTION
This PR updates the scripts to allow for individual tests (fixes #376).  The build script generates individual test files for each interface and CSS property that can be accessed for manual testing.  A dropdown is added to the homepage to allow for quickly getting to a specific test.