### PR TITLE
Improve resources and add reusable instances as a resource

### DIFF
--- a/DESIGN.md
+++ b/DESIGN.md
@@ -22,21 +22,13 @@ Each API interface is written in the following structure:
 
 ```json
 "INTERFACE_NAME": {
-    "__resources": {
-      "RESOURCE_ELEMENT_ID": {
-        "type": "RESOURCE_TYPE",
-        "src": [
-          "PATH_TO_RESOURCE",
-          "ALT_PATH_TO_RESOURCE"
-        ]
-      }
-    },
-    "__base": "CODE_TO_REPEAT_FOR_EVERY_TEST",
-    "__test": "CODE_SPECIFIC_TO_TEST_THE_INTERFACE",
-    "MEMBER": "CODE_TO_TEST_THE_MEMBER",
-    "__additional": {
-      "SUBFEATURE": "CODE_TO_TEST_SUBFEATURE"
-    }
+  "__resources": ["RESOURCE_ID", ...],
+  "__base": "CODE_TO_REPEAT_FOR_EVERY_TEST",
+  "__test": "CODE_SPECIFIC_TO_TEST_THE_INTERFACE",
+  "MEMBER": "CODE_TO_TEST_THE_MEMBER",
+  "__additional": {
+    "SUBFEATURE": "CODE_TO_TEST_SUBFEATURE"
+  }
 }
 ```
 
@@ -48,7 +40,7 @@ Each member can have a custom test by defining a property as the member name. Li
 
 Note: If an interface with a `__base` has a constructor test, but a custom test isn't defined for the constructor, the code will default to normal generation.
 
-Certain tests may require resources, like audio or video. To allow the resources to load before running the tests, rather than create and add an element with JavaScript, we can define resources to be loaded through the `__resources` object. For each resource we wish to load, we simply define the element ID after `resource-` to assign as the object's key, specify the resource's `type` (audio, video, image, etc.), and define the `src` as an array of file paths after `/custom-tests`. All resources should be placed in `/static/resources/custom-tests/media`.
+Certain tests may require resources, like audio or video. To allow the resources to load before running the tests, rather than create and add an element with JavaScript, we can define resources to be loaded through the `__resources` object.
 
 Additional members and submembers can be defined using the `__additional` property. If there is a subfeature to an API or one of its members, such as "api.AudioContext.AudioContext.latencyHint", that simply cannot be defined within IDL, you can include this object and specify tests for such subfeatures.
 
@@ -91,6 +83,28 @@ bcd.addTest('api.DOMTokenList.remove_duplicates', "(function() {var elm = docume
 ```
 
 Tips: make sure to implement thorough feature checking as to not raise exceptions.
+
+##### Resources
+
+Certain tests may require resources, like audio or video. To allow the resources to load before running the tests, rather than create and add an element with JavaScript, we can define resources to be loaded through the `__resources` object.
+
+```json
+  "api": {
+    "__resources": {
+      "RESOURCE_ELEMENT_ID": {
+        "type": "RESOURCE_TYPE",
+        "src": [
+          "PATH_TO_RESOURCE",
+          "ALT_PATH_TO_RESOURCE"
+        ]
+      }
+    }
+  }
+```
+
+For each resource we wish to load, we simply define the element ID after `resource-` to assign as the object's key, specify the resource's `type` (audio, video, image, etc.), and define the `src` as an array of file paths after `/custom-tests` (or in the case of an `instance` type, code like a custom test to return the instance).
+
+All resource files should be placed in `/static/resources/custom-tests`.
 
 #### CSS
 

--- a/build.js
+++ b/build.js
@@ -104,12 +104,20 @@ const getCustomSubtestsAPI = (name) => {
 };
 
 const getCustomResourcesAPI = (name) => {
+  const resources = {};
+
   // TODO: Use tests imports to inherit resources
   if (name in customTests.api && '__resources' in customTests.api[name]) {
-    return customTests.api[name].__resources;
+    for (const key of customTests.api[name].__resources) {
+      if (Object.keys(customTests.api.__resources).includes(key)) {
+        resources[key] = customTests.api.__resources[key];
+      } else {
+        throw new Error(`Resource ${key} is not defined but referenced in api.${name}`);
+      }
+    }
   }
 
-  return {};
+  return resources;
 };
 
 const getCustomTestCSS = (name) => {

--- a/custom-tests.json
+++ b/custom-tests.json
@@ -8,32 +8,46 @@
       "video-blank": {
         "type": "video",
         "src": ["/media/blank.mp4", "/media/blank.webm"]
+      },
+      "audioContext": {
+        "type": "instance",
+        "src": "return new (window.AudioContext || window.webkitAudioContext)();"
+      },
+      "webGL": {
+        "type": "instance",
+        "src": "var canvas = document.createElement('canvas'); if (!canvas) {return false}; return canvas.getContext('webgl') || canvas.getContext('experimental-webgl');"
       }
     },
     "ANGLE_instanced_arrays": {
-      "__base": "var canvas = document.createElement('canvas'); if (!canvas) {return false}; var gl = canvas.getContext('webgl') || canvas.getContext('experimental-webgl'); if (!gl) {return false}; var instance = gl.getExtension('ANGLE_instanced_arrays');"
+      "__base": "if (!reusableInstances.webGL) {return false}; reusableInstances.webGL.getExtension('ANGLE_instanced_arrays');"
     },
     "AnalyserNode": {
-      "__base": "<%api.AudioContext:audioCtx%> if (!audioCtx) {return false}; var instance = audioCtx.createAnalyser();"
+      "__resources": ["audioContext"],
+      "__base": "if (!reusableInstances.audioContext) {return false;} reusableInstances.audioContext.createAnalyser();"
     },
     "AudioBuffer": {
-      "__base": "<%api.AudioContext:audioCtx%> if (!audioCtx) {return false}; var instance = audioCtx.createBuffer(2, audioCtx.sampleRate * 3, audioCtx.sampleRate);"
+      "__resources": ["audioContext"],
+      "__base": "if (!reusableInstances.audioContext) {return false;} reusableInstances.audioContext.createBuffer(2, audioContext.sampleRate * 3, audioContext.sampleRate);"
     },
     "AudioBufferSourceNode": {
-      "__base": "<%api.AudioContext:audioCtx%> if (!audioCtx) {return false}; var instance = audioCtx.createBufferSource();"
+      "__resources": ["audioContext"],
+      "__base": "if (!reusableInstances.audioContext) {return false;} reusableInstances.audioContext.createBufferSource();"
     },
     "AudioContext": {
-      "__TODO": "Separate into different prefix variations when able",
-      "__base": "var instance = new (window.AudioContext || window.webkitAudioContext)();"
+      "__TODO": "Add webkit prefix",
+      "__base": "var instance = new window.AudioContext();"
     },
     "AudioDestinationNode": {
-      "__base": "<%api.AudioContext:audioCtx%> if (!audioCtx) {return false}; var instance = audioCtx.destination;"
+      "__resources": ["audioContext"],
+      "__base": "if (!reusableInstances.audioContext) {return false;} reusableInstances.audioContext.destination;"
     },
     "AudioListener": {
-      "__base": "<%api.AudioContext:audioCtx%> if (!audioCtx) {return false}; var instance = audioCtx.listener;"
+      "__resources": ["audioContext"],
+      "__base": "if (!reusableInstances.audioContext) {return false;} reusableInstances.audioContext.listener;"
     },
     "AudioNode": {
-      "__base": "<%api.AudioContext:audioCtx%> if (!audioCtx) {return false}; var instance = audioCtx.createAnalyser();"
+      "__resources": ["audioContext"],
+      "__base": "if (!reusableInstances.audioContext) {return false;} reusableInstances.audioContext.createAnalyser();"
     },
     "AudioParam": {
       "__base": "<%api.GainNode:gainNode%> var instance = gainNode.gain;"
@@ -52,25 +66,32 @@
     },
     "AudioWorkletNode": {
       "__TODO": "DEPENDS ON PROMISE TESTING SUPPORT",
-      "__base.disabled": "<%api.AudioContext:audioCtx%> if (!audioCtx) {return false}; await audioCtx.audioWorklet.addModule('/resources/custom-tests/api/AudioWorkletNode/WhiteNoiseProcessor.js'); var instance = new AudioWorkletNode(audioCtx, 'white-noise-processor');"
+      "__resources": ["audioContext"],
+      "__base.disabled": "await if (!reusableInstances.audioContext) {return false;} reusableInstances.audioContext.audioWorklet.addModule('/resources/custom-tests/api/AudioWorkletNode/WhiteNoiseProcessor.js'); var instance = new AudioWorkletNode(audioContext, 'white-noise-processor');"
     },
     "BiquadFilterNode": {
-      "__base": "<%api.AudioContext:audioCtx%> if (!audioCtx) {return false}; var instance = audioCtx.createBiquadFilter();"
+      "__resources": ["audioContext"],
+      "__base": "if (!reusableInstances.audioContext) {return false;} reusableInstances.audioContext.createBiquadFilter();"
     },
     "ChannelMergerNode": {
-      "__base": "<%api.AudioContext:audioCtx%> if (!audioCtx) {return false}; var instance = audioCtx.createChannelMerger();"
+      "__resources": ["audioContext"],
+      "__base": "if (!reusableInstances.audioContext) {return false;} reusableInstances.audioContext.createChannelMerger();"
     },
     "ChannelSplitterNode": {
-      "__base": "<%api.AudioContext:audioCtx%> if (!audioCtx) {return false}; var instance = audioCtx.createChannelSplitter();"
+      "__resources": ["audioContext"],
+      "__base": "if (!reusableInstances.audioContext) {return false;} reusableInstances.audioContext.createChannelSplitter();"
     },
     "ConstantSourceNode": {
-      "__base": "<%api.AudioContext:audioCtx%> if (!audioCtx) {return false}; var instance = audioCtx.createConstantSource();"
+      "__resources": ["audioContext"],
+      "__base": "if (!reusableInstances.audioContext) {return false;} reusableInstances.audioContext.createConstantSource();"
     },
     "ConvolverNode": {
-      "__base": "<%api.AudioContext:audioCtx%> if (!audioCtx) {return false}; var instance = audioCtx.createConvolver();"
+      "__resources": ["audioContext"],
+      "__base": "if (!reusableInstances.audioContext) {return false;} reusableInstances.audioContext.createConvolver();"
     },
     "DelayNode": {
-      "__base": "<%api.AudioContext:audioCtx%> if (!audioCtx) {return false}; var instance = audioCtx.createDelay();"
+      "__resources": ["audioContext"],
+      "__base": "if (!reusableInstances.audioContext) {return false;} reusableInstances.audioContext.createDelay();"
     },
     "Document": {
       "__base": "var instance = document;"
@@ -82,46 +103,60 @@
       }
     },
     "DynamicsCompressorNode": {
-      "__base": "<%api.AudioContext:audioCtx%> if (!audioCtx) {return false}; var instance = audioCtx.createDynamicsCompressor();"
+      "__resources": ["audioContext"],
+      "__base": "if (!reusableInstances.audioContext) {return false;} reusableInstances.audioContext.createDynamicsCompressor();"
     },
     "EXT_blend_minmax": {
-      "__base": "var canvas = document.createElement('canvas'); if (!canvas) {return false}; var gl = canvas.getContext('webgl') || canvas.getContext('experimental-webgl'); if (!gl) {return false}; var instance = gl.getExtension('EXT_blend_minmax');"
+      "__resources": ["webGL"],
+      "__base": "if (!reusableInstances.webGL) {return false}; reusableInstances.webGL.getExtension('EXT_blend_minmax');"
     },
     "EXT_color_buffer_float": {
-      "__base": "var canvas = document.createElement('canvas'); if (!canvas) {return false}; var gl = canvas.getContext('webgl') || canvas.getContext('experimental-webgl'); if (!gl) {return false}; var instance = gl.getExtension('EXT_color_buffer_float');"
+      "__resources": ["webGL"],
+      "__base": "if (!reusableInstances.webGL) {return false}; reusableInstances.webGL.getExtension('EXT_color_buffer_float');"
     },
     "EXT_color_buffer_half_float": {
-      "__base": "var canvas = document.createElement('canvas'); if (!canvas) {return false}; var gl = canvas.getContext('webgl') || canvas.getContext('experimental-webgl'); if (!gl) {return false}; var instance = gl.getExtension('EXT_color_buffer_half_float');"
+      "__resources": ["webGL"],
+      "__base": "if (!reusableInstances.webGL) {return false}; reusableInstances.webGL.getExtension('EXT_color_buffer_half_float');"
     },
     "EXT_disjoint_timer_query": {
-      "__base": "var canvas = document.createElement('canvas'); if (!canvas) {return false}; var gl = canvas.getContext('webgl') || canvas.getContext('experimental-webgl'); if (!gl) {return false}; var instance = gl.getExtension('EXT_disjoint_timer_query');"
+      "__resources": ["webGL"],
+      "__base": "if (!reusableInstances.webGL) {return false}; reusableInstances.webGL.getExtension('EXT_disjoint_timer_query');"
     },
     "EXT_float_blend": {
-      "__base": "var canvas = document.createElement('canvas'); if (!canvas) {return false}; var gl = canvas.getContext('webgl') || canvas.getContext('experimental-webgl'); if (!gl) {return false}; var instance = gl.getExtension('EXT_float_blend');"
+      "__resources": ["webGL"],
+      "__base": "if (!reusableInstances.webGL) {return false}; reusableInstances.webGL.getExtension('EXT_float_blend');"
     },
     "EXT_frag_depth": {
-      "__base": "var canvas = document.createElement('canvas'); if (!canvas) {return false}; var gl = canvas.getContext('webgl') || canvas.getContext('experimental-webgl'); if (!gl) {return false}; var instance = gl.getExtension('EXT_frag_depth');"
+      "__resources": ["webGL"],
+      "__base": "if (!reusableInstances.webGL) {return false}; reusableInstances.webGL.getExtension('EXT_frag_depth');"
     },
     "EXT_shader_texture_lod": {
-      "__base": "var canvas = document.createElement('canvas'); if (!canvas) {return false}; var gl = canvas.getContext('webgl') || canvas.getContext('experimental-webgl'); if (!gl) {return false}; var instance = gl.getExtension('EXT_shader_texture_lod');"
+      "__resources": ["webGL"],
+      "__base": "if (!reusableInstances.webGL) {return false}; reusableInstances.webGL.getExtension('EXT_shader_texture_lod');"
     },
     "EXT_sRGB": {
-      "__base": "var canvas = document.createElement('canvas'); if (!canvas) {return false}; var gl = canvas.getContext('webgl') || canvas.getContext('experimental-webgl'); if (!gl) {return false}; var instance = gl.getExtension('EXT_sRGB');"
+      "__resources": ["webGL"],
+      "__base": "if (!reusableInstances.webGL) {return false}; reusableInstances.webGL.getExtension('EXT_sRGB');"
     },
     "EXT_texture_compression_bptc": {
-      "__base": "var canvas = document.createElement('canvas'); if (!canvas) {return false}; var gl = canvas.getContext('webgl') || canvas.getContext('experimental-webgl'); if (!gl) {return false}; var instance = gl.getExtension('EXT_texture_compression_bptc');"
+      "__resources": ["webGL"],
+      "__base": "if (!reusableInstances.webGL) {return false}; reusableInstances.webGL.getExtension('EXT_texture_compression_bptc');"
     },
     "EXT_texture_compression_rgtc": {
-      "__base": "var canvas = document.createElement('canvas'); if (!canvas) {return false}; var gl = canvas.getContext('webgl') || canvas.getContext('experimental-webgl'); if (!gl) {return false}; var instance = gl.getExtension('EXT_texture_compression_rgtc');"
+      "__resources": ["webGL"],
+      "__base": "if (!reusableInstances.webGL) {return false}; reusableInstances.webGL.getExtension('EXT_texture_compression_rgtc');"
     },
     "EXT_texture_filter_anisotropic": {
-      "__base": "var canvas = document.createElement('canvas'); if (!canvas) {return false}; var gl = canvas.getContext('webgl') || canvas.getContext('experimental-webgl'); if (!gl) {return false}; var instance = gl.getExtension('EXT_texture_filter_anisotropic');"
+      "__resources": ["webGL"],
+      "__base": "if (!reusableInstances.webGL) {return false}; reusableInstances.webGL.getExtension('EXT_texture_filter_anisotropic');"
     },
     "GainNode": {
-      "__base": "<%api.AudioContext:audioCtx%> if (!audioCtx) {return false}; var instance = audioCtx.createGain();"
+      "__resources": ["audioContext"],
+      "__base": "if (!reusableInstances.audioContext) {return false;} reusableInstances.audioContext.createGain();"
     },
     "IIRFilterNode": {
-      "__base": "<%api.AudioContext:audioCtx%> if (!audioCtx) {return false}; var instance = audioCtx.createIIRFilter();"
+      "__resources": ["audioContext"],
+      "__base": "if (!reusableInstances.audioContext) {return false;} reusableInstances.audioContext.createIIRFilter();"
     },
     "MediaCapabilities": {
       "__base": "var instance = navigator.mediaCapabilities;"
@@ -135,7 +170,8 @@
     },
     "MediaElementAudioSourceNode": {
       "__resources": ["audio-blip"],
-      "__base": "<%api.AudioContext:audioCtx%> if (!audioCtx) {return false}; var instance = audioCtx.createMediaElementSource(document.getElementById('resource-audio-blip'));"
+      "__resources": ["audioContext"],
+      "__base": "if (!reusableInstances.audioContext) {return false;} reusableInstances.audioContext.createMediaElementSource(document.getElementById('resource-audio-blip'));"
     },
     "MediaSession": {
       "__base": "var instance = navigator.MediaSession;"
@@ -152,11 +188,13 @@
       "__base.disabled": "<%api.MediaDevices:mediaDevices%> if (!mediaDevices) {return false;} var instance = await mediaDevices.getUserMedia({video: true});"
     },
     "MediaStreamAudioDestinationNode": {
-      "__base": "<%api.AudioContext:audioCtx%> if (!audioCtx) {return false}; var instance = audioCtx.createMediaStreamDestination();"
+      "__resources": ["audioContext"],
+      "__base": "if (!reusableInstances.audioContext) {return false;} reusableInstances.audioContext.createMediaStreamDestination();"
     },
     "MediaStreamAudioSourceNode": {
       "__TODO": "DEPENDS ON PROMISE TESTING SUPPORT",
-      "__base.disabled": "<%api.MediaStream:mediaStream%> if (!mediaStream) {return false;} <%api.AudioContext:audioCtx%> if (!audioCtx) {return false}; var instance = audioCtx.createMediaStreamSource(mediaStream);"
+      "__resources": ["audioContext"],
+      "__base.disabled": "<%api.MediaStream:mediaStream%> if (!mediaStream) {return false;} if (!reusableInstances.audioContext) {return false;} reusableInstances.audioContext.createMediaStreamSource(mediaStream);"
     },
     "MediaStreamTrack": {
       "__TODO": "DEPENDS ON PROMISE TESTING SUPPORT",
@@ -164,7 +202,8 @@
     },
     "MediaStreamTrackAudioSourceNode": {
       "__TODO": "DEPENDS ON PROMISE TESTING SUPPORT",
-      "__base.disabled": "<%api.MediaStream:mediaStream%> if (!mediaStream) {return false;} <%api.AudioContext:audioCtx%> if (!audioCtx) {return false}; var instance = audioCtx.createMediaStreamTrackSource(mediaStream);"
+      "__resources": ["audioContext"],
+      "__base.disabled": "<%api.MediaStream:mediaStream%> if (!mediaStream) {return false;} if (!reusableInstances.audioContext) {return false;} reusableInstances.audioContext.createMediaStreamTrackSource(mediaStream);"
     },
     "Navigator": {
       "__base": "var instance = window.navigator;"
@@ -173,13 +212,16 @@
       "__base": "var instance = document.createNodeIterator(document);"
     },
     "OscillatorNode": {
-      "__base": "<%api.AudioContext:audioCtx%> if (!audioCtx) {return false}; var instance = audioCtx.createOscillator();"
+      "__resources": ["audioContext"],
+      "__base": "if (!reusableInstances.audioContext) {return false;} reusableInstances.audioContext.createOscillator();"
     },
     "PannerNode": {
-      "__base": "<%api.AudioContext:audioCtx%> if (!audioCtx) {return false}; var instance = audioCtx.createPanner();"
+      "__resources": ["audioContext"],
+      "__base": "if (!reusableInstances.audioContext) {return false;} reusableInstances.audioContext.createPanner();"
     },
     "StereoPannerNode": {
-      "__base": "<%api.AudioContext:audioCtx%> if (!audioCtx) {return false}; var instance = audioCtx.createStereoPanner();"
+      "__resources": ["audioContext"],
+      "__base": "if (!reusableInstances.audioContext) {return false;} reusableInstances.audioContext.createStereoPanner();"
     },
     "TreeWalker": {
       "__base": "var instance = document.createTreeWalker(document);"
@@ -193,7 +235,8 @@
       "__base": "var el = document.getElementById('resource-video-blank'); var instance = el.videoTracks;"
     },
     "WaveShaperNode": {
-      "__base": "<%api.AudioContext:audioCtx%> if (!audioCtx) {return false}; var instance = audioCtx.createWaveShaper();"
+      "__resources": ["audioContext"],
+      "__base": "if (!reusableInstances.audioContext) {return false;} reusableInstances.audioContext.createWaveShaper();"
     },
     "Window": {
       "__base": "var instance = window;"

--- a/custom-tests.json
+++ b/custom-tests.json
@@ -1,5 +1,15 @@
 {
   "api": {
+    "__resources": {
+      "audio-blip": {
+        "type": "audio",
+        "src": ["/media/blip.mp3", "/media/blip.ogg"]
+      },
+      "video-blank": {
+        "type": "video",
+        "src": ["/media/blank.mp4", "/media/blank.webm"]
+      }
+    },
     "ANGLE_instanced_arrays": {
       "__base": "var canvas = document.createElement('canvas'); if (!canvas) {return false}; var gl = canvas.getContext('webgl') || canvas.getContext('experimental-webgl'); if (!gl) {return false}; var instance = gl.getExtension('ANGLE_instanced_arrays');"
     },
@@ -33,21 +43,11 @@
       "__base.disabled": "<%api.AudioWorkletNode:worklet%> if (!worklet) {return false}; var instance = worklet.parameters;"
     },
     "AudioTrack": {
-      "__resources": {
-        "audio-blip": {
-          "type": "audio",
-          "src": ["/media/blip.mp3", "/media/blip.ogg"]
-        }
-      },
+      "__resources": ["audio-blip"],
       "__base": "<%api.AudioTrackList:audioTracks%> if (!audioTracks) {return false}; var instance = audioTracks[0];"
     },
     "AudioTrackList": {
-      "__resources": {
-        "audio-blip": {
-          "type": "audio",
-          "src": ["/media/blip.mp3", "/media/blip.ogg"]
-        }
-      },
+      "__resources": ["audio-blip"],
       "__base": "var el = document.getElementById('resource-audio-blip'); var instance = el.audioTracks;"
     },
     "AudioWorkletNode": {
@@ -134,12 +134,7 @@
       "__base": "var instance = navigator.mediaDevices;"
     },
     "MediaElementAudioSourceNode": {
-      "__resources": {
-        "audio-blip": {
-          "type": "audio",
-          "src": ["/media/blip.mp3", "/media/blip.ogg"]
-        }
-      },
+      "__resources": ["audio-blip"],
       "__base": "<%api.AudioContext:audioCtx%> if (!audioCtx) {return false}; var instance = audioCtx.createMediaElementSource(document.getElementById('resource-audio-blip'));"
     },
     "MediaSession": {
@@ -190,21 +185,11 @@
       "__base": "var instance = document.createTreeWalker(document);"
     },
     "VideoTrack": {
-      "__resources": {
-        "video-blank": {
-          "type": "video",
-          "src": ["/media/blank.mp4", "/media/blank.webm"]
-        }
-      },
+      "__resources": ["video-blank"],
       "__base": "<%api.VideoTrackList:videoTracks%> if (!videoTracks) {return false}; var instance = videoTracks[0];"
     },
     "VideoTrackList": {
-      "__resources": {
-        "video-blank": {
-          "type": "video",
-          "src": ["/media/blank.mp4", "/media/blank.webm"]
-        }
-      },
+      "__resources": ["video-blank"],
       "__base": "var el = document.getElementById('resource-video-blank'); var instance = el.videoTracks;"
     },
     "WaveShaperNode": {

--- a/package-lock.json
+++ b/package-lock.json
@@ -1,6 +1,6 @@
 {
   "name": "mdn-bcd-collector",
-  "version": "0.4.0",
+  "version": "0.5.0",
   "lockfileVersion": 1,
   "requires": true,
   "dependencies": {

--- a/package.json
+++ b/package.json
@@ -1,7 +1,7 @@
 {
   "name": "mdn-bcd-collector",
   "description": "Data collection service for mdn/browser-compat-data",
-  "version": "0.4.0",
+  "version": "0.5.0",
   "private": true,
   "license": "Apache-2.0",
   "repository": {

--- a/static/resources/harness.js
+++ b/static/resources/harness.js
@@ -28,6 +28,7 @@
     loaded: 0,
     testsStarted: false
   };
+  var reusableInstances = {};
 
   function stringify(value) {
     try {
@@ -54,6 +55,15 @@
       statusElement.innerHTML = statusElement.innerHTML + newStatus;
     } else {
       statusElement.innerHTML = newStatus;
+    }
+  }
+
+  function addInstance(name, code) {
+    try {
+      reusableInstances[name] = eval('(function () {' + code + '})()');
+    } catch (e) {
+      reusableInstances[name] = false;
+      console.error(e);
     }
   }
 
@@ -481,6 +491,7 @@
 
   global.bcd = {
     testConstructor: testConstructor,
+    addInstance: addInstance,
     addTest: addTest,
     test: test,
     run: run

--- a/unittest/unit/build.js
+++ b/unittest/unit/build.js
@@ -37,14 +37,14 @@ const {
   cssPropertyToIDLAttribute,
   buildCSS
 } = proxyquire('../../build', {
-  './custom-tests.json': {api: {}, css: {}}
+  './custom-tests.json': {api: {__resources: {}}, css: {}}
 });
 
 describe('build', () => {
   describe('getCustomTestAPI', () => {
     describe('no custom tests', () => {
       const {getCustomTestAPI} = proxyquire('../../build', {
-        './custom-tests.json': {api: {}, css: {}}
+        './custom-tests.json': {api: {__resources: {}}, css: {}}
       });
 
       it('interface', () => {
@@ -283,13 +283,14 @@ describe('build', () => {
       const {getCustomResourcesAPI} = proxyquire('../../build', {
         './custom-tests.json': {
           api: {
-            foo: {
-              __resources: {
-                'audio-blip': {
-                  type: 'audio',
-                  src: ['/media/blip.mp3', '/media/blip.ogg']
-                }
+            __resources: {
+              'audio-blip': {
+                type: 'audio',
+                src: ['/media/blip.mp3', '/media/blip.ogg']
               }
+            },
+            foo: {
+              __resources: ['audio-blip']
             }
           }
         }
@@ -310,6 +311,7 @@ describe('build', () => {
       const {getCustomResourcesAPI} = proxyquire('../../build', {
         './custom-tests.json': {
           api: {
+            __resources: {},
             foo: {}
           }
         }

--- a/unittest/unit/build.js
+++ b/unittest/unit/build.js
@@ -319,6 +319,24 @@ describe('build', () => {
 
       assert.deepEqual(getCustomResourcesAPI('foo'), {});
     });
+
+    it('try to get invalid resource', () => {
+      const {getCustomResourcesAPI} = proxyquire('../../build', {
+        './custom-tests.json': {
+          api: {
+            __resources: {},
+            foo: {
+              __resources: ['audio-blip']
+            }
+          }
+        }
+      });
+
+      assert.throws(() => {
+        getCustomResourcesAPI('foo');
+      }, Error,
+      'Resource audio-blip is not defined but referenced in api.foo');
+    });
   });
 
   describe('getCustomTestCSS', () => {

--- a/views/tests.ejs
+++ b/views/tests.ejs
@@ -44,11 +44,16 @@
     <script src="/resources/json3.min.js"></script>
     <script src="/resources/harness.js"></script>
     <script>
+      <% for (const [instanceId, instance] of Object.entries(resources)
+        .filter((item) => (item[1].type === 'instance'))) { %>
+        bcd.addInstance("<%- instanceId %>", "<%- instance.src %>");
+      <% }; %>
       <% tests.forEach(function(test) { %>
         bcd.addTest("<%- test.ident %>", <%- JSON.stringify(test.tests) %>, "<%- test.exposure %>");
       <% }); %>
       window.onload = function() {
-        bcd.run(undefined, <%-Object.keys(resources).length%>)
+        bcd.run(undefined, <%-Object.entries(resources)
+        .filter((item) => (item[1].type !== 'instance')).length%>)
       };
     </script>
   </body>


### PR DESCRIPTION
This PR updates the resources for custom tests in two main ways:

1) Rather than redefining resources per each and every API, this adds a `__resources` entry underneath `api`, where each interface will reference their keys to load them
2) Adds reusable instances as resources to eliminate issues found when creating too many Web Audio APIs (like AudioContext)