### PR TITLE
Have start-dev command rebuild automatically

### DIFF
--- a/README.md
+++ b/README.md
@@ -10,7 +10,6 @@ See [DESIGN.md](./DESIGN.md) for details of how this service works.
 
 ```sh
 npm install
-npm run build
 ```
 
 Before you can run or deploy, copy `secrets.sample.json` to `secrets.json`.
@@ -23,7 +22,7 @@ Before you can run or deploy, copy `secrets.sample.json` to `secrets.json`.
 npm run start-dev
 ```
 
-(`start-dev` as opposed to `start` will automatically reload the server on file changes.)
+(`start-dev`, as opposed to `start`, will automatically rebuild the tests and reload the server on file changes.)
 
 ## Deploying to App Engine
 

--- a/nodemon.json
+++ b/nodemon.json
@@ -1,8 +1,10 @@
 {
   "verbose": true,
   "ignore": [
+    "generated/*",
     "static/*",
     "views/*",
+    "tests.json",
     "find-missing.js",
     "selenium.js",
     "update-bcd.js"

--- a/package.json
+++ b/package.json
@@ -20,7 +20,7 @@
     "gcp-build": "npm run build",
     "deploy": "gcloud app deploy",
     "start": "node app.js",
-    "start-dev": "nodemon app.js",
+    "start-dev": "nodemon --exec 'npm run build && npm start'",
     "unittest": "NODE_ENV=test nyc mocha --recursive unittest",
     "coverage": "nyc report -r lcov && open-cli coverage/lcov-report/index.html",
     "test": "npm run lint && npm run unittest",


### PR DESCRIPTION
This PR configures `npm run start-dev` to rebuild the tests on file changes, making development slightly easier.