### PR TITLE
Always generate ranges for update-bcd

### DIFF
--- a/update-bcd.js
+++ b/update-bcd.js
@@ -234,9 +234,11 @@ const inferSupportStatements = (versionMap) => {
 
     if (supported === true) {
       if (!lastStatement) {
+        let versionAdded = (
+            (lastWasNull || lastKnown.support === false) ? '≤' : ''
+          ) + version;
         statements.push({
-          version_added: (lastWasNull || lastKnown.support === false) ?
-              true : version,
+          version_added: versionAdded,
           ...(prefix && {prefix: prefix})
         });
       } else if (!lastStatement.version_added) {
@@ -265,8 +267,9 @@ const inferSupportStatements = (versionMap) => {
         lastStatement.version_added &&
         !lastStatement.version_removed
       ) {
-        lastStatement.version_removed =
-          (!lastWasNull || lastKnown.support === false) ? version : true;
+        lastStatement.version_removed = (
+            (lastWasNull || lastKnown.support === false) ? '' : '≤'
+          ) + version;
       } else if (!lastStatement) {
         statements.push({version_added: false});
       }

--- a/update-bcd.js
+++ b/update-bcd.js
@@ -234,11 +234,10 @@ const inferSupportStatements = (versionMap) => {
 
     if (supported === true) {
       if (!lastStatement) {
-        let versionAdded = (
-            (lastWasNull || lastKnown.support === false) ? '≤' : ''
-          ) + version;
         statements.push({
-          version_added: versionAdded,
+          version_added: (
+            (lastWasNull || lastKnown.support === false) ? '≤' : ''
+          ) + version,
           ...(prefix && {prefix: prefix})
         });
       } else if (!lastStatement.version_added) {
@@ -269,7 +268,7 @@ const inferSupportStatements = (versionMap) => {
       ) {
         lastStatement.version_removed = (
             (lastWasNull || lastKnown.support === false) ? '' : '≤'
-          ) + version;
+        ) + version;
       } else if (!lastStatement) {
         statements.push({version_added: false});
       }


### PR DESCRIPTION
This PR changes `update-bcd` to, rather than produce `true` if data is inconclusive, generate a range.  While this will cause the BCD linters to always fail, a reviewer can narrow it down better later.