### PR TITLE
harness.js: handle status code better

### DIFF
--- a/static/resources/harness.js
+++ b/static/resources/harness.js
@@ -323,10 +323,10 @@
     client.send(body);
     client.onreadystatechange = function() {
       if (client.readyState == 4) {
-        if (client.status >= 400) {
-          updateStatus('Failed to upload results.');
-        } else {
+        if (client.status == 200) {
           updateStatus('Results uploaded. <a href="/results" id="submit">Submit to GitHub</a>');
+        } else {
+          updateStatus('Failed to upload results.');
         }
       }
     };


### PR DESCRIPTION
This PR updates the results posting so that, rather than check if the error code is 400 or greater, it checks exclusively for 200 to confirm success.