### PR TITLE
Force LF when checking out

### DIFF
--- a/.gitattributes
+++ b/.gitattributes
@@ -1,0 +1,1 @@
+* text=auto eol=lf


### PR DESCRIPTION
Git for Windows uses CRLF by default while the eslint configuration requires LF. This makes sure git uses LF regardless of local git configuration.