### PR TITLE
Start tests even if all resources don't load

### DIFF
--- a/static/resources/harness.js
+++ b/static/resources/harness.js
@@ -290,10 +290,10 @@
     };
 
     var resourceTimeout = setTimeout(function() {
-        // If the resources don't load, just start the tests anyways
-        console.log('Timed out waiting for resources to load, starting tests anyways');
-        startTests();
-      }, 5000);
+      // If the resources don't load, just start the tests anyways
+      console.log('Timed out waiting for resources to load, starting tests anyways');
+      startTests();
+    }, 5000);
 
     if (resourceCount) {
       resources.required = resourceCount;

--- a/static/resources/harness.js
+++ b/static/resources/harness.js
@@ -311,10 +311,12 @@
         resourceElements[i].onloadeddata = resourceLoaded;
       }
 
-      // If the resources don't load, just start the tests anyways
       setTimeout(function() {
-        console.log('Timed out waiting for resources to load, starting tests anyways');
-        startTests();
+        if (!resources.testStarted) {
+          // If the resources don't load, just start the tests anyways
+          console.log('Timed out waiting for resources to load, starting tests anyways');
+          startTests();
+        }
       }, 5000);
     } else {
       startTests();

--- a/static/resources/harness.js
+++ b/static/resources/harness.js
@@ -289,6 +289,12 @@
       }, []);
     };
 
+    var resourceTimeout = setTimeout(function() {
+        // If the resources don't load, just start the tests anyways
+        console.log('Timed out waiting for resources to load, starting tests anyways');
+        startTests();
+      }, 5000);
+
     if (resourceCount) {
       resources.required = resourceCount;
 
@@ -300,6 +306,7 @@
         resources.loaded += 1;
 
         if (resources.loaded >= resources.required) {
+          clearTimeout(resourceTimeout);
           startTests();
         }
       };
@@ -310,14 +317,6 @@
         resourceElements[i].load();
         resourceElements[i].onloadeddata = resourceLoaded;
       }
-
-      setTimeout(function() {
-        if (!resources.testStarted) {
-          // If the resources don't load, just start the tests anyways
-          console.log('Timed out waiting for resources to load, starting tests anyways');
-          startTests();
-        }
-      }, 5000);
     } else {
       startTests();
     }

--- a/static/resources/harness.js
+++ b/static/resources/harness.js
@@ -313,7 +313,7 @@
 
       // If the resources don't load, just start the tests anyways
       setTimeout(function() {
-        console.log('Timed out waiting for resources to load, starting tests');
+        console.log('Timed out waiting for resources to load, starting tests anyways');
         startTests();
       }, 5000);
     } else {

--- a/static/resources/harness.js
+++ b/static/resources/harness.js
@@ -25,7 +25,7 @@
   var resources = {
     required: 0,
     loaded: 0,
-    thresholdMet: false
+    testsStarted: false
   };
 
   function stringify(value) {
@@ -266,6 +266,8 @@
 
   function run(callback, resourceCount) {
     var startTests = function() {
+      resources.testsStarted = true;
+
       var timeout = setTimeout(function() {
         updateStatus('<br />This test seems to be taking a long time; ' +
             'it may have crashed. Check the console for errors.', true);
@@ -291,14 +293,13 @@
       resources.required = resourceCount;
 
       var resourceLoaded = function() {
-        if (resources.thresholdMet) {
+        if (resources.testsStarted) {
           // No need to restart the tests
           return;
         }
         resources.loaded += 1;
 
         if (resources.loaded >= resources.required) {
-          resources.thresholdMet = true;
           startTests();
         }
       };
@@ -309,6 +310,12 @@
         resourceElements[i].load();
         resourceElements[i].onloadeddata = resourceLoaded;
       }
+
+      // If the resources don't load, just start the tests anyways
+      setTimeout(function() {
+        console.log('Timed out waiting for resources to load, starting tests');
+        startTests();
+      }, 5000);
     } else {
       startTests();
     }


### PR DESCRIPTION
When attempting to run the Selenium script on Safari, I noticed that the tests wouldn't run, and they'd simply timeout.  After further review, it seems that the audio resources weren't loading for some odd reason.  This PR sets a five-second timeout to start the tests regardless of whether or not the resources have all loaded.