### PR TITLE
start-dev command: use double quotes for Windows compatibility

### DIFF
--- a/package.json
+++ b/package.json
@@ -20,7 +20,7 @@
     "gcp-build": "npm run build",
     "deploy": "gcloud app deploy",
     "start": "node app.js",
-    "start-dev": "nodemon --exec 'npm run build && npm start'",
+    "start-dev": "nodemon --exec \"npm run build && npm start\"",
     "unittest": "node scripts.js unittest",
     "coverage": "nyc report -r lcov && open-cli coverage/lcov-report/index.html",
     "test": "npm run lint && npm run unittest",


### PR DESCRIPTION
Small follow-up to #548.