### PR TITLE
Add find-missing script

### DIFF
--- a/find-missing.js
+++ b/find-missing.js
@@ -1,0 +1,56 @@
+'use strict';
+
+const bcd = require('mdn-browser-compat-data');
+const manifest = require('./MANIFEST.json');
+const tests = manifest.individualItems;
+
+const traverseFeatures = (obj, identifier) => {
+  const features = [];
+
+  for (const i in obj) {
+    if (
+      !!obj[i] &&
+      typeof obj[i] == 'object' &&
+      i !== '__compat'
+    ) {
+      if (obj[i].__compat) {
+        features.push(`${identifier}${i}`);
+      }
+
+      features.push(...traverseFeatures(obj[i], identifier + i + '.'));
+    }
+  }
+
+  return features;
+};
+
+const findMissing = () => {
+  const bcdEntries = [
+    ...traverseFeatures(bcd.api, 'api.'),
+    ...traverseFeatures(bcd.css.properties, 'css.properties.')
+  ];
+  const collectorEntries = Object.keys(tests);
+  const missingEntries = [];
+
+  for (const entry of bcdEntries) {
+    if (!collectorEntries.includes(entry)) {
+      missingEntries.push(entry);
+    }
+  }
+
+  return missingEntries;
+};
+
+const main = () => {
+  console.log(findMissing().join('\n'));
+};
+
+/* istanbul ignore if */
+if (require.main === module) {
+  main();
+} else {
+  module.exports = {
+    traverseFeatures,
+    findMissing
+  };
+}

--- a/package.json
+++ b/package.json
@@ -23,7 +23,8 @@
     "puppeteer": "NODE_ENV=test mocha test/puppeteer --timeout 30000 --slow 10000",
     "test": "npm run coverage && npm run puppeteer",
     "selenium": "mocha test/selenium",
-    "update-bcd": "node update-bcd.js"
+    "update-bcd": "node update-bcd.js",
+    "find-missing": "node find-missing.js"
   },
   "dependencies": {
     "@google-cloud/logging-winston": "4.0.0",


### PR DESCRIPTION
This PR adds a `find-missing` script to compare what's in BCD but not our tests.