### PR TITLE
Catch errors during Selenium run

### DIFF
--- a/selenium.js
+++ b/selenium.js
@@ -77,7 +77,7 @@ const run = async (browser, version) => {
       .withCapabilities(capabilities).build();
 
   await driver.get(host);
-  
+
   try {
     await driver.wait(
         until.elementIsEnabled(
@@ -93,7 +93,7 @@ const run = async (browser, version) => {
         ),
         30000
     );
-  } catch(e) {
+  } catch (e) {
     console.error(e);
   }
 

--- a/selenium.js
+++ b/selenium.js
@@ -77,20 +77,26 @@ const run = async (browser, version) => {
       .withCapabilities(capabilities).build();
 
   await driver.get(host);
-  await driver.wait(
-      until.elementIsEnabled(
-          await driver.findElement(By.id('start')), 'Run'
-      ),
-      10000
-  );
-  await driver.findElement(By.id('start')).click();
-  await driver.wait(until.urlIs(`${host}/results/`), 60000);
-  await driver.wait(
-      until.elementTextContains(
-          await driver.findElement(By.id('status')), 'to'
-      ),
-      30000
-  );
+  
+  try {
+    await driver.wait(
+        until.elementIsEnabled(
+            await driver.findElement(By.id('start')), 'Run'
+        ),
+        10000
+    );
+    await driver.findElement(By.id('start')).click();
+    await driver.wait(until.urlIs(`${host}/results/`), 60000);
+    await driver.wait(
+        until.elementTextContains(
+            await driver.findElement(By.id('status')), 'to'
+        ),
+        30000
+    );
+  } catch(e) {
+    console.error(e);
+  }
+
   await driver.quit();
 };
 


### PR DESCRIPTION
This PR adds a try-catch clause around the Selenium script's operation, so that it will not only close the driver on error (thus refraining from wasting automation minutes), but also so that if one browser version crashes, the script still runs through the rest.