### PR TITLE
Bump version number to 0.3.0

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -1,6 +1,6 @@
 {
   "name": "mdn-bcd-collector",
-  "version": "0.2.2",
+  "version": "0.3.0",
   "lockfileVersion": 1,
   "requires": true,
   "dependencies": {

--- a/package.json
+++ b/package.json
@@ -1,7 +1,7 @@
 {
   "name": "mdn-bcd-collector",
   "description": "Data collection service for mdn/browser-compat-data",
-  "version": "0.2.2",
+  "version": "0.3.0",
   "private": true,
   "license": "Apache-2.0",
   "repository": {


### PR DESCRIPTION
Since we've added some new functionality, this preemptively bumps the version number to 0.3.0 for the next production release.