### PR TITLE
IE XHR

### DIFF
--- a/static/resources/harness.js
+++ b/static/resources/harness.js
@@ -438,28 +438,36 @@
       }
     }
 
-    if ('XMLHttpRequest' in self) {
-      try {
-        var body = JSON.stringify(results);
-        var client = new XMLHttpRequest();
-        client.open('POST', '/api/results?for='+encodeURIComponent(location.href));
-        client.setRequestHeader('Content-Type', 'application/json;charset=UTF-8');
-        client.send(body);
-        client.onreadystatechange = function() {
-          if (client.readyState == 4) {
-            if (client.status >= 200 && client.status <= 299) {
-              updateStatus('Results uploaded. <a href="/results" id="submit">Submit to GitHub</a>');
-            } else {
-              updateStatus('Failed to upload results: server error.');
-            }
-          }
-        };
-      } catch (e) {
-        updateStatus('Failed to upload results: client error.');
-        console.error(e);
+    try {
+      var body = JSON.stringify(results);
+
+      var client;
+      if ('XMLHttpRequest' in self) {
+        client = new XMLHttpRequest();
+      } else if ('ActiveXObject' in self) {
+        client = new ActiveXObject('Microsoft.XMLHTTP');
       }
-    } else {
-      updateStatus('Cannot upload results: XMLHttpRequest is not supported.');
+
+      if (!client) {
+        updateStatus('Cannot upload results: XMLHttpRequest is not supported.');
+        return;
+      }
+
+      client.open('POST', '/api/results?for='+encodeURIComponent(location.href));
+      client.setRequestHeader('Content-Type', 'application/json;charset=UTF-8');
+      client.send(body);
+      client.onreadystatechange = function() {
+        if (client.readyState == 4) {
+          if (client.status >= 200 && client.status <= 299) {
+            updateStatus('Results uploaded. <a href="/results" id="submit">Submit to GitHub</a>');
+          } else {
+            updateStatus('Failed to upload results: server error.');
+          }
+        }
+      };
+    } catch (e) {
+      updateStatus('Failed to upload results: client error.');
+      console.error(e);
     }
   }
 

--- a/static/resources/harness.js
+++ b/static/resources/harness.js
@@ -14,7 +14,7 @@
 
 /* global console, document, window, location, navigator, XMLHttpRequest,
           self, Worker, Promise, setTimeout, clearTimeout, MessageChannel,
-          SharedWorker */
+          SharedWorker, ActiveXObject */
 
 'use strict';
 

--- a/views/results.ejs
+++ b/views/results.ejs
@@ -13,7 +13,19 @@
 function exportGitHub() {
   var status = document.getElementById('status');
   var link = document.getElementById('link');
-  var client = new XMLHttpRequest();
+
+  var client;
+  if ('XMLHttpRequest' in self) {
+    client = new XMLHttpRequest();
+  } else if ('ActiveXObject' in self) {
+    client = new ActiveXObject('Microsoft.XMLHTTP');
+  }
+
+  if (!client) {
+    status.innerHTML = 'Cannot upload results: XMLHttpRequest is not supported.';
+    return;
+  }
+
   client.open('POST', '/api/results/export/github', true);
   client.send();
   status.textContent = 'Exporting...';

--- a/views/results.ejs
+++ b/views/results.ejs
@@ -28,7 +28,7 @@ function exportGitHub() {
 
   client.open('POST', '/api/results/export/github', true);
   client.send();
-  status.textContent = 'Exporting...';
+  status.innerHTML = 'Exporting...';
   client.onreadystatechange = function() {
     if (client.readyState == 4) {
       var response = {};
@@ -40,10 +40,10 @@ function exportGitHub() {
       }
 
       if (response.error) {
-        status.textContent = 'Failed to export: ' + response.error;
+        status.innerHTML = 'Failed to export: ' + response.error;
       } else {
-        status.textContent = 'Exported to';
-        link.href = link.textContent = response.html_url;
+        status.innerHTML = 'Exported to';
+        link.href = link.innerHTML = response.html_url;
       }
     }
   }


### PR DESCRIPTION
This PR introduces additional compatibility improvements that allow for running the collector on as far back as IE 5.5 by falling back to the ActiveXObject implementation of XMLHttpRequest in older IE versions (5+).  It also replaces all instances of setting `textContent` with `innerHTML` on the GitHub submission page, which fixes compatibility across other browsers as well.

Compatibility Improvement: IE 5.5+ (vs. IE 7+), Safari bug fixes