### PR TITLE
Use different buckets for production and staging

### DIFF
--- a/.github/workflows/push.yml
+++ b/.github/workflows/push.yml
@@ -32,8 +32,8 @@ jobs:
       env:
         SECRETS_JSON: ${{ secrets.SECRETS_JSON }}
     - if: ${{ github.ref == 'refs/heads/main' }}
-      run: gcloud app deploy --version=staging --no-promote
+      run: gcloud app deploy app.staging.yaml
     - if: ${{ github.ref == 'refs/heads/prod' }}
-      run: gcloud app deploy --version=production --promote
+      run: gcloud app deploy app.yaml
 env:
   FORCE_COLOR: 3

--- a/app.js
+++ b/app.js
@@ -46,7 +46,8 @@ const getHost = () => {
 const {CloudStorage, MemoryStorage} = require('./storage');
 /* istanbul ignore next */
 const storage = process.env.NODE_ENV === 'production' ?
-   new CloudStorage(process.env.GOOGLE_CLOUD_PROJECT) :
+   new CloudStorage(process.env.GOOGLE_CLOUD_PROJECT,
+       process.env.GCLOUD_STORAGE_BUCKET) :
    new MemoryStorage;
 
 /* istanbul ignore next */

--- a/app.staging.yaml
+++ b/app.staging.yaml
@@ -13,6 +13,6 @@
 # limitations under the License.
 
 runtime: nodejs12
-service: default
+service: staging
 env_variables:
-  GCLOUD_STORAGE_BUCKET: mdn-bcd-buffer
+  GCLOUD_STORAGE_BUCKET: mdn-bcd-buffer-staging

--- a/storage.js
+++ b/storage.js
@@ -19,9 +19,9 @@ const assert = require('assert');
 const {Storage} = require('@google-cloud/storage');
 
 class CloudStorage {
-  constructor(projectId) {
+  constructor(projectId, bucketName) {
     const storage = new Storage({projectId});
-    this._bucket = storage.bucket('mdn-bcd-buffer');
+    this._bucket = storage.bucket(bucketName);
   }
 
   async put(sessionId, key, value) {

--- a/unittest/unit/storage.js
+++ b/unittest/unit/storage.js
@@ -67,9 +67,11 @@ describe('storage', () => {
       let storage = null;
 
       beforeEach(() => {
-        storage = new StorageClass;
         if (StorageClass === CloudStorage) {
+          storage = new CloudStorage('fake-project', 'fake-bucket');
           storage._bucket = new FakeBucket;
+        } else {
+          storage = new StorageClass;
         }
       });
 


### PR DESCRIPTION
To make this work, create a new app.staging.yaml which deploys to a
different service. Versions are again left unspecified, which means that
new versions will be created for each deploy.
