### PR TITLE
Allow for reversing direction of find-missing

### DIFF
--- a/find-missing.js
+++ b/find-missing.js
@@ -23,16 +23,11 @@ const traverseFeatures = (obj, identifier) => {
   return features;
 };
 
-const findMissing = () => {
-  const bcdEntries = [
-    ...traverseFeatures(bcd.api, 'api.'),
-    ...traverseFeatures(bcd.css.properties, 'css.properties.')
-  ];
-  const collectorEntries = Object.keys(tests);
+const findMissing = (entries1, entries2) => {
   const missingEntries = [];
 
-  for (const entry of bcdEntries) {
-    if (!collectorEntries.includes(entry)) {
+  for (const entry of entries1) {
+    if (!entries2.includes(entry)) {
       missingEntries.push(entry);
     }
   }
@@ -40,9 +35,25 @@ const findMissing = () => {
   return missingEntries;
 };
 
+const getMissing = (direction = 'collector-to-bcd') => {
+  const bcdEntries = [
+    ...traverseFeatures(bcd.api, 'api.'),
+    ...traverseFeatures(bcd.css.properties, 'css.properties.')
+  ];
+  const collectorEntries = Object.keys(tests);
+
+  switch (direction) {
+    case 'bcd-to-collector':
+      return findMissing(collectorEntries, bcdEntries);
+    case 'collector-to-bcd':
+    default:
+      return findMissing(bcdEntries, collectorEntries);
+  }
+};
+
 /* istanbul ignore next */
 const main = () => {
-  console.log(findMissing().join('\n'));
+  console.log(getMissing().join('\n'));
 };
 
 /* istanbul ignore if */

--- a/find-missing.js
+++ b/find-missing.js
@@ -62,6 +62,7 @@ if (require.main === module) {
 } else {
   module.exports = {
     traverseFeatures,
-    findMissing
+    findMissing,
+    getMissing
   };
 }

--- a/unittest/unit/find-missing.js
+++ b/unittest/unit/find-missing.js
@@ -16,7 +16,7 @@
 
 const assert = require('chai').assert;
 
-const proxyquire = require('proxyquire');
+const proxyquire = require('proxyquire').noCallThru();
 
 const tests = {
   'api.AbortController': {},
@@ -56,9 +56,7 @@ const bcd = {
 
 const {traverseFeatures, getMissing} = proxyquire('../../find-missing', {
   './tests.json': tests,
-  // Object.assign used to mitigate loading bug
-  // https://github.com/foolip/mdn-bcd-collector/pull/553#discussion_r495793082
-  '@mdn/browser-compat-data': Object.assign({}, bcd)
+  '@mdn/browser-compat-data': bcd
 });
 
 describe('find-missing', () => {

--- a/unittest/unit/find-missing.js
+++ b/unittest/unit/find-missing.js
@@ -54,7 +54,7 @@ const bcd = {
   }
 };
 
-const {traverseFeatures, findMissing} = proxyquire('../../find-missing', {
+const {traverseFeatures, getMissing} = proxyquire('../../find-missing', {
   './tests.json': tests,
   // Object.assign used to mitigate loading bug
   // https://github.com/foolip/mdn-bcd-collector/pull/553#discussion_r495793082
@@ -74,12 +74,20 @@ describe('find-missing', () => {
     ]);
   });
 
-  it('findMissing', () => {
-    assert.deepEqual(findMissing(bcd, ''), [
-      'api.AbortController.dummy',
-      'api.DummyAPI',
-      'api.DummyAPI.dummy',
-      'css.properties.font-face'
-    ]);
+  describe('getMissing', () => {
+    it('collector -> bcd', () => {
+      assert.deepEqual(getMissing(), [
+        'api.AbortController.dummy',
+        'api.DummyAPI',
+        'api.DummyAPI.dummy',
+        'css.properties.font-face'
+      ]);
+    });
+
+    it('bcd -> collector', () => {
+      assert.deepEqual(getMissing('bcd-to-collector'), [
+        'javascript.builtins.array'
+      ]);
+    });
   });
 });


### PR DESCRIPTION
This PR updates the code in `find-missing.js` to allow for reversing the direction of missing entries (so we can find what's in the collector but not in BCD).  It is not hooked up to any command line arguments yet -- that will be done in a follow-up PR to refactor everything to use `yargs`.