### PR TITLE
Remove the unused getHost() helper

### DIFF
--- a/app.js
+++ b/app.js
@@ -32,18 +32,6 @@ const secrets = process.env.NODE_ENV === 'test' ?
     require('./secrets.sample.json') :
     require('./secrets.json');
 
-const getHost = () => {
-  const project = process.env.GOOGLE_CLOUD_PROJECT;
-  if (project) {
-    const version = process.env.GAE_VERSION;
-    if (version === 'production') {
-      return `${project}.appspot.com`;
-    }
-    return `${version}-dot-${project}.appspot.com`;
-  }
-  return `localhost:${PORT}`;
-};
-
 /* istanbul ignore next */
 const github = require('./github')(
   secrets.github.token ?
@@ -54,7 +42,6 @@ const github = require('./github')(
 const Tests = require('./tests');
 const tests = new Tests({
   tests: require('./tests.json'),
-  host: getHost(),
   httpOnly: process.env.NODE_ENV !== 'production'
 });
 
@@ -205,7 +192,6 @@ if (require.main === module) {
   // Export for testing
   module.exports = {
     app: app,
-    version: appversion,
-    getHost: getHost
+    version: appversion
   };
 }

--- a/tests.js
+++ b/tests.js
@@ -18,7 +18,6 @@ class Tests {
   constructor(options) {
     this.tests = options.tests;
     this.endpoints = this.buildEndpoints();
-    this.host = options.host;
     this.httpOnly = options.httpOnly;
   }
 

--- a/unittest/app/app.js
+++ b/unittest/app/app.js
@@ -14,7 +14,7 @@
 
 'use strict';
 
-const {app, version, getHost} = require('../../app');
+const {app, version} = require('../../app');
 const chai = require('chai');
 const chaiHttp = require('chai-http');
 
@@ -139,34 +139,6 @@ describe('/tests/', () => {
   it('get a non-existent test', async () => {
     const res = await agent.get(`/tests/dummy/test`);
     assert.equal(res.status, 404);
-  });
-});
-
-describe('getHost', () => {
-  it('testing', () => {
-    process.env.GOOGLE_CLOUD_PROJECT = '';
-    process.env.GAE_VERSION = '';
-
-    assert.equal(getHost(), 'localhost:8080');
-  });
-
-  it('production', () => {
-    process.env.GOOGLE_CLOUD_PROJECT = 'testing-project';
-    process.env.GAE_VERSION = 'production';
-
-    assert.equal(getHost(), 'testing-project.appspot.com');
-  });
-
-  it('staging', () => {
-    process.env.GOOGLE_CLOUD_PROJECT = 'testing-project';
-    process.env.GAE_VERSION = 'staging';
-
-    assert.equal(getHost(), 'staging-dot-testing-project.appspot.com');
-  });
-
-  afterEach(() => {
-    delete process.env.GOOGLE_CLOUD_PROJECT;
-    delete process.env.GAE_VERSION;
   });
 });
 


### PR DESCRIPTION
The computed host is unused in tests.js since https://github.com/foolip/mdn-bcd-collector/pull/416.
