### PR TITLE
Add linebreaks to custom tests for better display

### DIFF
--- a/build.js
+++ b/build.js
@@ -40,7 +40,8 @@ const getCustomTestAPI = (name, member) => {
   let test = false;
 
   if (name in customTests.api) {
-    const testbase = customTests.api[name].__base || '';
+    const testbase = customTests.api[name].__base ?
+      customTests.api[name].__base + '\n' : '';
     if (member === undefined) {
       if ('__test' in customTests.api[name]) {
         test = testbase + customTests.api[name].__test;
@@ -64,17 +65,17 @@ const getCustomTestAPI = (name, member) => {
 
   if (test) {
     // Import code from other tests
-    test = test.replace(/<%(\w+)\.(\w+):(\w+)%>/g, (match, category, name, instancevar) => {
+    test = test.replace(/<%(\w+)\.(\w+):(\w+)%> ?/g, (match, category, name, instancevar) => {
       if (!(name in customTests.api)) {
         return `throw 'Test is malformed; ${match} is an invalid reference';`;
       }
-      return (customTests.api[name].__base || '').replace(
+      return (customTests.api[name].__base + '\n').replace(
           /var instance/g, `var ${instancevar}`
       );
     });
 
     // Wrap in a function
-    test = `(function() {${test}})()`;
+    test = `(function() {\n${test}\n})()`;
   }
 
   return test;
@@ -89,7 +90,7 @@ const getCustomSubtestsAPI = (name) => {
       for (
         const subtest of Object.entries(customTests.api[name].__additional)
       ) {
-        subtests[subtest[0]] = `(function() {${testbase}${subtest[1]}})()`;
+        subtests[subtest[0]] = `(function() {\n${testbase}${subtest[1]}\n})()`;
       }
     }
   }
@@ -100,7 +101,7 @@ const getCustomSubtestsAPI = (name) => {
 const getCustomTestCSS = (name) => {
   return 'properties' in customTests.css &&
       name in customTests.css.properties &&
-      `(function() {${customTests.css.properties[name]}})()`;
+      `(function() {\n${customTests.css.properties[name]}\n})()`;
 };
 
 const compileTestCode = (test, prefix = '', ownerPrefix = '') => {

--- a/build.js
+++ b/build.js
@@ -36,6 +36,11 @@ const writeFile = async (filename, content) => {
   await fs.writeFile(filename, content, 'utf8');
 };
 
+const wrapInFunction = (code) => {
+  return `(function() {${code}})()`.replace(/{/g, '{\n')
+      .replace(/; ?/g, ';\n');
+};
+
 const getCustomTestAPI = (name, member) => {
   let test = false;
 
@@ -74,8 +79,7 @@ const getCustomTestAPI = (name, member) => {
     });
 
     // Wrap in a function and format
-    test = `(function() {${test}})()`.replace(/{/g, '{\n')
-        .replace(/; ?/g, ';\n');
+    test = wrapInFunction(test);
   }
 
   return test;
@@ -90,7 +94,7 @@ const getCustomSubtestsAPI = (name) => {
       for (
         const subtest of Object.entries(customTests.api[name].__additional)
       ) {
-        subtests[subtest[0]] = `(function() {\n${testbase}${subtest[1]}\n})()`;
+        subtests[subtest[0]] = wrapInFunction(`${testbase}${subtest[1]}`);
       }
     }
   }
@@ -101,7 +105,7 @@ const getCustomSubtestsAPI = (name) => {
 const getCustomTestCSS = (name) => {
   return 'properties' in customTests.css &&
       name in customTests.css.properties &&
-      `(function() {\n${customTests.css.properties[name]}\n})()`;
+      wrapInFunction(customTests.css.properties[name]);
 };
 
 const compileTestCode = (test, prefix = '', ownerPrefix = '') => {

--- a/custom-tests.json
+++ b/custom-tests.json
@@ -1,108 +1,109 @@
 {
   "api": {
     "ANGLE_instanced_arrays": {
-      "__base": "var canvas = document.createElement('canvas'); if (!canvas) {return false}; var gl = canvas.getContext('webgl') || canvas.getContext('experimental-webgl'); if (!gl) {return false}; var instance = gl.getExtension('ANGLE_instanced_arrays');"
+      "__base": "var canvas = document.createElement('canvas');\nif (!canvas) {return false};\nvar gl = canvas.getContext('webgl') || canvas.getContext('experimental-webgl');\nif (!gl) {return false};\nvar instance = gl.getExtension('ANGLE_instanced_arrays');"
     },
     "AnalyserNode": {
-      "__base": "<%api.AudioContext:audioCtx%> if (!audioCtx) {return false}; var instance = audioCtx.createAnalyser();"
+      "__base": "<%api.AudioContext:audioCtx%> if (!audioCtx) {return false};\nvar instance = audioCtx.createAnalyser();"
     },
     "AudioBuffer": {
-      "__base": "<%api.AudioContext:audioCtx%> if (!audioCtx) {return false}; var instance = audioCtx.createBuffer(2, audioCtx.sampleRate * 3, audioCtx.sampleRate);"
+      "__base": "<%api.AudioContext:audioCtx%> if (!audioCtx) {return false};\nvar instance = audioCtx.createBuffer(2, audioCtx.sampleRate * 3, audioCtx.sampleRate);"
     },
     "AudioBufferSourceNode": {
-      "__base": "<%api.AudioContext:audioCtx%> if (!audioCtx) {return false}; var instance = audioCtx.createBufferSource();"
+      "__base": "<%api.AudioContext:audioCtx%> if (!audioCtx) {return false};\nvar instance = audioCtx.createBufferSource();"
     },
     "AudioContext": {
+      "__todo": "Separate into different prefix variations when able",
       "__base": "var instance = new (window.AudioContext || window.webkitAudioContext)();"
     },
     "AudioDestinationNode": {
-      "__base": "<%api.AudioContext:audioCtx%> if (!audioCtx) {return false}; var instance = audioCtx.destination;"
+      "__base": "<%api.AudioContext:audioCtx%> if (!audioCtx) {return false};\nvar instance = audioCtx.destination;"
     },
     "AudioListener": {
-      "__base": "<%api.AudioContext:audioCtx%> if (!audioCtx) {return false}; var instance = audioCtx.listener;"
+      "__base": "<%api.AudioContext:audioCtx%> if (!audioCtx) {return false};\nvar instance = audioCtx.listener;"
     },
     "AudioNode": {
-      "__base": "<%api.AudioContext:audioCtx%> if (!audioCtx) {return false}; var instance = audioCtx.createAnalyser();"
+      "__base": "<%api.AudioContext:audioCtx%> if (!audioCtx) {return false};\nvar instance = audioCtx.createAnalyser();"
     },
     "AudioParam": {
       "__base": "<%api.GainNode:gainNode%> var instance = gainNode.gain;"
     },
     "AudioParamMap": {
       "__TODO": "DEPENDS ON PROMISE TESTING SUPPORT",
-      "__base": "<%api.AudioWorkletNode:worklet%> if (!worklet) {return false}; var instance = worklet.parameters;"
+      "__base": "<%api.AudioWorkletNode:worklet%> if (!worklet) {return false};\nvar instance = worklet.parameters;"
     },
     "AudioWorkletNode": {
       "__TODO": "DEPENDS ON PROMISE TESTING SUPPORT",
-      "__base": "<%api.AudioContext:audioCtx%> if (!audioCtx) {return false}; await audioCtx.audioWorklet.addModule('/resources/custom-tests/api/AudioWorkletNode/WhiteNoiseProcessor.js'); var instance = new AudioWorkletNode(audioCtx, 'white-noise-processor');"
+      "__base": "<%api.AudioContext:audioCtx%> if (!audioCtx) {return false};\nawait audioCtx.audioWorklet.addModule('/resources/custom-tests/api/AudioWorkletNode/WhiteNoiseProcessor.js');\nvar instance = new AudioWorkletNode(audioCtx, 'white-noise-processor');"
     },
     "BiquadFilterNode": {
-      "__base": "<%api.AudioContext:audioCtx%> if (!audioCtx) {return false}; var instance = audioCtx.createBiquadFilter();"
+      "__base": "<%api.AudioContext:audioCtx%> if (!audioCtx) {return false};\nvar instance = audioCtx.createBiquadFilter();"
     },
     "ChannelMergerNode": {
-      "__base": "<%api.AudioContext:audioCtx%> if (!audioCtx) {return false}; var instance = audioCtx.createChannelMerger();"
+      "__base": "<%api.AudioContext:audioCtx%> if (!audioCtx) {return false};\nvar instance = audioCtx.createChannelMerger();"
     },
     "ChannelSplitterNode": {
-      "__base": "<%api.AudioContext:audioCtx%> if (!audioCtx) {return false}; var instance = audioCtx.createChannelSplitter();"
+      "__base": "<%api.AudioContext:audioCtx%> if (!audioCtx) {return false};\nvar instance = audioCtx.createChannelSplitter();"
     },
     "ConstantSourceNode": {
-      "__base": "<%api.AudioContext:audioCtx%> if (!audioCtx) {return false}; var instance = audioCtx.createConstantSource();"
+      "__base": "<%api.AudioContext:audioCtx%> if (!audioCtx) {return false};\nvar instance = audioCtx.createConstantSource();"
     },
     "ConvolverNode": {
-      "__base": "<%api.AudioContext:audioCtx%> if (!audioCtx) {return false}; var instance = audioCtx.createConvolver();"
+      "__base": "<%api.AudioContext:audioCtx%> if (!audioCtx) {return false};\nvar instance = audioCtx.createConvolver();"
     },
     "DelayNode": {
-      "__base": "<%api.AudioContext:audioCtx%> if (!audioCtx) {return false}; var instance = audioCtx.createDelay();"
+      "__base": "<%api.AudioContext:audioCtx%> if (!audioCtx) {return false};\nvar instance = audioCtx.createDelay();"
     },
     "Document": {
       "__base": "var instance = document;"
     },
     "DOMTokenList": {
       "__additional": {
-        "trim_whitespace": "var elm = document.createElement('b'); elm.className = ' foo bar foo '; elm.classList.remove('bar'); return elm.className === 'foo foo' || elm.className === 'foo';",
-        "remove_duplicates": "var elm = document.createElement('b'); elm.className = ' foo bar foo '; elm.classList.remove('bar'); return elm.className === 'foo';"
+        "trim_whitespace": "var elm = document.createElement('b');\nelm.className = ' foo bar foo ';\nelm.classList.remove('bar');\nreturn elm.className === 'foo foo' || elm.className === 'foo';",
+        "remove_duplicates": "var elm = document.createElement('b');\nelm.className = ' foo bar foo ';\nelm.classList.remove('bar');\nreturn elm.className === 'foo';"
       }
     },
     "DynamicsCompressorNode": {
-      "__base": "<%api.AudioContext:audioCtx%> if (!audioCtx) {return false}; var instance = audioCtx.createDynamicsCompressor();"
+      "__base": "<%api.AudioContext:audioCtx%> if (!audioCtx) {return false};\nvar instance = audioCtx.createDynamicsCompressor();"
     },
     "EXT_blend_minmax": {
-      "__base": "var canvas = document.createElement('canvas'); if (!canvas) {return false}; var gl = canvas.getContext('webgl') || canvas.getContext('experimental-webgl'); if (!gl) {return false}; var instance = gl.getExtension('EXT_blend_minmax');"
+      "__base": "var canvas = document.createElement('canvas');\nif (!canvas) {return false};\nvar gl = canvas.getContext('webgl') || canvas.getContext('experimental-webgl');\nif (!gl) {return false};\nvar instance = gl.getExtension('EXT_blend_minmax');"
     },
     "EXT_color_buffer_float": {
-      "__base": "var canvas = document.createElement('canvas'); if (!canvas) {return false}; var gl = canvas.getContext('webgl') || canvas.getContext('experimental-webgl'); if (!gl) {return false}; var instance = gl.getExtension('EXT_color_buffer_float');"
+      "__base": "var canvas = document.createElement('canvas');\nif (!canvas) {return false};\nvar gl = canvas.getContext('webgl') || canvas.getContext('experimental-webgl');\nif (!gl) {return false};\nvar instance = gl.getExtension('EXT_color_buffer_float');"
     },
     "EXT_color_buffer_half_float": {
-      "__base": "var canvas = document.createElement('canvas'); if (!canvas) {return false}; var gl = canvas.getContext('webgl') || canvas.getContext('experimental-webgl'); if (!gl) {return false}; var instance = gl.getExtension('EXT_color_buffer_half_float');"
+      "__base": "var canvas = document.createElement('canvas');\nif (!canvas) {return false};\nvar gl = canvas.getContext('webgl') || canvas.getContext('experimental-webgl');\nif (!gl) {return false};\nvar instance = gl.getExtension('EXT_color_buffer_half_float');"
     },
     "EXT_disjoint_timer_query": {
-      "__base": "var canvas = document.createElement('canvas'); if (!canvas) {return false}; var gl = canvas.getContext('webgl') || canvas.getContext('experimental-webgl'); if (!gl) {return false}; var instance = gl.getExtension('EXT_disjoint_timer_query');"
+      "__base": "var canvas = document.createElement('canvas');\nif (!canvas) {return false};\nvar gl = canvas.getContext('webgl') || canvas.getContext('experimental-webgl');\nif (!gl) {return false};\nvar instance = gl.getExtension('EXT_disjoint_timer_query');"
     },
     "EXT_float_blend": {
-      "__base": "var canvas = document.createElement('canvas'); if (!canvas) {return false}; var gl = canvas.getContext('webgl') || canvas.getContext('experimental-webgl'); if (!gl) {return false}; var instance = gl.getExtension('EXT_float_blend');"
+      "__base": "var canvas = document.createElement('canvas');\nif (!canvas) {return false};\nvar gl = canvas.getContext('webgl') || canvas.getContext('experimental-webgl');\nif (!gl) {return false};\nvar instance = gl.getExtension('EXT_float_blend');"
     },
     "EXT_frag_depth": {
-      "__base": "var canvas = document.createElement('canvas'); if (!canvas) {return false}; var gl = canvas.getContext('webgl') || canvas.getContext('experimental-webgl'); if (!gl) {return false}; var instance = gl.getExtension('EXT_frag_depth');"
+      "__base": "var canvas = document.createElement('canvas');\nif (!canvas) {return false};\nvar gl = canvas.getContext('webgl') || canvas.getContext('experimental-webgl');\nif (!gl) {return false};\nvar instance = gl.getExtension('EXT_frag_depth');"
     },
     "EXT_shader_texture_lod": {
-      "__base": "var canvas = document.createElement('canvas'); if (!canvas) {return false}; var gl = canvas.getContext('webgl') || canvas.getContext('experimental-webgl'); if (!gl) {return false}; var instance = gl.getExtension('EXT_shader_texture_lod');"
+      "__base": "var canvas = document.createElement('canvas');\nif (!canvas) {return false};\nvar gl = canvas.getContext('webgl') || canvas.getContext('experimental-webgl');\nif (!gl) {return false};\nvar instance = gl.getExtension('EXT_shader_texture_lod');"
     },
     "EXT_sRGB": {
-      "__base": "var canvas = document.createElement('canvas'); if (!canvas) {return false}; var gl = canvas.getContext('webgl') || canvas.getContext('experimental-webgl'); if (!gl) {return false}; var instance = gl.getExtension('EXT_sRGB');"
+      "__base": "var canvas = document.createElement('canvas');\nif (!canvas) {return false};\nvar gl = canvas.getContext('webgl') || canvas.getContext('experimental-webgl');\nif (!gl) {return false};\nvar instance = gl.getExtension('EXT_sRGB');"
     },
     "EXT_texture_compression_bptc": {
-      "__base": "var canvas = document.createElement('canvas'); if (!canvas) {return false}; var gl = canvas.getContext('webgl') || canvas.getContext('experimental-webgl'); if (!gl) {return false}; var instance = gl.getExtension('EXT_texture_compression_bptc');"
+      "__base": "var canvas = document.createElement('canvas');\nif (!canvas) {return false};\nvar gl = canvas.getContext('webgl') || canvas.getContext('experimental-webgl');\nif (!gl) {return false};\nvar instance = gl.getExtension('EXT_texture_compression_bptc');"
     },
     "EXT_texture_compression_rgtc": {
-      "__base": "var canvas = document.createElement('canvas'); if (!canvas) {return false}; var gl = canvas.getContext('webgl') || canvas.getContext('experimental-webgl'); if (!gl) {return false}; var instance = gl.getExtension('EXT_texture_compression_rgtc');"
+      "__base": "var canvas = document.createElement('canvas');\nif (!canvas) {return false};\nvar gl = canvas.getContext('webgl') || canvas.getContext('experimental-webgl');\nif (!gl) {return false};\nvar instance = gl.getExtension('EXT_texture_compression_rgtc');"
     },
     "EXT_texture_filter_anisotropic": {
-      "__base": "var canvas = document.createElement('canvas'); if (!canvas) {return false}; var gl = canvas.getContext('webgl') || canvas.getContext('experimental-webgl'); if (!gl) {return false}; var instance = gl.getExtension('EXT_texture_filter_anisotropic');"
+      "__base": "var canvas = document.createElement('canvas');\nif (!canvas) {return false};\nvar gl = canvas.getContext('webgl') || canvas.getContext('experimental-webgl');\nif (!gl) {return false};\nvar instance = gl.getExtension('EXT_texture_filter_anisotropic');"
     },
     "GainNode": {
-      "__base": "<%api.AudioContext:audioCtx%> if (!audioCtx) {return false}; var instance = audioCtx.createGain();"
+      "__base": "<%api.AudioContext:audioCtx%> if (!audioCtx) {return false};\nvar instance = audioCtx.createGain();"
     },
     "IIRFilterNode": {
-      "__base": "<%api.AudioContext:audioCtx%> if (!audioCtx) {return false}; var instance = audioCtx.createIIRFilter();"
+      "__base": "<%api.AudioContext:audioCtx%> if (!audioCtx) {return false};\nvar instance = audioCtx.createIIRFilter();"
     },
     "MediaDevices": {
       "__base": "var instance = navigator.mediaDevices;"
@@ -114,19 +115,19 @@
       "__base": "var instance = document.createNodeIterator(document);"
     },
     "OscillatorNode": {
-      "__base": "<%api.AudioContext:audioCtx%> if (!audioCtx) {return false}; var instance = audioCtx.createOscillator();"
+      "__base": "<%api.AudioContext:audioCtx%> if (!audioCtx) {return false};\nvar instance = audioCtx.createOscillator();"
     },
     "PannerNode": {
-      "__base": "<%api.AudioContext:audioCtx%> if (!audioCtx) {return false}; var instance = audioCtx.createPanner();"
+      "__base": "<%api.AudioContext:audioCtx%> if (!audioCtx) {return false};\nvar instance = audioCtx.createPanner();"
     },
     "StereoPannerNode": {
-      "__base": "<%api.AudioContext:audioCtx%> if (!audioCtx) {return false}; var instance = audioCtx.createStereoPanner();"
+      "__base": "<%api.AudioContext:audioCtx%> if (!audioCtx) {return false};\nvar instance = audioCtx.createStereoPanner();"
     },
     "TreeWalker": {
       "__base": "var instance = document.createTreeWalker(document);"
     },
     "WaveShaperNode": {
-      "__base": "<%api.AudioContext:audioCtx%> if (!audioCtx) {return false}; var instance = audioCtx.createWaveShaper();"
+      "__base": "<%api.AudioContext:audioCtx%> if (!audioCtx) {return false};\nvar instance = audioCtx.createWaveShaper();"
     },
     "Window": {
       "__base": "var instance = window;"

--- a/custom-tests.json
+++ b/custom-tests.json
@@ -1,109 +1,109 @@
 {
   "api": {
     "ANGLE_instanced_arrays": {
-      "__base": "var canvas = document.createElement('canvas');\nif (!canvas) {return false};\nvar gl = canvas.getContext('webgl') || canvas.getContext('experimental-webgl');\nif (!gl) {return false};\nvar instance = gl.getExtension('ANGLE_instanced_arrays');"
+      "__base": "var canvas = document.createElement('canvas'); if (!canvas) {return false}; var gl = canvas.getContext('webgl') || canvas.getContext('experimental-webgl'); if (!gl) {return false}; var instance = gl.getExtension('ANGLE_instanced_arrays');"
     },
     "AnalyserNode": {
-      "__base": "<%api.AudioContext:audioCtx%> if (!audioCtx) {return false};\nvar instance = audioCtx.createAnalyser();"
+      "__base": "<%api.AudioContext:audioCtx%> if (!audioCtx) {return false}; var instance = audioCtx.createAnalyser();"
     },
     "AudioBuffer": {
-      "__base": "<%api.AudioContext:audioCtx%> if (!audioCtx) {return false};\nvar instance = audioCtx.createBuffer(2, audioCtx.sampleRate * 3, audioCtx.sampleRate);"
+      "__base": "<%api.AudioContext:audioCtx%> if (!audioCtx) {return false}; var instance = audioCtx.createBuffer(2, audioCtx.sampleRate * 3, audioCtx.sampleRate);"
     },
     "AudioBufferSourceNode": {
-      "__base": "<%api.AudioContext:audioCtx%> if (!audioCtx) {return false};\nvar instance = audioCtx.createBufferSource();"
+      "__base": "<%api.AudioContext:audioCtx%> if (!audioCtx) {return false}; var instance = audioCtx.createBufferSource();"
     },
     "AudioContext": {
       "__todo": "Separate into different prefix variations when able",
       "__base": "var instance = new (window.AudioContext || window.webkitAudioContext)();"
     },
     "AudioDestinationNode": {
-      "__base": "<%api.AudioContext:audioCtx%> if (!audioCtx) {return false};\nvar instance = audioCtx.destination;"
+      "__base": "<%api.AudioContext:audioCtx%> if (!audioCtx) {return false}; var instance = audioCtx.destination;"
     },
     "AudioListener": {
-      "__base": "<%api.AudioContext:audioCtx%> if (!audioCtx) {return false};\nvar instance = audioCtx.listener;"
+      "__base": "<%api.AudioContext:audioCtx%> if (!audioCtx) {return false}; var instance = audioCtx.listener;"
     },
     "AudioNode": {
-      "__base": "<%api.AudioContext:audioCtx%> if (!audioCtx) {return false};\nvar instance = audioCtx.createAnalyser();"
+      "__base": "<%api.AudioContext:audioCtx%> if (!audioCtx) {return false}; var instance = audioCtx.createAnalyser();"
     },
     "AudioParam": {
       "__base": "<%api.GainNode:gainNode%> var instance = gainNode.gain;"
     },
     "AudioParamMap": {
       "__TODO": "DEPENDS ON PROMISE TESTING SUPPORT",
-      "__base": "<%api.AudioWorkletNode:worklet%> if (!worklet) {return false};\nvar instance = worklet.parameters;"
+      "__base": "<%api.AudioWorkletNode:worklet%> if (!worklet) {return false}; var instance = worklet.parameters;"
     },
     "AudioWorkletNode": {
       "__TODO": "DEPENDS ON PROMISE TESTING SUPPORT",
-      "__base": "<%api.AudioContext:audioCtx%> if (!audioCtx) {return false};\nawait audioCtx.audioWorklet.addModule('/resources/custom-tests/api/AudioWorkletNode/WhiteNoiseProcessor.js');\nvar instance = new AudioWorkletNode(audioCtx, 'white-noise-processor');"
+      "__base": "<%api.AudioContext:audioCtx%> if (!audioCtx) {return false}; await audioCtx.audioWorklet.addModule('/resources/custom-tests/api/AudioWorkletNode/WhiteNoiseProcessor.js'); var instance = new AudioWorkletNode(audioCtx, 'white-noise-processor');"
     },
     "BiquadFilterNode": {
-      "__base": "<%api.AudioContext:audioCtx%> if (!audioCtx) {return false};\nvar instance = audioCtx.createBiquadFilter();"
+      "__base": "<%api.AudioContext:audioCtx%> if (!audioCtx) {return false}; var instance = audioCtx.createBiquadFilter();"
     },
     "ChannelMergerNode": {
-      "__base": "<%api.AudioContext:audioCtx%> if (!audioCtx) {return false};\nvar instance = audioCtx.createChannelMerger();"
+      "__base": "<%api.AudioContext:audioCtx%> if (!audioCtx) {return false}; var instance = audioCtx.createChannelMerger();"
     },
     "ChannelSplitterNode": {
-      "__base": "<%api.AudioContext:audioCtx%> if (!audioCtx) {return false};\nvar instance = audioCtx.createChannelSplitter();"
+      "__base": "<%api.AudioContext:audioCtx%> if (!audioCtx) {return false}; var instance = audioCtx.createChannelSplitter();"
     },
     "ConstantSourceNode": {
-      "__base": "<%api.AudioContext:audioCtx%> if (!audioCtx) {return false};\nvar instance = audioCtx.createConstantSource();"
+      "__base": "<%api.AudioContext:audioCtx%> if (!audioCtx) {return false}; var instance = audioCtx.createConstantSource();"
     },
     "ConvolverNode": {
-      "__base": "<%api.AudioContext:audioCtx%> if (!audioCtx) {return false};\nvar instance = audioCtx.createConvolver();"
+      "__base": "<%api.AudioContext:audioCtx%> if (!audioCtx) {return false}; var instance = audioCtx.createConvolver();"
     },
     "DelayNode": {
-      "__base": "<%api.AudioContext:audioCtx%> if (!audioCtx) {return false};\nvar instance = audioCtx.createDelay();"
+      "__base": "<%api.AudioContext:audioCtx%> if (!audioCtx) {return false}; var instance = audioCtx.createDelay();"
     },
     "Document": {
       "__base": "var instance = document;"
     },
     "DOMTokenList": {
       "__additional": {
-        "trim_whitespace": "var elm = document.createElement('b');\nelm.className = ' foo bar foo ';\nelm.classList.remove('bar');\nreturn elm.className === 'foo foo' || elm.className === 'foo';",
-        "remove_duplicates": "var elm = document.createElement('b');\nelm.className = ' foo bar foo ';\nelm.classList.remove('bar');\nreturn elm.className === 'foo';"
+        "trim_whitespace": "var elm = document.createElement('b'); elm.className = ' foo bar foo '; elm.classList.remove('bar'); return elm.className === 'foo foo' || elm.className === 'foo';",
+        "remove_duplicates": "var elm = document.createElement('b'); elm.className = ' foo bar foo '; elm.classList.remove('bar'); return elm.className === 'foo';"
       }
     },
     "DynamicsCompressorNode": {
-      "__base": "<%api.AudioContext:audioCtx%> if (!audioCtx) {return false};\nvar instance = audioCtx.createDynamicsCompressor();"
+      "__base": "<%api.AudioContext:audioCtx%> if (!audioCtx) {return false}; var instance = audioCtx.createDynamicsCompressor();"
     },
     "EXT_blend_minmax": {
-      "__base": "var canvas = document.createElement('canvas');\nif (!canvas) {return false};\nvar gl = canvas.getContext('webgl') || canvas.getContext('experimental-webgl');\nif (!gl) {return false};\nvar instance = gl.getExtension('EXT_blend_minmax');"
+      "__base": "var canvas = document.createElement('canvas'); if (!canvas) {return false}; var gl = canvas.getContext('webgl') || canvas.getContext('experimental-webgl'); if (!gl) {return false}; var instance = gl.getExtension('EXT_blend_minmax');"
     },
     "EXT_color_buffer_float": {
-      "__base": "var canvas = document.createElement('canvas');\nif (!canvas) {return false};\nvar gl = canvas.getContext('webgl') || canvas.getContext('experimental-webgl');\nif (!gl) {return false};\nvar instance = gl.getExtension('EXT_color_buffer_float');"
+      "__base": "var canvas = document.createElement('canvas'); if (!canvas) {return false}; var gl = canvas.getContext('webgl') || canvas.getContext('experimental-webgl'); if (!gl) {return false}; var instance = gl.getExtension('EXT_color_buffer_float');"
     },
     "EXT_color_buffer_half_float": {
-      "__base": "var canvas = document.createElement('canvas');\nif (!canvas) {return false};\nvar gl = canvas.getContext('webgl') || canvas.getContext('experimental-webgl');\nif (!gl) {return false};\nvar instance = gl.getExtension('EXT_color_buffer_half_float');"
+      "__base": "var canvas = document.createElement('canvas'); if (!canvas) {return false}; var gl = canvas.getContext('webgl') || canvas.getContext('experimental-webgl'); if (!gl) {return false}; var instance = gl.getExtension('EXT_color_buffer_half_float');"
     },
     "EXT_disjoint_timer_query": {
-      "__base": "var canvas = document.createElement('canvas');\nif (!canvas) {return false};\nvar gl = canvas.getContext('webgl') || canvas.getContext('experimental-webgl');\nif (!gl) {return false};\nvar instance = gl.getExtension('EXT_disjoint_timer_query');"
+      "__base": "var canvas = document.createElement('canvas'); if (!canvas) {return false}; var gl = canvas.getContext('webgl') || canvas.getContext('experimental-webgl'); if (!gl) {return false}; var instance = gl.getExtension('EXT_disjoint_timer_query');"
     },
     "EXT_float_blend": {
-      "__base": "var canvas = document.createElement('canvas');\nif (!canvas) {return false};\nvar gl = canvas.getContext('webgl') || canvas.getContext('experimental-webgl');\nif (!gl) {return false};\nvar instance = gl.getExtension('EXT_float_blend');"
+      "__base": "var canvas = document.createElement('canvas'); if (!canvas) {return false}; var gl = canvas.getContext('webgl') || canvas.getContext('experimental-webgl'); if (!gl) {return false}; var instance = gl.getExtension('EXT_float_blend');"
     },
     "EXT_frag_depth": {
-      "__base": "var canvas = document.createElement('canvas');\nif (!canvas) {return false};\nvar gl = canvas.getContext('webgl') || canvas.getContext('experimental-webgl');\nif (!gl) {return false};\nvar instance = gl.getExtension('EXT_frag_depth');"
+      "__base": "var canvas = document.createElement('canvas'); if (!canvas) {return false}; var gl = canvas.getContext('webgl') || canvas.getContext('experimental-webgl'); if (!gl) {return false}; var instance = gl.getExtension('EXT_frag_depth');"
     },
     "EXT_shader_texture_lod": {
-      "__base": "var canvas = document.createElement('canvas');\nif (!canvas) {return false};\nvar gl = canvas.getContext('webgl') || canvas.getContext('experimental-webgl');\nif (!gl) {return false};\nvar instance = gl.getExtension('EXT_shader_texture_lod');"
+      "__base": "var canvas = document.createElement('canvas'); if (!canvas) {return false}; var gl = canvas.getContext('webgl') || canvas.getContext('experimental-webgl'); if (!gl) {return false}; var instance = gl.getExtension('EXT_shader_texture_lod');"
     },
     "EXT_sRGB": {
-      "__base": "var canvas = document.createElement('canvas');\nif (!canvas) {return false};\nvar gl = canvas.getContext('webgl') || canvas.getContext('experimental-webgl');\nif (!gl) {return false};\nvar instance = gl.getExtension('EXT_sRGB');"
+      "__base": "var canvas = document.createElement('canvas'); if (!canvas) {return false}; var gl = canvas.getContext('webgl') || canvas.getContext('experimental-webgl'); if (!gl) {return false}; var instance = gl.getExtension('EXT_sRGB');"
     },
     "EXT_texture_compression_bptc": {
-      "__base": "var canvas = document.createElement('canvas');\nif (!canvas) {return false};\nvar gl = canvas.getContext('webgl') || canvas.getContext('experimental-webgl');\nif (!gl) {return false};\nvar instance = gl.getExtension('EXT_texture_compression_bptc');"
+      "__base": "var canvas = document.createElement('canvas'); if (!canvas) {return false}; var gl = canvas.getContext('webgl') || canvas.getContext('experimental-webgl'); if (!gl) {return false}; var instance = gl.getExtension('EXT_texture_compression_bptc');"
     },
     "EXT_texture_compression_rgtc": {
-      "__base": "var canvas = document.createElement('canvas');\nif (!canvas) {return false};\nvar gl = canvas.getContext('webgl') || canvas.getContext('experimental-webgl');\nif (!gl) {return false};\nvar instance = gl.getExtension('EXT_texture_compression_rgtc');"
+      "__base": "var canvas = document.createElement('canvas'); if (!canvas) {return false}; var gl = canvas.getContext('webgl') || canvas.getContext('experimental-webgl'); if (!gl) {return false}; var instance = gl.getExtension('EXT_texture_compression_rgtc');"
     },
     "EXT_texture_filter_anisotropic": {
-      "__base": "var canvas = document.createElement('canvas');\nif (!canvas) {return false};\nvar gl = canvas.getContext('webgl') || canvas.getContext('experimental-webgl');\nif (!gl) {return false};\nvar instance = gl.getExtension('EXT_texture_filter_anisotropic');"
+      "__base": "var canvas = document.createElement('canvas'); if (!canvas) {return false}; var gl = canvas.getContext('webgl') || canvas.getContext('experimental-webgl'); if (!gl) {return false}; var instance = gl.getExtension('EXT_texture_filter_anisotropic');"
     },
     "GainNode": {
-      "__base": "<%api.AudioContext:audioCtx%> if (!audioCtx) {return false};\nvar instance = audioCtx.createGain();"
+      "__base": "<%api.AudioContext:audioCtx%> if (!audioCtx) {return false}; var instance = audioCtx.createGain();"
     },
     "IIRFilterNode": {
-      "__base": "<%api.AudioContext:audioCtx%> if (!audioCtx) {return false};\nvar instance = audioCtx.createIIRFilter();"
+      "__base": "<%api.AudioContext:audioCtx%> if (!audioCtx) {return false}; var instance = audioCtx.createIIRFilter();"
     },
     "MediaDevices": {
       "__base": "var instance = navigator.mediaDevices;"
@@ -115,19 +115,19 @@
       "__base": "var instance = document.createNodeIterator(document);"
     },
     "OscillatorNode": {
-      "__base": "<%api.AudioContext:audioCtx%> if (!audioCtx) {return false};\nvar instance = audioCtx.createOscillator();"
+      "__base": "<%api.AudioContext:audioCtx%> if (!audioCtx) {return false}; var instance = audioCtx.createOscillator();"
     },
     "PannerNode": {
-      "__base": "<%api.AudioContext:audioCtx%> if (!audioCtx) {return false};\nvar instance = audioCtx.createPanner();"
+      "__base": "<%api.AudioContext:audioCtx%> if (!audioCtx) {return false}; var instance = audioCtx.createPanner();"
     },
     "StereoPannerNode": {
-      "__base": "<%api.AudioContext:audioCtx%> if (!audioCtx) {return false};\nvar instance = audioCtx.createStereoPanner();"
+      "__base": "<%api.AudioContext:audioCtx%> if (!audioCtx) {return false}; var instance = audioCtx.createStereoPanner();"
     },
     "TreeWalker": {
       "__base": "var instance = document.createTreeWalker(document);"
     },
     "WaveShaperNode": {
-      "__base": "<%api.AudioContext:audioCtx%> if (!audioCtx) {return false};\nvar instance = audioCtx.createWaveShaper();"
+      "__base": "<%api.AudioContext:audioCtx%> if (!audioCtx) {return false}; var instance = audioCtx.createWaveShaper();"
     },
     "Window": {
       "__base": "var instance = window;"

--- a/unittest/unit/build.js
+++ b/unittest/unit/build.js
@@ -272,7 +272,7 @@ describe('build', () => {
       it('invalid import', () => {
         assert.equal(
             getCustomTestAPI('bad'),
-            '(function() {\nthrow \'Test is malformed; <%api.foobar:apple%> is an invalid reference\';\nreturn !!instance;\n})()'
+            '(function() {\nthrow \'Test is malformed: <%api.foobar:apple%> is an invalid reference\';\nreturn !!instance;\n})()'
         );
       });
     });
@@ -1124,7 +1124,7 @@ describe('build', () => {
         './custom-tests.json': {
           api: {
             ANGLE_instanced_arrays: {
-              __base: 'var canvas = document.createElement(\'canvas\');\nvar gl = canvas.getContext(\'webgl\');\nvar instance = gl.getExtension(\'ANGLE_instanced_arrays\');',
+              __base: 'var canvas = document.createElement(\'canvas\'); var gl = canvas.getContext(\'webgl\'); var instance = gl.getExtension(\'ANGLE_instanced_arrays\');',
               __test: 'return !!instance;',
               drawArraysInstancedANGLE: 'return true && instance && \'drawArraysInstancedANGLE\' in instance;'
             },

--- a/unittest/unit/build.js
+++ b/unittest/unit/build.js
@@ -104,14 +104,14 @@ describe('build', () => {
       it('interface', () => {
         assert.equal(
             getCustomTestAPI('foo'),
-            '(function() {var a = 1;return a;})()'
+            '(function() {\nvar a = 1;\nreturn a;\n})()'
         );
       });
 
       it('member', () => {
         assert.equal(
             getCustomTestAPI('foo', 'bar'),
-            '(function() {var a = 1;return \'bar\' in instance;})()'
+            '(function() {\nvar a = 1;\nreturn \'bar\' in instance;\n})()'
         );
       });
 
@@ -132,7 +132,7 @@ describe('build', () => {
       });
 
       it('interface', () => {
-        assert.equal(getCustomTestAPI('foo'), '(function() {return 1;})()');
+        assert.equal(getCustomTestAPI('foo'), '(function() {\nreturn 1;\n})()');
       });
 
       it('member', () => {
@@ -155,14 +155,14 @@ describe('build', () => {
       it('interface', () => {
         assert.equal(
             getCustomTestAPI('foo'),
-            '(function() {var a = 1;return !!instance;})()'
+            '(function() {\nvar a = 1;\nreturn !!instance;\n})()'
         );
       });
 
       it('member', () => {
         assert.equal(
             getCustomTestAPI('foo', 'bar'),
-            '(function() {var a = 1;return a + 1;})()'
+            '(function() {\nvar a = 1;\nreturn a + 1;\n})()'
         );
       });
     });
@@ -185,7 +185,7 @@ describe('build', () => {
       it('member', () => {
         assert.equal(
             getCustomTestAPI('foo', 'bar'),
-            '(function() {return 1 + 1;})()'
+            '(function() {\nreturn 1 + 1;\n})()'
         );
       });
     });
@@ -212,7 +212,7 @@ describe('build', () => {
       it('member', () => {
         assert.equal(
             getCustomTestAPI('foo', 'bar'),
-            '(function() {return 1 + 1;})()'
+            '(function() {\nreturn 1 + 1;\n})()'
         );
       });
     });
@@ -233,14 +233,14 @@ describe('build', () => {
       it('interface', () => {
         assert.equal(
             getCustomTestAPI('foo'),
-            '(function() {var a = 1;return a;})()'
+            '(function() {\nvar a = 1;\nreturn a;\n})()'
         );
       });
 
       it('member', () => {
         assert.equal(
             getCustomTestAPI('foo', 'bar'),
-            '(function() {var a = 1;return a + 1;})()'
+            '(function() {\nvar a = 1;\nreturn a + 1;\n})()'
         );
       });
     });
@@ -265,14 +265,14 @@ describe('build', () => {
       it('valid import', () => {
         assert.equal(
             getCustomTestAPI('bar'),
-            '(function() {var a = 1; var instance = a;return !!instance;})()'
+            '(function() {\nvar a = 1;\nvar instance = a;\nreturn !!instance;\n})()'
         );
       });
 
       it('invalid import', () => {
         assert.equal(
             getCustomTestAPI('bad'),
-            '(function() {throw \'Test is malformed; <%api.foobar:apple%> is an invalid reference\';return !!instance;})()'
+            '(function() {\nthrow \'Test is malformed; <%api.foobar:apple%> is an invalid reference\';\nreturn !!instance;\n})()'
         );
       });
     });
@@ -296,8 +296,8 @@ describe('build', () => {
       assert.deepEqual(
           getCustomSubtestsAPI('foo', 'bar'),
           {
-            multiple: '(function() {return 1 + 1 + 1;})()',
-            'one.only': '(function() {return 1;})()'
+            multiple: '(function() {\nreturn 1 + 1 + 1;\n})()',
+            'one.only': '(function() {\nreturn 1;\n})()'
           }
       );
     });
@@ -323,7 +323,7 @@ describe('build', () => {
         }
       });
 
-      assert.equal(getCustomTestCSS('foo'), '(function() {return 1;})()');
+      assert.equal(getCustomTestCSS('foo'), '(function() {\nreturn 1;\n})()');
     });
   });
 
@@ -1124,7 +1124,7 @@ describe('build', () => {
         './custom-tests.json': {
           api: {
             ANGLE_instanced_arrays: {
-              __base: 'var canvas = document.createElement(\'canvas\'); var gl = canvas.getContext(\'webgl\'); var instance = gl.getExtension(\'ANGLE_instanced_arrays\');',
+              __base: 'var canvas = document.createElement(\'canvas\');\nvar gl = canvas.getContext(\'webgl\');\nvar instance = gl.getExtension(\'ANGLE_instanced_arrays\');',
               __test: 'return !!instance;',
               drawArraysInstancedANGLE: 'return true && instance && \'drawArraysInstancedANGLE\' in instance;'
             },
@@ -1142,7 +1142,7 @@ describe('build', () => {
         'api.ANGLE_instanced_arrays': {
           tests: [
             {
-              code: '(function() {var canvas = document.createElement(\'canvas\'); var gl = canvas.getContext(\'webgl\'); var instance = gl.getExtension(\'ANGLE_instanced_arrays\');return !!instance;})()',
+              code: '(function() {\nvar canvas = document.createElement(\'canvas\');\nvar gl = canvas.getContext(\'webgl\');\nvar instance = gl.getExtension(\'ANGLE_instanced_arrays\');\nreturn !!instance;\n})()',
               prefix: ''
             }
           ],
@@ -1152,7 +1152,7 @@ describe('build', () => {
         'api.ANGLE_instanced_arrays.drawArraysInstancedANGLE': {
           tests: [
             {
-              code: '(function() {var canvas = document.createElement(\'canvas\'); var gl = canvas.getContext(\'webgl\'); var instance = gl.getExtension(\'ANGLE_instanced_arrays\');return true && instance && \'drawArraysInstancedANGLE\' in instance;})()',
+              code: '(function() {\nvar canvas = document.createElement(\'canvas\');\nvar gl = canvas.getContext(\'webgl\');\nvar instance = gl.getExtension(\'ANGLE_instanced_arrays\');\nreturn true && instance && \'drawArraysInstancedANGLE\' in instance;\n})()',
               prefix: ''
             }
           ],
@@ -1162,7 +1162,7 @@ describe('build', () => {
         'api.ANGLE_instanced_arrays.drawElementsInstancedANGLE': {
           tests: [
             {
-              code: '(function() {var canvas = document.createElement(\'canvas\'); var gl = canvas.getContext(\'webgl\'); var instance = gl.getExtension(\'ANGLE_instanced_arrays\');return \'drawElementsInstancedANGLE\' in instance;})()',
+              code: '(function() {\nvar canvas = document.createElement(\'canvas\');\nvar gl = canvas.getContext(\'webgl\');\nvar instance = gl.getExtension(\'ANGLE_instanced_arrays\');\nreturn \'drawElementsInstancedANGLE\' in instance;\n})()',
               prefix: ''
             }
           ],
@@ -1182,7 +1182,7 @@ describe('build', () => {
         'api.Document.charset': {
           tests: [
             {
-              code: '(function() {return document.charset == "UTF-8";})()',
+              code: '(function() {\nreturn document.charset == "UTF-8";\n})()',
               prefix: ''
             }
           ],
@@ -1202,7 +1202,7 @@ describe('build', () => {
         'api.Document.loaded.loaded_is_boolean': {
           tests: [
             {
-              code: '(function() {return typeof document.loaded === "boolean";})()',
+              code: '(function() {\nreturn typeof document.loaded === "boolean";\n})()',
               prefix: ''
             }
           ],
@@ -1780,7 +1780,7 @@ describe('build', () => {
         'api.CSS': {
           tests: [
             {
-              code: '(function() {var css = CSS;return !!css;})()',
+              code: '(function() {\nvar css = CSS;\nreturn !!css;\n})()',
               prefix: ''
             }
           ],
@@ -1790,7 +1790,7 @@ describe('build', () => {
         'api.CSS.paintWorklet': {
           tests: [
             {
-              code: '(function() {var css = CSS;return css && \'paintWorklet\' in css;})()',
+              code: '(function() {\nvar css = CSS;\nreturn css && \'paintWorklet\' in css;\n})()',
               prefix: ''
             }
           ],


### PR DESCRIPTION
This PR adds linebreaks to the custom tests to improve their display, making them more legible, like so:

<img width="546" alt="Screen Shot 2020-09-17 at 11 55 29" src="https://user-images.githubusercontent.com/5179191/93514955-af8d7b80-f8dc-11ea-90f5-e3e47556bdde.png">
