### PR TITLE
Fix condition within update-bcd

### DIFF
--- a/update-bcd.js
+++ b/update-bcd.js
@@ -232,7 +232,7 @@ const inferSupportStatements = (versionMap) => {
     if (supported === true) {
       if (!lastStatement) {
         statements.push({
-          version_added: (lastWasNull && lastKnown.support === false) ?
+          version_added: (lastWasNull || lastKnown.support === false) ?
               true : version,
           ...(prefix && {prefix: prefix})
         });


### PR DESCRIPTION
This PR fixes a condition within the BCD updater for when the first browser version we have results for isn't the first browser version.