### PR TITLE
Improve update-bcd

### DIFF
--- a/update-bcd.js
+++ b/update-bcd.js
@@ -310,6 +310,8 @@ const update = (bcd, supportMatrix) => {
           simpleStatement.version_added = inferredStatement.version_added;
           modified = true;
         }
+      } else if (simpleStatement.version_removed) {
+        delete simpleStatement.version_removed;
       }
     }
   }

--- a/update-bcd.js
+++ b/update-bcd.js
@@ -284,9 +284,9 @@ const update = (bcd, supportMatrix) => {
         inferredStatement.version_added.includes('≤')
       ) {
         if (compareVersions.compare(
-          simpleStatement.version_added.replace('≤', ''),
-          inferredStatement.version_added.replace('≤', ''),
-          '>'
+            simpleStatement.version_added.replace('≤', ''),
+            inferredStatement.version_added.replace('≤', ''),
+            '>'
         )) {
           simpleStatement.version_added = inferredStatement.version_added;
           modified = true;
@@ -303,9 +303,9 @@ const update = (bcd, supportMatrix) => {
           inferredStatement.version_removed.includes('≤')
         ) {
           if (compareVersions.compare(
-            simpleStatement.version_removed.replace('≤', ''),
-            inferredStatement.version_removed.replace('≤', ''),
-            '>'
+              simpleStatement.version_removed.replace('≤', ''),
+              inferredStatement.version_removed.replace('≤', ''),
+              '>'
           )) {
             simpleStatement.version_removed = inferredStatement.version_removed;
             modified = true;

--- a/update-bcd.js
+++ b/update-bcd.js
@@ -257,6 +257,7 @@ const update = (bcd, supportMatrix) => {
             .filter((key) => !ignoreKeys.has(key));
         return keys.length === 1;
       });
+
       if (!simpleStatement) {
         // No simple statement probably means it's prefixed or under and
         // alternative name, but in any case implies that the main feature
@@ -273,17 +274,42 @@ const update = (bcd, supportMatrix) => {
         continue;
       }
 
-      if (!(typeof(simpleStatement.version_added) === 'string' &&
+      if (typeof(simpleStatement.version_added) === 'string' &&
+        typeof(inferredStatement.version_added) === 'string' &&
+        inferredStatement.version_added.includes('≤')
+      ) {
+        if (compareVersions.compare(
+          simpleStatement.version_added.replace('≤', ''),
+          inferredStatement.version_added.replace('≤', ''),
+          '>'
+        )) {
+          simpleStatement.version_added = inferredStatement.version_added;
+          modified = true;
+        }
+      } else if (!(typeof(simpleStatement.version_added) === 'string' &&
             inferredStatement.version_added === true)) {
         simpleStatement.version_added = inferredStatement.version_added;
         modified = true;
       }
 
-      if (inferredStatement.version_removed &&
-          !(typeof(simpleStatement.version_removed) === 'string' &&
-            inferredStatement.version_removed === true)) {
-        simpleStatement.version_removed = inferredStatement.version_removed;
-        modified = true;
+      if (inferredStatement.version_removed) {
+        if (typeof(simpleStatement.version_removed) === 'string' &&
+          typeof(inferredStatement.version_removed) === 'string' &&
+          inferredStatement.version_removed.includes('≤')
+        ) {
+          if (compareVersions.compare(
+            simpleStatement.version_removed.replace('≤', ''),
+            inferredStatement.version_removed.replace('≤', ''),
+            '>'
+          )) {
+            simpleStatement.version_removed = inferredStatement.version_removed;
+            modified = true;
+          }
+        } else if (!(typeof(simpleStatement.version_removed) === 'string' &&
+              inferredStatement.version_removed === true)) {
+          simpleStatement.version_added = inferredStatement.version_added;
+          modified = true;
+        }
       }
     }
   }

--- a/update-bcd.js
+++ b/update-bcd.js
@@ -73,6 +73,11 @@ const getSupportMap = (report) => {
     // eslint-disable-next-line no-unused-vars
     for (const {url, result, prefix} of results) {
       if (result === null) {
+        const parentName = name.split('.').slice(0, -1).join('.');
+        const parentSupport = supportMap.get(parentName);
+        if (parentSupport && parentSupport.result === false) {
+          supported.result = false;
+        }
         continue;
       }
       if (supported.result === null) {

--- a/update-bcd.js
+++ b/update-bcd.js
@@ -234,8 +234,8 @@ const update = (bcd, supportMatrix) => {
     }
 
     for (const [browser, versionMap] of browserMap.entries()) {
-      const inferredStatments = inferSupportStatements(versionMap);
-      if (inferredStatments.length !== 1) {
+      const inferredStatements = inferSupportStatements(versionMap);
+      if (inferredStatements.length !== 1) {
         // TODO: handle more complicated scenarios
         continue;
       }
@@ -259,8 +259,8 @@ const update = (bcd, supportMatrix) => {
         // No simple statement probably means it's prefixed or under and
         // alternative name, but in any case implies that the main feature
         // is not supported. So only update in case new data contradicts that.
-        if (inferredStatments.some((statement) => statement.version_added)) {
-          supportStatement.unshift(...inferredStatments);
+        if (inferredStatements.some((statement) => statement.version_added)) {
+          supportStatement.unshift(...inferredStatements);
           supportStatement = supportStatement.filter((item, pos, self) => {
             return pos === self.findIndex((el) => isEquivalent(el, item));
           });
@@ -272,15 +272,15 @@ const update = (bcd, supportMatrix) => {
       }
 
       if (!(typeof(simpleStatement.version_added) === 'string' &&
-            inferredStatments[0].version_added === true)) {
-        simpleStatement.version_added = inferredStatments[0].version_added;
+            inferredStatements[0].version_added === true)) {
+        simpleStatement.version_added = inferredStatements[0].version_added;
         modified = true;
       }
 
-      if (inferredStatments[0].version_removed &&
+      if (inferredStatements[0].version_removed &&
           !(typeof(simpleStatement.version_removed) === 'string' &&
-            inferredStatments[0].version_removed === true)) {
-        simpleStatement.version_removed = inferredStatments[0].version_removed;
+            inferredStatements[0].version_removed === true)) {
+        simpleStatement.version_removed = inferredStatements[0].version_removed;
         modified = true;
       }
     }

--- a/update-bcd.js
+++ b/update-bcd.js
@@ -11,7 +11,9 @@ const {isEquivalent} = require('./utils');
 const overrides = require('./overrides').filter(Array.isArray);
 
 const findEntry = (bcd, path) => {
-  if (!path) return null;
+  if (!path) {
+    return null;
+  }
   const keys = path.split('.');
   let entry = bcd;
   while (entry && keys.length) {

--- a/update-bcd.js
+++ b/update-bcd.js
@@ -240,6 +240,8 @@ const update = (bcd, supportMatrix) => {
         continue;
       }
 
+      const inferredStatement = inferredStatements[0];
+
       let supportStatement = entry.__compat.support[browser];
       if (!supportStatement) {
         // TODO: add a support statement
@@ -272,15 +274,15 @@ const update = (bcd, supportMatrix) => {
       }
 
       if (!(typeof(simpleStatement.version_added) === 'string' &&
-            inferredStatements[0].version_added === true)) {
-        simpleStatement.version_added = inferredStatements[0].version_added;
+            inferredStatement.version_added === true)) {
+        simpleStatement.version_added = inferredStatement.version_added;
         modified = true;
       }
 
-      if (inferredStatements[0].version_removed &&
+      if (inferredStatement.version_removed &&
           !(typeof(simpleStatement.version_removed) === 'string' &&
-            inferredStatements[0].version_removed === true)) {
-        simpleStatement.version_removed = inferredStatements[0].version_removed;
+            inferredStatement.version_removed === true)) {
+        simpleStatement.version_removed = inferredStatement.version_removed;
         modified = true;
       }
     }

--- a/update-bcd.js
+++ b/update-bcd.js
@@ -11,6 +11,7 @@ const {isEquivalent} = require('./utils');
 const overrides = require('./overrides').filter(Array.isArray);
 
 const findEntry = (bcd, path) => {
+  if (!path) return null;
   const keys = path.split('.');
   let entry = bcd;
   while (entry && keys.length) {


### PR DESCRIPTION
This PR provides a number of updates to the `update-bcd` script to improve its performance, including the following:

- If a version number in BCD doesn't contradict a generated range, don't replace it with the range
- Remove a version_removed if proven wrong
- Account for the support of the parent (fixes #506)