### PR TITLE
Adjust custom tests to account for constructors better

### DIFF
--- a/DESIGN.md
+++ b/DESIGN.md
@@ -37,6 +37,8 @@ You can define a custom method to test the interface instance itself via `__test
 
 Each member can have a custom test by defining a property as the member name.  Like `__test`, it should be a return statement that returns `true` or `false`.  If no custom test is defined, it will default to `return instance && 'MEMBER' in instance`.
 
+Note: If an interface with a `__base` has a constructor test, but a custom test isn't defined for the constructor, the code will default to normal generation.
+
 Additional members and submembers can be defined using the `__additional` property.  If there is a subfeature to an API or one of its members, such as "api.AudioContext.AudioContext.latencyHint", that simply cannot be defined within IDL, you can include this object and specify tests for such subfeatures.
 
 Each test will compile into a function as follows: `function() {__base + __test/MEMBER/SUBFEATURE}`

--- a/build.js
+++ b/build.js
@@ -51,8 +51,13 @@ const getCustomTestAPI = (name, member) => {
       if (member in customTests.api[name]) {
         test = testbase + customTests.api[name][member];
       } else {
-        test = testbase ?
-          testbase + `return instance && '${member}' in instance;` : false;
+        if (name === member) {
+          // Constructors need special testing
+          test = false;
+        } else {
+          test = testbase ?
+            testbase + `return instance && '${member}' in instance;` : false;
+        }
       }
     }
   }

--- a/package-lock.json
+++ b/package-lock.json
@@ -1,6 +1,6 @@
 {
   "name": "mdn-bcd-collector",
-  "version": "0.2.0",
+  "version": "0.2.1",
   "lockfileVersion": 1,
   "requires": true,
   "dependencies": {

--- a/package.json
+++ b/package.json
@@ -1,7 +1,7 @@
 {
   "name": "mdn-bcd-collector",
   "description": "Data collection service for mdn/browser-compat-data",
-  "version": "0.2.0",
+  "version": "0.2.1",
   "private": true,
   "license": "Apache-2.0",
   "repository": {


### PR DESCRIPTION
This PR updates the custom test generation to use normal test generation for constructors if a custom constructor test isn't defined.  This resolves all constructors for interfaces with custom tests resulting in `false`.  Found in cases like `api.AudioBuffer.AudioBuffer`.

(Bumps patch version since it resolves a bug in test results.)