### PR TITLE
Prevent callThru on proxyquire

### DIFF
--- a/unittest/unit/build.js
+++ b/unittest/unit/build.js
@@ -21,7 +21,7 @@ const assert = chai.assert;
 const expect = chai.expect;
 
 const WebIDL2 = require('webidl2');
-const proxyquire = require('proxyquire');
+const proxyquire = require('proxyquire').noCallThru();
 
 const {
   flattenIDL,

--- a/unittest/unit/find-missing.js
+++ b/unittest/unit/find-missing.js
@@ -16,7 +16,7 @@
 
 const assert = require('chai').assert;
 
-const proxyquire = require('proxyquire');
+const proxyquire = require('proxyquire').noCallThru();
 
 const tests = {
   'api.AbortController': {},
@@ -56,9 +56,7 @@ const bcd = {
 
 const {traverseFeatures, findMissing} = proxyquire('../../find-missing', {
   './tests.json': tests,
-  // Object.assign used to mitigate loading bug
-  // https://github.com/foolip/mdn-bcd-collector/pull/553#discussion_r495793082
-  '@mdn/browser-compat-data': Object.assign({}, bcd)
+  '@mdn/browser-compat-data': bcd
 });
 
 describe('find-missing', () => {

--- a/unittest/unit/github.js
+++ b/unittest/unit/github.js
@@ -16,7 +16,7 @@
 
 const assert = require('chai').assert;
 
-const proxyquire = require('proxyquire');
+const proxyquire = require('proxyquire').noCallThru();
 const sinon = require('sinon');
 const {Octokit} = require('@octokit/rest');
 

--- a/unittest/unit/update-bcd.js
+++ b/unittest/unit/update-bcd.js
@@ -16,7 +16,7 @@
 
 const {assert} = require('chai');
 
-const proxyquire = require('proxyquire');
+const proxyquire = require('proxyquire').noCallThru();
 const sinon = require('sinon');
 
 const logger = require('../../logger');


### PR DESCRIPTION
This PR prevents `proxyquire` from loading the original files or modules, thus resolving the issue mentioned in https://github.com/foolip/mdn-bcd-collector/pull/553#discussion_r495793082.