### PR TITLE
Simplify module.exports

### DIFF
--- a/app.js
+++ b/app.js
@@ -193,6 +193,11 @@ app.use((req, res) => {
   });
 });
 
+module.exports = {
+  app,
+  version: appversion
+};
+
 /* istanbul ignore if */
 if (require.main === module) {
   // Start the server
@@ -200,10 +205,4 @@ if (require.main === module) {
     logger.info(`App listening on port ${PORT}`);
     logger.info('Press Ctrl+C to quit.');
   });
-} else {
-  // Export for testing
-  module.exports = {
-    app: app,
-    version: appversion
-  };
 }

--- a/build.js
+++ b/build.js
@@ -765,29 +765,29 @@ const build = async (specData, bcd) => {
   await copyResources();
 };
 
+module.exports = {
+  getCustomTestAPI,
+  getCustomSubtestsAPI,
+  getCustomResourcesAPI,
+  getCustomTestCSS,
+  compileTestCode,
+  compileTest,
+  flattenIDL,
+  getExposureSet,
+  getName,
+  buildIDLTests,
+  buildIDL,
+  validateIDL,
+  collectCSSPropertiesFromBCD,
+  collectCSSPropertiesFromWebref,
+  cssPropertyToIDLAttribute,
+  buildCSS
+};
+
 /* istanbul ignore if */
 if (require.main === module) {
   build(specData, bcd).catch((reason) => {
     console.error(reason);
     process.exit(1);
   });
-} else {
-  module.exports = {
-    getCustomTestAPI,
-    getCustomSubtestsAPI,
-    getCustomResourcesAPI,
-    getCustomTestCSS,
-    compileTestCode,
-    compileTest,
-    flattenIDL,
-    getExposureSet,
-    getName,
-    buildIDLTests,
-    buildIDL,
-    validateIDL,
-    collectCSSPropertiesFromBCD,
-    collectCSSPropertiesFromWebref,
-    cssPropertyToIDLAttribute,
-    buildCSS
-  };
 }

--- a/find-missing.js
+++ b/find-missing.js
@@ -74,13 +74,13 @@ const main = () => {
   console.log(getMissing(argv.direction).join('\n'));
 };
 
+module.exports = {
+  traverseFeatures,
+  findMissing,
+  getMissing
+};
+
 /* istanbul ignore if */
 if (require.main === module) {
   main();
-} else {
-  module.exports = {
-    traverseFeatures,
-    findMissing,
-    getMissing
-  };
 }

--- a/github.js
+++ b/github.js
@@ -20,7 +20,7 @@ const slugify = require('slugify');
 const uaParser = require('ua-parser-js');
 const stringify = require('json-stable-stringify');
 
-module.exports = (options) => {
+const github = (options) => {
   const octokit = new Octokit(options);
 
   const getReportMeta = (report) => {
@@ -84,3 +84,5 @@ module.exports = (options) => {
 
   return {getReportMeta, exportAsPR};
 };
+
+module.exports = github;

--- a/selenium.js
+++ b/selenium.js
@@ -241,9 +241,4 @@ if (require.main === module) {
   if (runAll(argv.browser) === false) {
     process.exit(1);
   }
-} else {
-  module.exports = {
-    run,
-    runAll
-  };
 }

--- a/update-bcd.js
+++ b/update-bcd.js
@@ -394,6 +394,16 @@ const main = async (reportPaths) => {
   }
 };
 
+module.exports = {
+  findEntry,
+  getMajorMinorVersion,
+  getBrowserAndVersion,
+  getSupportMap,
+  getSupportMatrix,
+  inferSupportStatements,
+  update
+};
+
 /* istanbul ignore if */
 if (require.main === module) {
   const {argv} = require('yargs').command(
@@ -412,14 +422,4 @@ if (require.main === module) {
     logger.error(error);
     process.exit(1);
   });
-} else {
-  module.exports = {
-    findEntry,
-    getMajorMinorVersion,
-    getBrowserAndVersion,
-    getSupportMap,
-    getSupportMatrix,
-    inferSupportStatements,
-    update
-  };
 }


### PR DESCRIPTION
This PR simplifies the module exports, removing them from the `else {}` clauses.