### PR TITLE
Use MessageChannel API to handle messaging with Service Worker

### DIFF
--- a/static/resources/harness.js
+++ b/static/resources/harness.js
@@ -215,11 +215,17 @@
           }).then(function(reg) {
             return window.__waitForSWState(reg, 'activated');
           }).then(navigator.serviceWorker.ready).then(function(reg) {
-            navigator.serviceWorker.onmessage = function(event) {
+            var messageChannel = new MessageChannel();
+
+            messageChannel.port1.onmessage = function(event) {
+              console.log(event);
               callback(results.concat(event.data));
             };
 
-            reg.active.postMessage(pending.ServiceWorker);
+            reg.active.postMessage(
+              pending.ServiceWorker,
+              [messageChannel.port2]
+            );
           });
         });
       } else {

--- a/static/resources/harness.js
+++ b/static/resources/harness.js
@@ -13,7 +13,7 @@
 // limitations under the License.
 
 /* global console, document, window, location, navigator, XMLHttpRequest,
-          self, Worker, Promise, setTimeout, clearTimeout */
+          self, Worker, Promise, setTimeout, clearTimeout, MessageChannel */
 
 'use strict';
 
@@ -223,8 +223,8 @@
             };
 
             reg.active.postMessage(
-              pending.ServiceWorker,
-              [messageChannel.port2]
+                pending.ServiceWorker,
+                [messageChannel.port2]
             );
           });
         });

--- a/static/resources/serviceworker.js
+++ b/static/resources/serviceworker.js
@@ -38,5 +38,5 @@ self.addEventListener('message', function(event) {
     }
   }
 
-  event.source.postMessage(results);
+  event.ports[0].postMessage(results);
 });


### PR DESCRIPTION
This PR fixes communication with service workers due to lack of support for certain features.  By using the `MessageChannel` API, which by BCD was supported in all browsers before Service Workers were supported, we can now get messages from service workers in any browser.

Fixes #453.