### PR TITLE
Simplify the lookup of tests for /tests/*

### DIFF
--- a/app.js
+++ b/app.js
@@ -162,12 +162,12 @@ app.get('/results', (req, res) => {
 
 app.all('/tests/*', (req, res) => {
   const ident = req.params['0'].replace(/\//g, '.');
-
-  if (tests.listEndpoints().some((item) => (item === ident))) {
+  const foundTests = tests.getTests(ident, req.query.exposure);
+  if (foundTests && foundTests.length) {
     res.render('tests', {
       title: `${ident || 'All Tests'}`,
       layout: false,
-      tests: tests.getTests(ident, req.query.exposure)
+      tests: foundTests
     });
   } else {
     res.status(404).render('error', {

--- a/tests.js
+++ b/tests.js
@@ -52,6 +52,10 @@ class Tests {
   }
 
   getTests(endpoint, testExposure) {
+    if (!(endpoint in this.endpoints)) {
+      return [];
+    }
+
     const idents = this.endpoints[endpoint];
 
     const tests = [];

--- a/unittest/app/app.js
+++ b/unittest/app/app.js
@@ -136,7 +136,7 @@ describe('/tests/', () => {
     assert.equal(res.status, 200);
   });
 
-  it('get a non-existent tests', async () => {
+  it('get a non-existent test', async () => {
     const res = await agent.get(`/tests/dummy/test`);
     assert.equal(res.status, 404);
   });


### PR DESCRIPTION
First checking if there were endpoints and then getting the tests was
doing double/unnecessary work.