### PR TITLE
Get WebGL2 context when able

### DIFF
--- a/custom-tests.json
+++ b/custom-tests.json
@@ -15,7 +15,7 @@
       },
       "webGL": {
         "type": "instance",
-        "src": "var canvas = document.createElement('canvas'); if (!canvas) {return false}; return canvas.getContext('webgl') || canvas.getContext('experimental-webgl');"
+        "src": "var canvas = document.createElement('canvas'); if (!canvas) {return false}; return canvas.getContext('webgl2') || canvas.getContext('webgl') || canvas.getContext('experimental-webgl');"
       }
     },
     "ANGLE_instanced_arrays": {


### PR DESCRIPTION
This PR updates the WebGL reusable instance to get a WebGL2 context when able.  WebGL2 contexts inherit all WebGL1 extensions, so we do not have to worry about testing them separately.

Inspried by https://github.com/mdn/browser-compat-data/pull/6840#discussion_r501871182.