### PR TITLE
Use global regex for did-you-mean suggestion

### DIFF
--- a/views/testnotfound.ejs
+++ b/views/testnotfound.ejs
@@ -2,7 +2,7 @@
 <h1>Test Not Found</h1>
 <p>Could not find a test for <code><%= ident %></code>. 
   <% if (suggestion) { %>
-    <span class="notice">Did you mean <a href="/tests/<%= suggestion.replace(/\./, '/') %>"><code><%= suggestion %></code></a>?</span>
+    <span class="notice">Did you mean <a href="/tests/<%= suggestion.replace(/\./g, '/') %>"><code><%= suggestion %></code></a>?</span>
   <% } %>
 </p>
 


### PR DESCRIPTION
This PR fixes a slight issue with the regex in the did-you-mean suggestions when tests aren't found.