### PR TITLE
Improve compatibility for Internet Explorer

### DIFF
--- a/app.js
+++ b/app.js
@@ -86,11 +86,16 @@ app.set('layout extractScripts', true);
 // Additional config
 app.use(cookieParser());
 app.use(cookieSession);
+app.use(express.urlencoded({extended: true}));
 app.use(express.json({limit: '32mb'}));
 app.use(express.static('static'));
 app.use(express.static('generated'));
 
 // Backend API
+
+app.post('/api/get', (req, res) => {
+  res.redirect(`/tests/${req.body.testSelection.replace(/\./g, '/')}${req.body.limitExposure || ''}`);
+});
 
 app.post('/api/results', (req, res) => {
   if (!req.is('json')) {

--- a/app.js
+++ b/app.js
@@ -94,7 +94,9 @@ app.use(express.static('generated'));
 // Backend API
 
 app.post('/api/get', (req, res) => {
-  res.redirect(`/tests/${req.body.testSelection.replace(/\./g, '/')}${req.body.limitExposure || ''}`);
+  const testSelection = (req.body.testSelection || '').replace(/\./g, '/');
+  const query = req.body.limitExposure ? `?exposure=${req.body.limitExposure}` : '';
+  res.redirect(`/tests/${testSelection}${query}`);
 });
 
 app.post('/api/results', (req, res) => {

--- a/app.js
+++ b/app.js
@@ -97,9 +97,11 @@ app.use(express.static('generated'));
 
 app.post('/api/get', (req, res) => {
   const testSelection = (req.body.testSelection || '').replace(/\./g, '/');
-  const queryParams = {...(req.body.limitExposure && {exposure: req.body.limitExposure})};
+  const queryParams = {
+    ...(req.body.limitExposure && {exposure: req.body.limitExposure})
+  };
   const query = querystring.encode(queryParams);
-  
+
   res.redirect(`/tests/${testSelection}${query ? `?${query}`: ''}`);
 });
 

--- a/app.js
+++ b/app.js
@@ -15,6 +15,8 @@
 'use strict';
 
 const path = require('path');
+const querystring = require('querystring');
+
 const express = require('express');
 const cookieParser = require('cookie-parser');
 const uniqueString = require('unique-string');
@@ -95,8 +97,10 @@ app.use(express.static('generated'));
 
 app.post('/api/get', (req, res) => {
   const testSelection = (req.body.testSelection || '').replace(/\./g, '/');
-  const query = req.body.limitExposure ? `?exposure=${req.body.limitExposure}` : '';
-  res.redirect(`/tests/${testSelection}${query}`);
+  const queryParams = {...(req.body.limitExposure && {exposure: req.body.limitExposure})};
+  const query = querystring.encode(queryParams);
+  
+  res.redirect(`/tests/${testSelection}${query ? `?${query}`: ''}`);
 });
 
 app.post('/api/results', (req, res) => {

--- a/static/resources/harness.js
+++ b/static/resources/harness.js
@@ -30,6 +30,14 @@
   };
   var reusableInstances = {};
 
+  if (!window.console) {
+    // IE undefined console workaround
+    console = {
+      log: function() {},
+      error: function() {}
+    };
+  }
+
   function stringify(value) {
     try {
       return String(value);

--- a/static/resources/harness.js
+++ b/static/resources/harness.js
@@ -32,6 +32,7 @@
 
   if (!('console' in self)) {
     // IE undefined console workaround
+    // eslint-disable-next-line no-global-assign
     console = {
       log: function() {},
       error: function() {}

--- a/static/resources/harness.js
+++ b/static/resources/harness.js
@@ -30,7 +30,7 @@
   };
   var reusableInstances = {};
 
-  if (!window.console) {
+  if (!('console' in self)) {
     // IE undefined console workaround
     console = {
       log: function() {},

--- a/unittest/app/app.js
+++ b/unittest/app/app.js
@@ -18,6 +18,7 @@ const chai = require('chai');
 const chaiHttp = require('chai-http');
 chai.use(chaiHttp);
 const assert = chai.assert;
+const expect = chai.expect;
 
 const {app, version} = require('../../app');
 const agent = chai.request.agent(app);
@@ -113,6 +114,50 @@ describe('/api/results', () => {
         .query({for: testURL})
         .send('my bad results');
     assert.equal(res.status, 400);
+  });
+});
+
+describe('/api/get', () => {
+  it('get all tests, no post vars', async () => {
+    const res = await agent.post('/api/get')
+        .send({});
+    expect(res).to.redirectTo(/\/tests\/$/);
+  });
+
+  it('get all tests, with post vars', async () => {
+    const res = await agent.post('/api/get')
+        .send({testSelection: '', limitExposure: ''});
+    expect(res).to.redirectTo(/\/tests\/$/);
+  });
+
+  it('get all tests, limit exposure', async () => {
+    const res = await agent.post('/api/get')
+        .send({testSelection: '', limitExposure: 'Window'});
+    expect(res).to.redirectTo(/\/tests\/\?exposure=Window$/);
+  });
+
+  it('get "api"', async () => {
+    const res = await agent.post('/api/get')
+        .send({testSelection: 'api', limitExposure: ''});
+    expect(res).to.redirectTo(/\/tests\/api$/);
+  });
+
+  it('get "api", limit exposure', async () => {
+    const res = await agent.post('/api/get')
+        .send({testSelection: 'api', limitExposure: 'Window'});
+    expect(res).to.redirectTo(/\/tests\/api\?exposure=Window$/);
+  });
+
+  it('get specific test', async () => {
+    const res = await agent.post('/api/get')
+        .send({testSelection: 'api.AbortController.signal', limitExposure: ''});
+    expect(res).to.redirectTo(/\/tests\/api\/AbortController\/signal$/);
+  });
+
+  it('get specific test, limit exposure', async () => {
+    const res = await agent.post('/api/get')
+        .send({testSelection: 'api.AbortController.signal', limitExposure: 'Window'});
+    expect(res).to.redirectTo(/\/tests\/api\/AbortController\/signal\?exposure=Window$/);
   });
 });
 

--- a/views/index.ejs
+++ b/views/index.ejs
@@ -15,10 +15,10 @@
     <label for="limitExposure">Limit Exposure:</label>
     <select id="limitExposure" name="limitExposure">
       <option value="">All Global Exposures</option>
-      <option value="?exposure=Window">Window</option>
-      <option value="?exposure=Worker">Dedicated Worker</option>
-      <option value="?exposure=SharedWorker">Shared Worker</option>
-      <option value="?exposure=ServiceWorker">Service Worker</option>
+      <option value="Window">Window</option>
+      <option value="Worker">Dedicated Worker</option>
+      <option value="SharedWorker">Shared Worker</option>
+      <option value="ServiceWorker">Service Worker</option>
     </select>
   </div>
 </form>

--- a/views/index.ejs
+++ b/views/index.ejs
@@ -2,18 +2,18 @@
 <h1>mdn-bcd-collector</h1>
 <p>Data collection service for <a href="https://github.com/mdn/browser-compat-data">mdn/browser-compat-data</a>. This website provides automatic feature detection for Web APIs and CSS properties, to assist in obtaining data for the BCD project.</p>
 
-<form id="testForm">
+<form id="testForm" action="/api/get" method="post">
   <input type="submit" id="start" value="Run" />
   <datalist id="tests">
     <% tests.forEach(function(test) { %>
       <option value="<%- test %>"></option>
     <% }); %>
   </datalist>
-  <input id="testSelection" list="tests" placeholder="All Tests" size="40" />
+  <input id="testSelection" name="testSelection" list="tests" placeholder="All Tests" size="40" />
   <br /><br />
   <div id="limitExposureBox">
     <label for="limitExposure">Limit Exposure:</label>
-    <select id="limitExposure">
+    <select id="limitExposure" name="limitExposure">
       <option value="">All Global Exposures</option>
       <option value="?exposure=Window">Window</option>
       <option value="?exposure=Worker">Dedicated Worker</option>
@@ -46,19 +46,6 @@
       } else {
         limitExposureBox.style.display = "none";
       }
-    }
-
-    form.onsubmit = function(event) {
-      event.preventDefault();
-
-      var newUrl = window.location.protocol + '//' + window.location.host +
-          '/tests/' + testSelection.value.replace(/\./g, '/');
-
-      if (testSelection.value == '' || testSelection.value.indexOf('api') == 0) {
-        newUrl += limitExposure.options[limitExposure.selectedIndex].value;
-      }
-      
-      if (newUrl) window.location = newUrl;
     }
   }
 


### PR DESCRIPTION
This PR performs a few compatibility updates to improve compatibility with Internet Explorer:

- Patches console being undefined when IE DevTools are closed
- Moves test URL generation server-side (IE 8 and below don't support form.onsubmit -- this also reduces client-side JavaScript)

Confirmed full compatibility*: IE 7, Safari 3, Firefox 1, Chrome 1, Opera 9.5
_* Full compatibility includes form submission, test operation, result rendering, result submission, and GitHub submission.  Does not include datalist and styling._