### PR TITLE
Go back to using a single service (default) and two versions (staging/production)

### DIFF
--- a/.github/workflows/push.yml
+++ b/.github/workflows/push.yml
@@ -32,8 +32,8 @@ jobs:
       env:
         SECRETS_JSON: ${{ secrets.SECRETS_JSON }}
     - if: ${{ github.ref == 'refs/heads/main' }}
-      run: gcloud app deploy app.staging.yaml
+      run: gcloud app deploy app.staging.yaml --version=staging --no-promote
     - if: ${{ github.ref == 'refs/heads/prod' }}
-      run: gcloud app deploy app.yaml
+      run: gcloud app deploy app.yaml --version=production --promote
 env:
   FORCE_COLOR: 3

--- a/app.staging.yaml
+++ b/app.staging.yaml
@@ -13,6 +13,5 @@
 # limitations under the License.
 
 runtime: nodejs12
-service: staging
 env_variables:
   GCLOUD_STORAGE_BUCKET: mdn-bcd-buffer-staging

--- a/app.yaml
+++ b/app.yaml
@@ -13,6 +13,5 @@
 # limitations under the License.
 
 runtime: nodejs12
-service: default
 env_variables:
   GCLOUD_STORAGE_BUCKET: mdn-bcd-buffer


### PR DESCRIPTION
Updating getHost in app.js to use GAE_SERVICE instead of GAE_VERSION it
became apparent that determining the host name from the service would be
dubious. Every version in default would map to
mdn-bcd-collector.appspot.com and every version in staging would map to
staging-dot-mdn-bcd-collector.appspot.com, making it pointless to have
multiple versions.

And indeed it is. It's just a bit ugly to spell out the version in
push.yml, because it can't be specified in app.yaml. Whatever.
