### PR TITLE
Custom tests import support

### DIFF
--- a/DESIGN.md
+++ b/DESIGN.md
@@ -118,6 +118,36 @@ bcd.addTest('css.properties.custom-property', "(function() {return CSS.supports(
 
 Tips: make sure that all return statements will return a boolean, and implement thorough feature checking.
 
+#### Importing code from other tests
+
+Sometimes, some features will depend on the setup and configuration from other features, especially with APIs.  To prevent repeating the same code over and over again, you can import code from other custom tests to build new ones quicker.  The syntax to specify a test import is the following: `<%ident:varname%>`, where `ident` is the full identifier to import from, and `varname` is what to rename the `instance` variable from that test to.
+
+Example:
+
+The following JSON...
+
+```
+{
+  "api": {
+    "AudioContext": {
+      "__base": "var instance = new (window.AudioContext || window.webkitAudioContext)();"
+    },
+    "AudioDestinationNode": {
+      "__base": "<%api.AudioContext:audioCtx%> if (!audioCtx) {return false}; var instance = audioCtx.destination;"
+    }
+  }
+}
+```
+
+...will compile into...
+
+```javascript
+bcd.addTest('api.AudioContext', "(function() {var instance = new (window.AudioContext || window.webkitAudioContext)();})()", 'Window');
+bcd.addTest('api.AudioDestinationNode', "(function() {var instance = new (window.AudioContext || window.webkitAudioContext)(); if (!audioCtx) {return false}; var instance = audioCtx.destination;})()", 'Window');
+```
+
+Note: if the specified `ident` cannot be found, the code will be replaced with a error to throw indicating as such.
+
 ## API
 
 HTTP endpoints under `/api/` are used to enumerate/iterate test URLs, report

--- a/build.js
+++ b/build.js
@@ -63,6 +63,17 @@ const getCustomTestAPI = (name, member) => {
   }
 
   if (test) {
+    // Import code from other tests
+    test = test.replace(/<%(\w+)\.(\w+):(\w+)%>/g, (match, category, name, instancevar) => {
+      if (!(name in customTests.api)) {
+        return `throw 'Test is malformed; ${match} is an invalid reference';`;
+      }
+      return (customTests.api[name].__base || '').replace(
+          /var instance/g, `var ${instancevar}`
+      );
+    });
+
+    // Wrap in a function
     test = `(function() {${test}})()`;
   }
 

--- a/custom-tests.json
+++ b/custom-tests.json
@@ -4,54 +4,54 @@
       "__base": "var canvas = document.createElement('canvas'); if (!canvas) {return false}; var gl = canvas.getContext('webgl') || canvas.getContext('experimental-webgl'); if (!gl) {return false}; var instance = gl.getExtension('ANGLE_instanced_arrays');"
     },
     "AnalyserNode": {
-      "__base": "var audioCtx = new (window.AudioContext || window.webkitAudioContext)(); if (!audioCtx) {return false}; var instance = audioCtx.createAnalyser();"
+      "__base": "<%api.AudioContext:audioCtx%> if (!audioCtx) {return false}; var instance = audioCtx.createAnalyser();"
     },
     "AudioBuffer": {
-      "__base": "var audioCtx = new (window.AudioContext || window.webkitAudioContext)(); if (!audioCtx) {return false}; var instance = audioCtx.createBuffer(2, audioCtx.sampleRate * 3, audioCtx.sampleRate);"
+      "__base": "<%api.AudioContext:audioCtx%> if (!audioCtx) {return false}; var instance = audioCtx.createBuffer(2, audioCtx.sampleRate * 3, audioCtx.sampleRate);"
     },
     "AudioBufferSourceNode": {
-      "__base": "var audioCtx = new (window.AudioContext || window.webkitAudioContext)(); if (!audioCtx) {return false}; var instance = audioCtx.createBufferSource();"
+      "__base": "<%api.AudioContext:audioCtx%> if (!audioCtx) {return false}; var instance = audioCtx.createBufferSource();"
     },
     "AudioContext": {
       "__base": "var instance = new (window.AudioContext || window.webkitAudioContext)();"
     },
     "AudioDestinationNode": {
-      "__base": "var audioCtx = new (window.AudioContext || window.webkitAudioContext)(); if (!audioCtx) {return false}; var instance = audioCtx.destination;"
+      "__base": "<%api.AudioContext:audioCtx%> if (!audioCtx) {return false}; var instance = audioCtx.destination;"
     },
     "AudioListener": {
-      "__base": "var audioCtx = new (window.AudioContext || window.webkitAudioContext)(); if (!audioCtx) {return false}; var instance = audioCtx.listener;"
+      "__base": "<%api.AudioContext:audioCtx%> if (!audioCtx) {return false}; var instance = audioCtx.listener;"
     },
     "AudioNode": {
-      "__base": "var audioCtx = new (window.AudioContext || window.webkitAudioContext)(); if (!audioCtx) {return false}; var instance = audioCtx.createAnalyser();"
+      "__base": "<%api.AudioContext:audioCtx%> if (!audioCtx) {return false}; var instance = audioCtx.createAnalyser();"
     },
     "AudioParam": {
-      "__base": "var audioCtx = new (window.AudioContext || window.webkitAudioContext)(); if (!audioCtx) {return false}; var gainNode = audioCtx.createGain(); var instance = gainNode.gain;"
+      "__base": "<%api.GainNode:gainNode%> var instance = gainNode.gain;"
     },
     "AudioParamMap": {
       "__TODO": "DEPENDS ON PROMISE TESTING SUPPORT",
-      "__base": "var audioCtx = new (window.AudioContext || window.webkitAudioContext)(); if (!audioCtx) {return false}; await audioCtx.audioWorklet.addModule('/resources/custom-tests/api/AudioWorkletNode/WhiteNoiseProcessor.js'); var worklet = new AudioWorkletNode(audioCtx, 'white-noise-processor'); if (!worklet) {return false}; var instance = worklet.parameters;"
+      "__base": "<%api.AudioWorkletNode:worklet%> if (!worklet) {return false}; var instance = worklet.parameters;"
     },
     "AudioWorkletNode": {
       "__TODO": "DEPENDS ON PROMISE TESTING SUPPORT",
-      "__base": "var audioCtx = new (window.AudioContext || window.webkitAudioContext)(); if (!audioCtx) {return false}; await audioCtx.audioWorklet.addModule('/resources/custom-tests/api/AudioWorkletNode/WhiteNoiseProcessor.js'); var instance = new AudioWorkletNode(audioCtx, 'white-noise-processor');"
+      "__base": "<%api.AudioContext:audioCtx%> if (!audioCtx) {return false}; await audioCtx.audioWorklet.addModule('/resources/custom-tests/api/AudioWorkletNode/WhiteNoiseProcessor.js'); var instance = new AudioWorkletNode(audioCtx, 'white-noise-processor');"
     },
     "BiquadFilterNode": {
-      "__base": "var audioCtx = new (window.AudioContext || window.webkitAudioContext)(); if (!audioCtx) {return false}; var instance = audioCtx.createBiquadFilter();"
+      "__base": "<%api.AudioContext:audioCtx%> if (!audioCtx) {return false}; var instance = audioCtx.createBiquadFilter();"
     },
     "ChannelMergerNode": {
-      "__base": "var audioCtx = new (window.AudioContext || window.webkitAudioContext)(); if (!audioCtx) {return false}; var instance = audioCtx.createChannelMerger();"
+      "__base": "<%api.AudioContext:audioCtx%> if (!audioCtx) {return false}; var instance = audioCtx.createChannelMerger();"
     },
     "ChannelSplitterNode": {
-      "__base": "var audioCtx = new (window.AudioContext || window.webkitAudioContext)(); if (!audioCtx) {return false}; var instance = audioCtx.createChannelSplitter();"
+      "__base": "<%api.AudioContext:audioCtx%> if (!audioCtx) {return false}; var instance = audioCtx.createChannelSplitter();"
     },
     "ConstantSourceNode": {
-      "__base": "var audioCtx = new (window.AudioContext || window.webkitAudioContext)(); if (!audioCtx) {return false}; var instance = audioCtx.createConstantSource();"
+      "__base": "<%api.AudioContext:audioCtx%> if (!audioCtx) {return false}; var instance = audioCtx.createConstantSource();"
     },
     "ConvolverNode": {
-      "__base": "var audioCtx = new (window.AudioContext || window.webkitAudioContext)(); if (!audioCtx) {return false}; var instance = audioCtx.createConvolver();"
+      "__base": "<%api.AudioContext:audioCtx%> if (!audioCtx) {return false}; var instance = audioCtx.createConvolver();"
     },
     "DelayNode": {
-      "__base": "var audioCtx = new (window.AudioContext || window.webkitAudioContext)(); if (!audioCtx) {return false}; var instance = audioCtx.createDelay();"
+      "__base": "<%api.AudioContext:audioCtx%> if (!audioCtx) {return false}; var instance = audioCtx.createDelay();"
     },
     "Document": {
       "__base": "var instance = document;"
@@ -63,7 +63,7 @@
       }
     },
     "DynamicsCompressorNode": {
-      "__base": "var audioCtx = new (window.AudioContext || window.webkitAudioContext)(); if (!audioCtx) {return false}; var instance = audioCtx.createDynamicsCompressor();"
+      "__base": "<%api.AudioContext:audioCtx%> if (!audioCtx) {return false}; var instance = audioCtx.createDynamicsCompressor();"
     },
     "EXT_blend_minmax": {
       "__base": "var canvas = document.createElement('canvas'); if (!canvas) {return false}; var gl = canvas.getContext('webgl') || canvas.getContext('experimental-webgl'); if (!gl) {return false}; var instance = gl.getExtension('EXT_blend_minmax');"
@@ -99,10 +99,10 @@
       "__base": "var canvas = document.createElement('canvas'); if (!canvas) {return false}; var gl = canvas.getContext('webgl') || canvas.getContext('experimental-webgl'); if (!gl) {return false}; var instance = gl.getExtension('EXT_texture_filter_anisotropic');"
     },
     "GainNode": {
-      "__base": "var audioCtx = new (window.AudioContext || window.webkitAudioContext)(); if (!audioCtx) {return false}; var instance = audioCtx.createGain();"
+      "__base": "<%api.AudioContext:audioCtx%> if (!audioCtx) {return false}; var instance = audioCtx.createGain();"
     },
     "IIRFilterNode": {
-      "__base": "var audioCtx = new (window.AudioContext || window.webkitAudioContext)(); if (!audioCtx) {return false}; var instance = audioCtx.createIIRFilter();"
+      "__base": "<%api.AudioContext:audioCtx%> if (!audioCtx) {return false}; var instance = audioCtx.createIIRFilter();"
     },
     "MediaDevices": {
       "__base": "var instance = navigator.mediaDevices;"
@@ -114,19 +114,19 @@
       "__base": "var instance = document.createNodeIterator(document);"
     },
     "OscillatorNode": {
-      "__base": "var audioCtx = new (window.AudioContext || window.webkitAudioContext)(); if (!audioCtx) {return false}; var instance = audioCtx.createOscillator();"
+      "__base": "<%api.AudioContext:audioCtx%> if (!audioCtx) {return false}; var instance = audioCtx.createOscillator();"
     },
     "PannerNode": {
-      "__base": "var audioCtx = new (window.AudioContext || window.webkitAudioContext)(); if (!audioCtx) {return false}; var instance = audioCtx.createPanner();"
+      "__base": "<%api.AudioContext:audioCtx%> if (!audioCtx) {return false}; var instance = audioCtx.createPanner();"
     },
     "StereoPannerNode": {
-      "__base": "var audioCtx = new (window.AudioContext || window.webkitAudioContext)(); if (!audioCtx) {return false}; var instance = audioCtx.createStereoPanner();"
+      "__base": "<%api.AudioContext:audioCtx%> if (!audioCtx) {return false}; var instance = audioCtx.createStereoPanner();"
     },
     "TreeWalker": {
       "__base": "var instance = document.createTreeWalker(document);"
     },
     "WaveShaperNode": {
-      "__base": "var audioCtx = new (window.AudioContext || window.webkitAudioContext)(); if (!audioCtx) {return false}; var instance = audioCtx.createWaveShaper();"
+      "__base": "<%api.AudioContext:audioCtx%> if (!audioCtx) {return false}; var instance = audioCtx.createWaveShaper();"
     },
     "Window": {
       "__base": "var instance = window;"

--- a/unittest/unit/build.js
+++ b/unittest/unit/build.js
@@ -244,6 +244,38 @@ describe('build', () => {
         );
       });
     });
+
+    describe('import other test', () => {
+      const {getCustomTestAPI} = proxyquire('../../build', {
+        './custom-tests.json': {
+          api: {
+            foo: {
+              __base: 'var instance = 1;'
+            },
+            bar: {
+              __base: '<%api.foo:a%> var instance = a;'
+            },
+            bad: {
+              __base: '<%api.foobar:apple%>'
+            }
+          }
+        }
+      });
+
+      it('valid import', () => {
+        assert.equal(
+            getCustomTestAPI('bar'),
+            '(function() {var a = 1; var instance = a;return !!instance;})()'
+        );
+      });
+
+      it('invalid import', () => {
+        assert.equal(
+            getCustomTestAPI('bad'),
+            '(function() {throw \'Test is malformed; <%api.foobar:apple%> is an invalid reference\';return !!instance;})()'
+        );
+      });
+    });
   });
 
   describe('getCustomSubtestsAPI', () => {


### PR DESCRIPTION
This PR fixes #500 by implementing a syntax to import the custom test code from other APIs and their members with a simple syntax of `<%ident:varname%>`, where the `ident` is the identifier to copy from, and the `varname` is what to rename the `instance` variable to.  This also updates the audio node code to use this new syntax.