### PR TITLE
Handle server errors in harness.js and results pages better

### DIFF
--- a/static/resources/harness.js
+++ b/static/resources/harness.js
@@ -323,7 +323,7 @@
     client.send(body);
     client.onreadystatechange = function() {
       if (client.readyState == 4) {
-        if (client.status >= 500) {
+        if (client.status >= 400) {
           updateStatus('Failed to upload results.');
         } else {
           updateStatus('Results uploaded. <a href="/results" id="submit">Submit to GitHub</a>');

--- a/views/results.ejs
+++ b/views/results.ejs
@@ -23,7 +23,9 @@ function exportGitHub() {
 
       try {
         response = JSON.parse(client.responseText);
-      } catch (e) {}
+      } catch (e) {
+        response.error = client.responseText;
+      }
 
       if (response.error) {
         status.textContent = 'Failed to export: ' + response.error;

--- a/views/results.ejs
+++ b/views/results.ejs
@@ -19,7 +19,12 @@ function exportGitHub() {
   status.textContent = 'Exporting...';
   client.onreadystatechange = function() {
     if (client.readyState == 4) {
-      var response = JSON.parse(client.responseText);
+      var response = {};
+
+      try {
+        response = JSON.parse(client.responseText);
+      } catch (e) {}
+
       if (response.error) {
         status.textContent = 'Failed to export: ' + response.error;
       } else {


### PR DESCRIPTION
This PR updates the error handling a little better to prevent client crashes, by doing the following:

1) Catch 4xx errors as well as 5xx errors
2) If no parseable JSON, set `response.error` to the response's text