### PR TITLE
Add Samsung Internet to getBrowserAndVersion() in update-bcd.js

### DIFF
--- a/update-bcd.js
+++ b/update-bcd.js
@@ -84,6 +84,9 @@ const getBrowserAndVersion = (userAgent, browsers) => {
   if (browser === 'mobile safari') {
     browser = 'safari_ios';
   }
+  if (browser === 'samsung browser') {
+    browser = 'samsunginternet';
+  }
   if (os === 'android') {
     browser += '_android';
   }


### PR DESCRIPTION
This PR loosely maps the UA string of Samsung Internet in `update-bcd.js`.