### PR TITLE
Prettier

### DIFF
--- a/.eslintrc.json
+++ b/.eslintrc.json
@@ -1,28 +1,31 @@
 {
-    "extends": ["eslint:recommended", "google"],
-    "plugins": ["prefer-arrow"],
-    "parser": "babel-eslint",
-    "parserOptions": {
-        "ecmaVersion": 8
-    },
-    "rules": {
-        "comma-dangle": ["error", "never"],
-        "curly": ["error", "all"],
-        "max-len": ["error", {
-            "ignoreRegExpLiterals": true,
-            "ignoreStrings": true,
-            "ignoreTemplateLiterals": true,
-            "ignoreUrls": true
-        }],
-        "no-else-return": "error",
-        "no-unused-vars": ["error", {"varsIgnorePattern": "^_$"}],
-        "prefer-arrow/prefer-arrow-functions": "error",
-        "quote-props": ["error", "as-needed"],
-        "require-jsdoc": "off"
-    },
-    "env": {
-        "es6": true,
-        "mocha": true,
-        "node": true
-    }
+  "extends": ["eslint:recommended", "google"],
+  "plugins": ["prefer-arrow"],
+  "parser": "babel-eslint",
+  "parserOptions": {
+    "ecmaVersion": 8
+  },
+  "rules": {
+    "comma-dangle": ["error", "never"],
+    "curly": ["error", "all"],
+    "max-len": [
+      "error",
+      {
+        "ignoreRegExpLiterals": true,
+        "ignoreStrings": true,
+        "ignoreTemplateLiterals": true,
+        "ignoreUrls": true
+      }
+    ],
+    "no-else-return": "error",
+    "no-unused-vars": ["error", { "varsIgnorePattern": "^_$" }],
+    "prefer-arrow/prefer-arrow-functions": "error",
+    "quote-props": ["error", "as-needed"],
+    "require-jsdoc": "off"
+  },
+  "env": {
+    "es6": true,
+    "mocha": true,
+    "node": true
+  }
 }

--- a/.prettierignore
+++ b/.prettierignore
@@ -1,0 +1,5 @@
+.nyc_output/
+coverage/
+generated/
+node_modules/
+tests.json

--- a/DESIGN.md
+++ b/DESIGN.md
@@ -14,7 +14,7 @@ interpreted with knowledge of what the test does.
 
 ### Writing custom tests
 
-The `custom-tests.json` file is used to write custom tests for APIs and CSS properties that cannot be tested with a simple statement (for example, WebGL extensions).  Custom tests are written in the following structure:
+The `custom-tests.json` file is used to write custom tests for APIs and CSS properties that cannot be tested with a simple statement (for example, WebGL extensions). Custom tests are written in the following structure:
 
 #### APIs
 
@@ -31,15 +31,15 @@ Each API interface is written in the following structure:
 }
 ```
 
-`__base` is the common code to access the interface, repeated across every test.  This is where you create your elements and set up your environment.  The instance of the interface being tested should be defined in a variable called `instance`.  This will allow the build script to automatically generate tests for the instance and its members.
+`__base` is the common code to access the interface, repeated across every test. This is where you create your elements and set up your environment. The instance of the interface being tested should be defined in a variable called `instance`. This will allow the build script to automatically generate tests for the instance and its members.
 
-You can define a custom method to test the interface instance itself via `__test`.  The `__test` should be a return statement that returns `true` or `false`.  If no `__test` is defined, it will default to `return !!instance`.
+You can define a custom method to test the interface instance itself via `__test`. The `__test` should be a return statement that returns `true` or `false`. If no `__test` is defined, it will default to `return !!instance`.
 
-Each member can have a custom test by defining a property as the member name.  Like `__test`, it should be a return statement that returns `true` or `false`.  If no custom test is defined, it will default to `return instance && 'MEMBER' in instance`.
+Each member can have a custom test by defining a property as the member name. Like `__test`, it should be a return statement that returns `true` or `false`. If no custom test is defined, it will default to `return instance && 'MEMBER' in instance`.
 
 Note: If an interface with a `__base` has a constructor test, but a custom test isn't defined for the constructor, the code will default to normal generation.
 
-Additional members and submembers can be defined using the `__additional` property.  If there is a subfeature to an API or one of its members, such as "api.AudioContext.AudioContext.latencyHint", that simply cannot be defined within IDL, you can include this object and specify tests for such subfeatures.
+Additional members and submembers can be defined using the `__additional` property. If there is a subfeature to an API or one of its members, such as "api.AudioContext.AudioContext.latencyHint", that simply cannot be defined within IDL, you can include this object and specify tests for such subfeatures.
 
 Each test will compile into a function as follows: `function() {__base + __test/MEMBER/SUBFEATURE}`
 
@@ -59,11 +59,9 @@ The following JSON...
       "__additional": {
         "remove_duplicates": "var elm = document.createElement('b'); elm.className = ' foo bar foo '; elm.classList.remove('bar'); return elm.className === 'foo';"
       }
-    },
+    }
   },
-  "css": {
-
-  }
+  "css": {}
 }
 ```
 
@@ -99,9 +97,7 @@ The following JSON...
 
 ```json
 {
-  "api": {
-
-  },
+  "api": {},
   "css": {
     "properties": {
       "custom-property": "return CSS.supports('color', 'var(--foo)') || CSS.supports('color', 'env(--foo)');"
@@ -113,14 +109,18 @@ The following JSON...
 ...will compile into...
 
 ```javascript
-bcd.addTest('css.properties.custom-property', "(function() {return CSS.supports('color', 'var(--foo)') || CSS.supports('color', 'env(--foo)');})()", 'CSS');
+bcd.addTest(
+  "css.properties.custom-property",
+  "(function() {return CSS.supports('color', 'var(--foo)') || CSS.supports('color', 'env(--foo)');})()",
+  "CSS"
+);
 ```
 
 Tips: make sure that all return statements will return a boolean, and implement thorough feature checking.
 
 #### Importing code from other tests
 
-Sometimes, some features will depend on the setup and configuration from other features, especially with APIs.  To prevent repeating the same code over and over again, you can import code from other custom tests to build new ones quicker.  The syntax to specify a test import is the following: `<%ident:varname%>`, where `ident` is the full identifier to import from, and `varname` is what to rename the `instance` variable from that test to.
+Sometimes, some features will depend on the setup and configuration from other features, especially with APIs. To prevent repeating the same code over and over again, you can import code from other custom tests to build new ones quicker. The syntax to specify a test import is the following: `<%ident:varname%>`, where `ident` is the full identifier to import from, and `varname` is what to rename the `instance` variable from that test to.
 
 Example:
 
@@ -142,8 +142,16 @@ The following JSON...
 ...will compile into...
 
 ```javascript
-bcd.addTest('api.AudioContext', "(function() {var instance = new (window.AudioContext || window.webkitAudioContext)();})()", 'Window');
-bcd.addTest('api.AudioDestinationNode', "(function() {var instance = new (window.AudioContext || window.webkitAudioContext)(); if (!audioCtx) {return false}; var instance = audioCtx.destination;})()", 'Window');
+bcd.addTest(
+  "api.AudioContext",
+  "(function() {var instance = new (window.AudioContext || window.webkitAudioContext)();})()",
+  "Window"
+);
+bcd.addTest(
+  "api.AudioDestinationNode",
+  "(function() {var instance = new (window.AudioContext || window.webkitAudioContext)(); if (!audioCtx) {return false}; var instance = audioCtx.destination;})()",
+  "Window"
+);
 ```
 
 Note: if the specified `ident` cannot be found, the code will be replaced with a error to throw indicating as such.
@@ -274,4 +282,4 @@ entirely static.
 
 ## Reports
 
-A JSON report file is automatically generated and submitted to https://github.com/foolip/mdn-bcd-results as a pull request.  A user can also download the JSON report by visiting `/api/results` (of which is linked at the end of the tests).
+A JSON report file is automatically generated and submitted to https://github.com/foolip/mdn-bcd-results as a pull request. A user can also download the JSON report by visiting `/api/results` (of which is linked at the end of the tests).

--- a/README.md
+++ b/README.md
@@ -31,6 +31,7 @@ npm run deploy
 ```
 
 This step is performed automatically when the `main` or `prod` branches are pushed:
+
 - `main` deploys to https://staging-dot-mdn-bcd-collector.appspot.com/
 - `prod` deploys to https://mdn-bcd-collector.appspot.com/
 
@@ -43,7 +44,7 @@ npm run selenium
 ```
 
 You must configure your Selenium remote in `secrets.json`; local environments
-are not supported.  You may use any testing service, such as SauceLabs,
+are not supported. You may use any testing service, such as SauceLabs,
 BrowserStack, LambdaTest, etc. -- please check with your provider on how to
 configure your WebDriver URL.
 

--- a/build.js
+++ b/build.js
@@ -55,7 +55,7 @@ const compileCustomTest = (code, format = true) => {
 
   if (format) {
     // Wrap in a function
-    code = `(function() {${code}})()`;
+    code = `(function () {${code}})()`;
 
     // Format
     code = prettier.format(code, {parser: 'babel'});

--- a/build.js
+++ b/build.js
@@ -39,7 +39,7 @@ const writeFile = async (filename, content) => {
 
 const compileCustomTest = (code, format = true) => {
   // Import code from other tests
-  code.replace(/<%(\w+)\.(\w+)(?:.(\w+))?:(\w+)%> ?/g, (match, category, name, member, instancevar) => {
+  code = code.replace(/<%(\w+)\.(\w+)(?:\.(\w+))?:(\w+)%> ?/g, (match, category, name, member, instancevar) => {
     if (category === 'api') {
       if (!(name in customTests.api && '__base' in customTests.api[name])) {
         return `throw 'Test is malformed: ${match} is an invalid reference';`;

--- a/build.js
+++ b/build.js
@@ -18,6 +18,7 @@ const fs = require('fs-extra');
 const path = require('path');
 const WebIDL2 = require('webidl2');
 const bcd = require('mdn-browser-compat-data');
+const prettier = require('prettier');
 
 const customTests = require('./custom-tests.json');
 const specData = require('./spec-data');
@@ -56,9 +57,8 @@ const compileCustomTest = (code, format = true) => {
     // Wrap in a function
     code = `(function() {${code}})()`;
 
-    // Format (TODO: replace with Prettier)
-    code = code.replace(/{/g, '{\n')
-        .replace(/; ?/g, ';\n');
+    // Format
+    code = prettier.format(code, {parser: 'babel'});
   }
 
   return code;

--- a/build.js
+++ b/build.js
@@ -58,7 +58,7 @@ const compileCustomTest = (code, format = true) => {
     code = `(function () {${code}})()`;
 
     // Format
-    code = prettier.format(code, {parser: 'babel'});
+    code = prettier.format(code, {singleQuote: true, parser: 'babel'});
   }
 
   return code;

--- a/build.js
+++ b/build.js
@@ -58,7 +58,7 @@ const compileCustomTest = (code, format = true) => {
     code = `(function () {${code}})()`;
 
     // Format
-    code = prettier.format(code, {singleQuote: true, parser: 'babel'});
+    code = prettier.format(code, {singleQuote: true, parser: 'babel'}).trim();
   }
 
   return code;

--- a/custom-tests.json
+++ b/custom-tests.json
@@ -13,7 +13,7 @@
       "__base": "<%api.AudioContext:audioCtx%> if (!audioCtx) {return false}; var instance = audioCtx.createBufferSource();"
     },
     "AudioContext": {
-      "__todo": "Separate into different prefix variations when able",
+      "__TODO": "Separate into different prefix variations when able",
       "__base": "var instance = new (window.AudioContext || window.webkitAudioContext)();"
     },
     "AudioDestinationNode": {
@@ -30,11 +30,11 @@
     },
     "AudioParamMap": {
       "__TODO": "DEPENDS ON PROMISE TESTING SUPPORT",
-      "__base": "<%api.AudioWorkletNode:worklet%> if (!worklet) {return false}; var instance = worklet.parameters;"
+      "__base.disabled": "<%api.AudioWorkletNode:worklet%> if (!worklet) {return false}; var instance = worklet.parameters;"
     },
     "AudioWorkletNode": {
       "__TODO": "DEPENDS ON PROMISE TESTING SUPPORT",
-      "__base": "<%api.AudioContext:audioCtx%> if (!audioCtx) {return false}; await audioCtx.audioWorklet.addModule('/resources/custom-tests/api/AudioWorkletNode/WhiteNoiseProcessor.js'); var instance = new AudioWorkletNode(audioCtx, 'white-noise-processor');"
+      "__base.disabled": "<%api.AudioContext:audioCtx%> if (!audioCtx) {return false}; await audioCtx.audioWorklet.addModule('/resources/custom-tests/api/AudioWorkletNode/WhiteNoiseProcessor.js'); var instance = new AudioWorkletNode(audioCtx, 'white-noise-processor');"
     },
     "BiquadFilterNode": {
       "__base": "<%api.AudioContext:audioCtx%> if (!audioCtx) {return false}; var instance = audioCtx.createBiquadFilter();"

--- a/package-lock.json
+++ b/package-lock.json
@@ -5138,6 +5138,12 @@
       "integrity": "sha1-6SQ0v6XqjBn0HN/UAddBo8gZ2Jc=",
       "dev": true
     },
+    "prettier": {
+      "version": "2.1.2",
+      "resolved": "https://registry.npmjs.org/prettier/-/prettier-2.1.2.tgz",
+      "integrity": "sha512-16c7K+x4qVlJg9rEbXl7HEGmQyZlG4R9AgP+oHKRMsMsuk8s+ATStlf1NpDqyBI1HpVyfjLOeMhH2LvuNvV5Vg==",
+      "dev": true
+    },
     "process-nextick-args": {
       "version": "2.0.1",
       "resolved": "https://registry.npmjs.org/process-nextick-args/-/process-nextick-args-2.0.1.tgz",

--- a/package.json
+++ b/package.json
@@ -61,6 +61,7 @@
     "nodemon": "2.0.4",
     "nyc": "15.1.0",
     "open-cli": "6.0.1",
+    "prettier": "2.1.2",
     "proxyquire": "2.1.3",
     "puppeteer": "5.3.0",
     "puppeteer-to-istanbul": "1.4.0",

--- a/package.json
+++ b/package.json
@@ -13,8 +13,8 @@
   },
   "scripts": {
     "prepare": "if [ -d node_modules/puppeteer ]; then cd node_modules/puppeteer && PUPPETEER_PRODUCT=firefox node install.js; fi",
-    "lint": "eslint . && ejslint views/*",
-    "lint-fix": "eslint --fix .",
+    "lint": "eslint . && prettier -c '**/*.json' '**/*.md' --color && ejslint views/*",
+    "lint-fix": "eslint --fix . && prettier --write '**/*.json' '**/*.md'",
     "clean": "rm -rf .nyc_output coverage generated tests.json",
     "build": "node build.js",
     "gcp-build": "npm run build",

--- a/static/.eslintrc.json
+++ b/static/.eslintrc.json
@@ -1,22 +1,25 @@
 {
-    "extends": ["eslint:recommended", "google"],
-    "parserOptions": {
-        "ecmaVersion": 3
-    },
-    "rules": {
-        "comma-dangle": ["error", "never"],
-        "curly": ["error", "all"],
-        "guard-for-in": "off",
-        "max-len": ["error", {
-            "ignoreRegExpLiterals": true,
-            "ignoreStrings": true,
-            "ignoreTemplateLiterals": true,
-            "ignoreUrls": true
-        }],
-        "no-invalid-this": "off",
-        "no-var": "off",
-        "prefer-arrow/prefer-arrow-functions": "off",
-        "require-jsdoc": "off"
-    },
-    "root": true
+  "extends": ["eslint:recommended", "google"],
+  "parserOptions": {
+    "ecmaVersion": 3
+  },
+  "rules": {
+    "comma-dangle": ["error", "never"],
+    "curly": ["error", "all"],
+    "guard-for-in": "off",
+    "max-len": [
+      "error",
+      {
+        "ignoreRegExpLiterals": true,
+        "ignoreStrings": true,
+        "ignoreTemplateLiterals": true,
+        "ignoreUrls": true
+      }
+    ],
+    "no-invalid-this": "off",
+    "no-var": "off",
+    "prefer-arrow/prefer-arrow-functions": "off",
+    "require-jsdoc": "off"
+  },
+  "root": true
 }

--- a/static/resources/custom-tests/api/AudioWorkletNode/.eslintrc.json
+++ b/static/resources/custom-tests/api/AudioWorkletNode/.eslintrc.json
@@ -1,6 +1,5 @@
 {
-    "parserOptions": {
-        "ecmaVersion": 6
-    }
+  "parserOptions": {
+    "ecmaVersion": 6
+  }
 }
-

--- a/unittest/unit/build.js
+++ b/unittest/unit/build.js
@@ -104,14 +104,14 @@ describe('build', () => {
       it('interface', () => {
         assert.equal(
             getCustomTestAPI('foo'),
-            '(function() {\nvar a = 1;\nreturn a;\n})()'
+            '(function () {\n  var a = 1;\n  return a;\n})();'
         );
       });
 
       it('member', () => {
         assert.equal(
             getCustomTestAPI('foo', 'bar'),
-            '(function() {\nvar a = 1;\nreturn \'bar\' in instance;\n})()'
+            '(function () {\n  var a = 1;\n  return \'bar\' in instance;\n})();'
         );
       });
 
@@ -132,7 +132,7 @@ describe('build', () => {
       });
 
       it('interface', () => {
-        assert.equal(getCustomTestAPI('foo'), '(function() {\nreturn 1;\n})()');
+        assert.equal(getCustomTestAPI('foo'), '(function () {\n  return 1;\n})();');
       });
 
       it('member', () => {
@@ -155,14 +155,14 @@ describe('build', () => {
       it('interface', () => {
         assert.equal(
             getCustomTestAPI('foo'),
-            '(function() {\nvar a = 1;\nreturn !!instance;\n})()'
+            '(function () {\n  var a = 1;\n  return !!instance;\n});()'
         );
       });
 
       it('member', () => {
         assert.equal(
             getCustomTestAPI('foo', 'bar'),
-            '(function() {\nvar a = 1;\nreturn a + 1;\n})()'
+            '(function () {\n  var a = 1;\n  return a + 1;\n});()'
         );
       });
     });
@@ -185,7 +185,7 @@ describe('build', () => {
       it('member', () => {
         assert.equal(
             getCustomTestAPI('foo', 'bar'),
-            '(function() {\nreturn 1 + 1;\n})()'
+            '(function () {\n  return 1 + 1;\n});()'
         );
       });
     });
@@ -212,7 +212,7 @@ describe('build', () => {
       it('member', () => {
         assert.equal(
             getCustomTestAPI('foo', 'bar'),
-            '(function() {\nreturn 1 + 1;\n})()'
+            '(function () {\n  return 1 + 1;\n});()'
         );
       });
     });
@@ -233,14 +233,14 @@ describe('build', () => {
       it('interface', () => {
         assert.equal(
             getCustomTestAPI('foo'),
-            '(function() {\nvar a = 1;\nreturn a;\n})()'
+            '(function () {\n  var a = 1;\n  return a;\n});()'
         );
       });
 
       it('member', () => {
         assert.equal(
             getCustomTestAPI('foo', 'bar'),
-            '(function() {\nvar a = 1;\nreturn a + 1;\n})()'
+            '(function () {\n  var a = 1;\n  return a + 1;\n});()'
         );
       });
     });
@@ -268,19 +268,19 @@ describe('build', () => {
       it('valid import', () => {
         assert.equal(
             getCustomTestAPI('bar'),
-            '(function() {\nvar a = 1;\nvar instance = a;\nreturn !!instance;\n})()'
+            '(function () {\n  var a = 1;\n  var instance = a;\n  return !!instance;\n});()'
         );
 
         assert.equal(
             getCustomTestAPI('baz'),
-            '(function() {\nvar a = 1;\nvar b = a;\nvar instance = b;\nreturn !!instance;\n})()'
+            '(function () {\n  var a = 1;\n  var b = a;\n  var instance = b;\n  return !!instance;\n});()'
         );
       });
 
       it('invalid import', () => {
         assert.equal(
             getCustomTestAPI('bad'),
-            '(function() {\nthrow \'Test is malformed: <%api.foobar:apple%> is an invalid reference\';\nreturn !!instance;\n})()'
+            '(function () {\n  throw \'Test is malformed: <%api.foobar:apple%> is an invalid reference\';\n  return !!instance;\n});()'
         );
       });
     });
@@ -304,8 +304,8 @@ describe('build', () => {
       assert.deepEqual(
           getCustomSubtestsAPI('foo', 'bar'),
           {
-            multiple: '(function() {\nreturn 1 + 1 + 1;\n})()',
-            'one.only': '(function() {\nreturn 1;\n})()'
+            multiple: '(function () {\n  return 1 + 1 + 1;\n})(;)',
+            'one.only': '(function () {\n  return 1;\n});()'
           }
       );
     });
@@ -331,7 +331,7 @@ describe('build', () => {
         }
       });
 
-      assert.equal(getCustomTestCSS('foo'), '(function() {\nreturn 1;\n})()');
+      assert.equal(getCustomTestCSS('foo'), '(function () {\nreturn 1;\n})();');
     });
 
     it('import (not implemented)', () => {
@@ -346,7 +346,7 @@ describe('build', () => {
         }
       });
 
-      assert.equal(getCustomTestCSS('bar'), '(function() {\nthrow \'Test is malformed: import <%css.properties.foo:a%>, category css is not importable\';\n})()');
+      assert.equal(getCustomTestCSS('bar'), '(function () {\n  throw \'Test is malformed: import <%css.properties.foo:a%>, category css is not importable\';\n})();');
     });
   });
 
@@ -1165,7 +1165,7 @@ describe('build', () => {
         'api.ANGLE_instanced_arrays': {
           tests: [
             {
-              code: '(function() {\nvar canvas = document.createElement(\'canvas\');\nvar gl = canvas.getContext(\'webgl\');\nvar instance = gl.getExtension(\'ANGLE_instanced_arrays\');\nreturn !!instance;\n})()',
+              code: '(function () {\nvar canvas = document.createElement(\'canvas\');\nvar gl = canvas.getContext(\'webgl\');\nvar instance = gl.getExtension(\'ANGLE_instanced_arrays\');\nreturn !!instance;\n})(;)',
               prefix: ''
             }
           ],
@@ -1175,7 +1175,7 @@ describe('build', () => {
         'api.ANGLE_instanced_arrays.drawArraysInstancedANGLE': {
           tests: [
             {
-              code: '(function() {\nvar canvas = document.createElement(\'canvas\');\nvar gl = canvas.getContext(\'webgl\');\nvar instance = gl.getExtension(\'ANGLE_instanced_arrays\');\nreturn true && instance && \'drawArraysInstancedANGLE\' in instance;\n})()',
+              code: '(function () {\nvar canvas = document.createElement(\'canvas\');\nvar gl = canvas.getContext(\'webgl\');\nvar instance = gl.getExtension(\'ANGLE_instanced_arrays\');\nreturn true && instance && \'drawArraysInstancedANGLE\' in instance;\n})(;)',
               prefix: ''
             }
           ],
@@ -1185,7 +1185,7 @@ describe('build', () => {
         'api.ANGLE_instanced_arrays.drawElementsInstancedANGLE': {
           tests: [
             {
-              code: '(function() {\nvar canvas = document.createElement(\'canvas\');\nvar gl = canvas.getContext(\'webgl\');\nvar instance = gl.getExtension(\'ANGLE_instanced_arrays\');\nreturn \'drawElementsInstancedANGLE\' in instance;\n})()',
+              code: '(function () {\nvar canvas = document.createElement(\'canvas\');\nvar gl = canvas.getContext(\'webgl\');\nvar instance = gl.getExtension(\'ANGLE_instanced_arrays\');\nreturn \'drawElementsInstancedANGLE\' in instance;\n})(;)',
               prefix: ''
             }
           ],
@@ -1205,7 +1205,7 @@ describe('build', () => {
         'api.Document.charset': {
           tests: [
             {
-              code: '(function() {\nreturn document.charset == "UTF-8";\n})()',
+              code: '(function () {\nreturn document.charset == "UTF-8";\n})(;)',
               prefix: ''
             }
           ],
@@ -1225,7 +1225,7 @@ describe('build', () => {
         'api.Document.loaded.loaded_is_boolean': {
           tests: [
             {
-              code: '(function() {\nreturn typeof document.loaded === "boolean";\n})()',
+              code: '(function () {\nreturn typeof document.loaded === "boolean";\n})(;)',
               prefix: ''
             }
           ],
@@ -1803,7 +1803,7 @@ describe('build', () => {
         'api.CSS': {
           tests: [
             {
-              code: '(function() {\nvar css = CSS;\nreturn !!css;\n})()',
+              code: '(function () {\nvar css = CSS;\nreturn !!css;\n})(;)',
               prefix: ''
             }
           ],
@@ -1813,7 +1813,7 @@ describe('build', () => {
         'api.CSS.paintWorklet': {
           tests: [
             {
-              code: '(function() {\nvar css = CSS;\nreturn css && \'paintWorklet\' in css;\n})()',
+              code: '(function () {\nvar css = CSS;\nreturn css && \'paintWorklet\' in css;\n})(;)',
               prefix: ''
             }
           ],

--- a/unittest/unit/build.js
+++ b/unittest/unit/build.js
@@ -255,6 +255,9 @@ describe('build', () => {
             bar: {
               __base: '<%api.foo:a%> var instance = a;'
             },
+            baz: {
+              __base: '<%api.bar:b%> var instance = b;'
+            },
             bad: {
               __base: '<%api.foobar:apple%>'
             }
@@ -266,6 +269,11 @@ describe('build', () => {
         assert.equal(
             getCustomTestAPI('bar'),
             '(function() {\nvar a = 1;\nvar instance = a;\nreturn !!instance;\n})()'
+        );
+
+        assert.equal(
+            getCustomTestAPI('baz'),
+            '(function() {\nvar a = 1;\nvar b = a;\nvar instance = b;\nreturn !!instance;\n})()'
         );
       });
 

--- a/unittest/unit/build.js
+++ b/unittest/unit/build.js
@@ -155,14 +155,14 @@ describe('build', () => {
       it('interface', () => {
         assert.equal(
             getCustomTestAPI('foo'),
-            '(function () {\n  var a = 1;\n  return !!instance;\n});()'
+            '(function () {\n  var a = 1;\n  return !!instance;\n})();'
         );
       });
 
       it('member', () => {
         assert.equal(
             getCustomTestAPI('foo', 'bar'),
-            '(function () {\n  var a = 1;\n  return a + 1;\n});()'
+            '(function () {\n  var a = 1;\n  return a + 1;\n})();'
         );
       });
     });
@@ -185,7 +185,7 @@ describe('build', () => {
       it('member', () => {
         assert.equal(
             getCustomTestAPI('foo', 'bar'),
-            '(function () {\n  return 1 + 1;\n});()'
+            '(function () {\n  return 1 + 1;\n})();'
         );
       });
     });
@@ -212,7 +212,7 @@ describe('build', () => {
       it('member', () => {
         assert.equal(
             getCustomTestAPI('foo', 'bar'),
-            '(function () {\n  return 1 + 1;\n});()'
+            '(function () {\n  return 1 + 1;\n})();'
         );
       });
     });
@@ -233,14 +233,14 @@ describe('build', () => {
       it('interface', () => {
         assert.equal(
             getCustomTestAPI('foo'),
-            '(function () {\n  var a = 1;\n  return a;\n});()'
+            '(function () {\n  var a = 1;\n  return a;\n})();'
         );
       });
 
       it('member', () => {
         assert.equal(
             getCustomTestAPI('foo', 'bar'),
-            '(function () {\n  var a = 1;\n  return a + 1;\n});()'
+            '(function () {\n  var a = 1;\n  return a + 1;\n})();'
         );
       });
     });
@@ -268,19 +268,19 @@ describe('build', () => {
       it('valid import', () => {
         assert.equal(
             getCustomTestAPI('bar'),
-            '(function () {\n  var a = 1;\n  var instance = a;\n  return !!instance;\n});()'
+            '(function () {\n  var a = 1;\n  var instance = a;\n  return !!instance;\n})();'
         );
 
         assert.equal(
             getCustomTestAPI('baz'),
-            '(function () {\n  var a = 1;\n  var b = a;\n  var instance = b;\n  return !!instance;\n});()'
+            '(function () {\n  var a = 1;\n  var b = a;\n  var instance = b;\n  return !!instance;\n})();'
         );
       });
 
       it('invalid import', () => {
         assert.equal(
             getCustomTestAPI('bad'),
-            '(function () {\n  throw \'Test is malformed: <%api.foobar:apple%> is an invalid reference\';\n  return !!instance;\n});()'
+            '(function () {\n  throw \'Test is malformed: <%api.foobar:apple%> is an invalid reference\';\n  return !!instance;\n})();'
         );
       });
     });
@@ -304,8 +304,8 @@ describe('build', () => {
       assert.deepEqual(
           getCustomSubtestsAPI('foo', 'bar'),
           {
-            multiple: '(function () {\n  return 1 + 1 + 1;\n})(;)',
-            'one.only': '(function () {\n  return 1;\n});()'
+            multiple: '(function () {\n  return 1 + 1 + 1;\n})();',
+            'one.only': '(function () {\n  return 1;\n})();'
           }
       );
     });
@@ -331,7 +331,7 @@ describe('build', () => {
         }
       });
 
-      assert.equal(getCustomTestCSS('foo'), '(function () {\nreturn 1;\n})();');
+      assert.equal(getCustomTestCSS('foo'), '(function () {\n  return 1;\n})();');
     });
 
     it('import (not implemented)', () => {
@@ -1165,7 +1165,7 @@ describe('build', () => {
         'api.ANGLE_instanced_arrays': {
           tests: [
             {
-              code: '(function () {\nvar canvas = document.createElement(\'canvas\');\nvar gl = canvas.getContext(\'webgl\');\nvar instance = gl.getExtension(\'ANGLE_instanced_arrays\');\nreturn !!instance;\n})(;)',
+              code: '(function () {\n  var canvas = document.createElement(\'canvas\');\n  var gl = canvas.getContext(\'webgl\');\n  var instance = gl.getExtension(\'ANGLE_instanced_arrays\');\n  return !!instance;\n})();',
               prefix: ''
             }
           ],
@@ -1175,7 +1175,7 @@ describe('build', () => {
         'api.ANGLE_instanced_arrays.drawArraysInstancedANGLE': {
           tests: [
             {
-              code: '(function () {\nvar canvas = document.createElement(\'canvas\');\nvar gl = canvas.getContext(\'webgl\');\nvar instance = gl.getExtension(\'ANGLE_instanced_arrays\');\nreturn true && instance && \'drawArraysInstancedANGLE\' in instance;\n})(;)',
+              code: '(function () {\n  var canvas = document.createElement(\'canvas\');\n  var gl = canvas.getContext(\'webgl\');\n  var instance = gl.getExtension(\'ANGLE_instanced_arrays\');\n  return true && instance && \'drawArraysInstancedANGLE\' in instance;\n})();',
               prefix: ''
             }
           ],
@@ -1185,7 +1185,7 @@ describe('build', () => {
         'api.ANGLE_instanced_arrays.drawElementsInstancedANGLE': {
           tests: [
             {
-              code: '(function () {\nvar canvas = document.createElement(\'canvas\');\nvar gl = canvas.getContext(\'webgl\');\nvar instance = gl.getExtension(\'ANGLE_instanced_arrays\');\nreturn \'drawElementsInstancedANGLE\' in instance;\n})(;)',
+              code: '(function () {\n  var canvas = document.createElement(\'canvas\');\n  var gl = canvas.getContext(\'webgl\');\n  var instance = gl.getExtension(\'ANGLE_instanced_arrays\');\n  return \'drawElementsInstancedANGLE\' in instance;\n})();',
               prefix: ''
             }
           ],
@@ -1205,7 +1205,7 @@ describe('build', () => {
         'api.Document.charset': {
           tests: [
             {
-              code: '(function () {\nreturn document.charset == "UTF-8";\n})(;)',
+              code: '(function () {\n  return document.charset == \'UTF-8\';\n})();',
               prefix: ''
             }
           ],
@@ -1225,7 +1225,7 @@ describe('build', () => {
         'api.Document.loaded.loaded_is_boolean': {
           tests: [
             {
-              code: '(function () {\nreturn typeof document.loaded === "boolean";\n})(;)',
+              code: '(function () {\n  return typeof document.loaded === \'boolean\';\n})();',
               prefix: ''
             }
           ],
@@ -1803,7 +1803,7 @@ describe('build', () => {
         'api.CSS': {
           tests: [
             {
-              code: '(function () {\nvar css = CSS;\nreturn !!css;\n})(;)',
+              code: '(function () {\n  var css = CSS;\n  return !!css;\n})();',
               prefix: ''
             }
           ],
@@ -1813,7 +1813,7 @@ describe('build', () => {
         'api.CSS.paintWorklet': {
           tests: [
             {
-              code: '(function () {\nvar css = CSS;\nreturn css && \'paintWorklet\' in css;\n})(;)',
+              code: '(function () {\n  var css = CSS;\n  return css && \'paintWorklet\' in css;\n})();',
               prefix: ''
             }
           ],


### PR DESCRIPTION
This PR imports Prettier and configures it for two purposes:

1) To format the Markdown and JSON files within the repository
2) To format and beautify custom tests