### PR TITLE
Catch crash of individual Selenium run on configuration

### DIFF
--- a/selenium.js
+++ b/selenium.js
@@ -103,7 +103,11 @@ const runAll = async () => {
   for (const browser in browsersToTest) {
     for (const version of browsersToTest[browser]) {
       console.log(`Running ${bcd.browsers[browser].name} ${version}...`);
-      await run(browser, version);
+      try {
+        await run(browser, version);
+      } catch (e) {
+        console.error(e);
+      }
     }
   }
 };


### PR DESCRIPTION
This PR fixes the Selenium script to catch when an initial run crashes during steps like the configuration stage, rather than just within the individual run.  This will prevent the whole script from crashing if the Selenium server doesn't support a specific configuration (like Edge 12).