### PR TITLE
Add custom test for MediaDevices API

### DIFF
--- a/custom-tests.json
+++ b/custom-tests.json
@@ -41,6 +41,9 @@
     },
     "EXT_texture_filter_anisotropic": {
       "__base": "var canvas = document.createElement('canvas'); if (!canvas) {return false}; var gl = canvas.getContext('webgl'); if (!gl) {return false}; var instance = gl.getExtension('EXT_texture_filter_anisotropic');"
+    },
+    "MediaDevices": {
+      "__base": "var instance = navigator.mediaDevices;"
     }
   },
   "css": {


### PR DESCRIPTION
This PR adds a custom test for the MediaDevices API to test the instance exposed via `navigator.mediaDevices`.