### PR TITLE
Fix individual test generation

### DIFF
--- a/build.js
+++ b/build.js
@@ -215,7 +215,7 @@ function buildCSS(bcd, reffy) {
   const individualItems = [];
 
   for (const property of propertyNames) {
-    buildCSSTests([property], 'all', `${property}.html`);
+    buildCSSTests([property], 'all', `${property}/index.html`);
     individualItems.push(`css.properties.${property}`);
   }
 
@@ -658,7 +658,7 @@ function buildIDLIndividual(tests) {
       const test = `bcd.addTest('api.${name}.${memberName}', ${JSON.stringify(memberExpr)}, '${scope}');`;
       lines.push(test);
 
-      const pathname = path.join('api', `${name}/${memberName}.html`);
+      const pathname = path.join('api', `${name}/${memberName}/index.html`);
       const filename = path.join(generatedDir, pathname);
       writeTestFile(filename, [
         test, `bcd.run("${scope}", bcd.finishIndividual);`
@@ -751,10 +751,7 @@ async function build(bcd, reffy) {
     if (individualItems) {
       for (const item of individualItems) {
         let url = item.replace(/\./g, '/');
-        if (item.split('.').length == 2 && item.startsWith('api')) {
-          url += '/index';
-        }
-        manifest.individualItems[item] = url + '.html';
+        manifest.individualItems[item] = url;
       }
     }
   }

--- a/build.js
+++ b/build.js
@@ -173,12 +173,12 @@ function buildCSSTests(propertyNames, method, basename) {
       if (method === 'CSSStyleDeclaration' || method === 'all') {
         const attrName = cssPropertyToIDLAttribute(name, name.startsWith('-'));
         lines.push(`bcd.addTest("${ident}", ${JSON.stringify(
-          {property: attrName, scope: 'document.body.style'}
+            {property: attrName, scope: 'document.body.style'}
         )}, 'CSS');`);
       }
       if (method === 'CSS.supports' || method === 'all') {
         lines.push(`bcd.addTest("${ident}", ${JSON.stringify(
-          {property: name, scope: 'CSS.supports'}
+            {property: name, scope: 'CSS.supports'}
         )}, 'CSS');`);
       }
     }
@@ -751,8 +751,7 @@ async function build(bcd, reffy) {
     }
     if (individualItems) {
       for (const item of individualItems) {
-        let url = item.replace(/\./g, '/');
-        manifest.individualItems[item] = url;
+        manifest.individualItems[item] = item.replace(/\./g, '/');
       }
     }
   }

--- a/build.js
+++ b/build.js
@@ -165,19 +165,22 @@ function buildCSSTests(propertyNames, method, basename) {
     const ident = `css.properties.${name}`;
     const customExpr = getCustomTestCSS(name);
 
-    if (method === 'custom' || method === 'all') {
-      lines.push(`bcd.addTest("${ident}", "${customExpr}", 'CSS');`);
-    }
-    if (method === 'CSSStyleDeclaration' || method === 'all') {
-      const attrName = cssPropertyToIDLAttribute(name, name.startsWith('-'));
-      lines.push(`bcd.addTest("${ident}", ${JSON.stringify(
-        {property: attrName, scope: 'document.body.style'}
-      )}, 'CSS');`);
-    }
-    if (method === 'CSS.supports' || method === 'all') {
-      lines.push(`bcd.addTest("${ident}", ${JSON.stringify(
-        {property: name, scope: 'CSS.supports'}
-      )}, 'CSS');`);
+    if (customExpr) {
+      if (method === 'custom' || method === 'all') {
+        lines.push(`bcd.addTest("${ident}", "${customExpr}", 'CSS');`);
+      }
+    } else {
+      if (method === 'CSSStyleDeclaration' || method === 'all') {
+        const attrName = cssPropertyToIDLAttribute(name, name.startsWith('-'));
+        lines.push(`bcd.addTest("${ident}", ${JSON.stringify(
+          {property: attrName, scope: 'document.body.style'}
+        )}, 'CSS');`);
+      }
+      if (method === 'CSS.supports' || method === 'all') {
+        lines.push(`bcd.addTest("${ident}", ${JSON.stringify(
+          {property: name, scope: 'CSS.supports'}
+        )}, 'CSS');`);
+      }
     }
   }
 

--- a/build.js
+++ b/build.js
@@ -165,21 +165,19 @@ function buildCSSTests(propertyNames, method, basename) {
     const ident = `css.properties.${name}`;
     const customExpr = getCustomTestCSS(name);
 
-    if (customExpr) {
-      if (method === 'custom' || method === 'all') {
-        lines.push(`bcd.addTest("${ident}", "${customExpr}", 'CSS');`);
-      }
-    } else {
-      let expr = '';
-      if (method === 'CSSStyleDeclaration' || method === 'all') {
-        const attrName = cssPropertyToIDLAttribute(name, name.startsWith('-'));
-        expr = {property: attrName, scope: 'document.body.style'};
-      } else if (method === 'CSS.supports' || method === 'all') {
-        expr = {property: name, scope: 'CSS.supports'};
-      }
-      if (expr) {
-        lines.push(`bcd.addTest("${ident}", ${JSON.stringify(expr)}, 'CSS');`);
-      }
+    if (method === 'custom' || method === 'all') {
+      lines.push(`bcd.addTest("${ident}", "${customExpr}", 'CSS');`);
+    }
+    if (method === 'CSSStyleDeclaration' || method === 'all') {
+      const attrName = cssPropertyToIDLAttribute(name, name.startsWith('-'));
+      lines.push(`bcd.addTest("${ident}", ${JSON.stringify(
+        {property: attrName, scope: 'document.body.style'}
+      )}, 'CSS');`);
+    }
+    if (method === 'CSS.supports' || method === 'all') {
+      lines.push(`bcd.addTest("${ident}", ${JSON.stringify(
+        {property: name, scope: 'CSS.supports'}
+      )}, 'CSS');`);
     }
   }
 


### PR DESCRIPTION
This provides a few hotfixes to the most recent 0.0.6 upgrade that resolves some test generation.  Namely, the following:

- All individual tests are generated in folders to allow for any number of subtests
- CSS individual tests now generate both methods