### PR TITLE
Bump version number and upgrade to BCD 2.0.0

### DIFF
--- a/build.js
+++ b/build.js
@@ -17,7 +17,7 @@
 const fs = require('fs-extra');
 const path = require('path');
 const WebIDL2 = require('webidl2');
-const bcd = require('mdn-browser-compat-data');
+const bcd = require('@mdn/browser-compat-data');
 const prettier = require('prettier');
 
 const customTests = require('./custom-tests.json');

--- a/find-missing.js
+++ b/find-missing.js
@@ -1,6 +1,6 @@
 'use strict';
 
-const bcd = require('mdn-browser-compat-data');
+const bcd = require('@mdn/browser-compat-data');
 const tests = require('./tests.json');
 
 const traverseFeatures = (obj, identifier) => {

--- a/package-lock.json
+++ b/package-lock.json
@@ -551,6 +551,15 @@
       "integrity": "sha512-tsAQNx32a8CoFhjhijUIhI4kccIAgmGhy8LZMZgGfmXcpMbPRUqn5LWmgRttILi6yeGmBJd2xsPkFMs0PzgPCw==",
       "dev": true
     },
+    "@mdn/browser-compat-data": {
+      "version": "2.0.0",
+      "resolved": "https://registry.npmjs.org/@mdn/browser-compat-data/-/browser-compat-data-2.0.0.tgz",
+      "integrity": "sha512-roBXuLIX2HQ6BP+UuoXekJ9yENSE4JbeA9NpBgfg+zjSU4tnG2MpHeKaNsM48gj3gnhdBhi7wBjggE55zwCDAg==",
+      "dev": true,
+      "requires": {
+        "extend": "3.0.2"
+      }
+    },
     "@nodelib/fs.scandir": {
       "version": "2.1.3",
       "resolved": "https://registry.npmjs.org/@nodelib/fs.scandir/-/fs.scandir-2.1.3.tgz",
@@ -4316,15 +4325,6 @@
       "version": "4.1.0",
       "resolved": "https://registry.npmjs.org/map-obj/-/map-obj-4.1.0.tgz",
       "integrity": "sha512-glc9y00wgtwcDmp7GaE/0b0OnxpNJsVf3ael/An6Fe2Q51LLwN1er6sdomLRzz5h0+yMpiYLhWYF5R7HeqVd4g=="
-    },
-    "mdn-browser-compat-data": {
-      "version": "1.0.38",
-      "resolved": "https://registry.npmjs.org/mdn-browser-compat-data/-/mdn-browser-compat-data-1.0.38.tgz",
-      "integrity": "sha512-DXE8KYzmOp9eXpZ12NkprE2ggmhFCxlNRs47HnYgSuGc4SJLwHPXC/EMLrw5/5L42/sIewMV06jJ4DKCMNIYRQ==",
-      "dev": true,
-      "requires": {
-        "extend": "3.0.2"
-      }
     },
     "media-typer": {
       "version": "0.3.0",

--- a/package-lock.json
+++ b/package-lock.json
@@ -1,6 +1,6 @@
 {
   "name": "mdn-bcd-collector",
-  "version": "0.3.0",
+  "version": "0.3.1",
   "lockfileVersion": 1,
   "requires": true,
   "dependencies": {

--- a/package.json
+++ b/package.json
@@ -1,7 +1,7 @@
 {
   "name": "mdn-bcd-collector",
   "description": "Data collection service for mdn/browser-compat-data",
-  "version": "0.3.0",
+  "version": "0.3.1",
   "private": true,
   "license": "Apache-2.0",
   "repository": {

--- a/package.json
+++ b/package.json
@@ -56,7 +56,7 @@
     "fs-extra": "9.0.1",
     "json3": "3.3.3",
     "klaw": "3.0.0",
-    "mdn-browser-compat-data": "1.0.38",
+    "@mdn/browser-compat-data": "2.0.0",
     "mocha": "8.1.3",
     "mock-fs": "4.13.0",
     "nodemon": "2.0.4",

--- a/selenium.js
+++ b/selenium.js
@@ -21,7 +21,7 @@ const {
   logging,
   until
 } = require('selenium-webdriver');
-const bcd = require('mdn-browser-compat-data');
+const bcd = require('@mdn/browser-compat-data');
 const ora = require('ora');
 const path = require('path');
 


### PR DESCRIPTION
This PR bumps the version number to 0.3.1 and upgrades BCD to the new 2.0.0 release.