### PR TITLE
Test NODE_ENV=production to get closer to the real deal

### DIFF
--- a/.github/workflows/pull_request.yml
+++ b/.github/workflows/pull_request.yml
@@ -14,7 +14,13 @@ jobs:
     - run: npm run build
     - run: npm run unittest
     # ensure we can start the server without dev dependencies
-    - run: npm ci --production
-    - run: NODE_ENV=test npm start & npx wait-on -t 10000 -v http://localhost:8080
+    - name: production smoke test
+      run: |
+        npm ci
+        cp secrets.sample.json secrets.json
+        npm start &
+        npx wait-on -t 10000 -v http://localhost:8080
+      env:
+        NODE_ENV: production
 env:
   FORCE_COLOR: 3

--- a/logger.js
+++ b/logger.js
@@ -19,8 +19,7 @@ const {LoggingWinston} = require('@google-cloud/logging-winston');
 
 const getTransport = () => {
   /* istanbul ignore if */
-  if (process.env.NODE_ENV === 'production' ||
-      process.env.GOOGLE_APPLICATION_CREDENTIALS) {
+  if (process.env.GOOGLE_APPLICATION_CREDENTIALS) {
     return new LoggingWinston();
   }
   return new winston.transports.Console({


### PR DESCRIPTION
To make it possible to start with NODE_ENV=production outside of GAE,
tweak the logic in logger.js.
