### PR TITLE
Hotfix for Selenium misconfiguration errors

### DIFF
--- a/selenium.js
+++ b/selenium.js
@@ -73,8 +73,9 @@ const run = async (browser, version) => {
   );
   capabilities.set(Capability.VERSION, version);
 
-  const driver = new Builder().usingServer(seleniumUrl)
-      .withCapabilities(capabilities).build();
+  const driverBuilder = new Builder().usingServer(seleniumUrl)
+      .withCapabilities(capabilities);
+  const driver = await driverBuilder.build();
 
   try {
     await driver.get(`${host}`);


### PR DESCRIPTION
This PR tells the Selenium script to await the driver build, rather than creating an uncaught promise rejection.