### PR TITLE
Selenium upgrades: multiple OS support

### DIFF
--- a/selenium.js
+++ b/selenium.js
@@ -102,7 +102,7 @@ const run = async (browser, version, os) => {
       Capability.BROWSER_NAME,
       Browser[browser.toUpperCase()]
   );
-  capabilities.set(Capability.VERSION, version);
+  capabilities.set(Capability.VERSION, version.split('.')[0]);
   capabilities.set(
       'name',
       `mdn-bcd-collector: ${bcd.browsers[browser].name} ${version} on ${os}`

--- a/selenium.js
+++ b/selenium.js
@@ -213,7 +213,7 @@ const runAll = async (limitBrowsers, oses) => {
   // eslint-disable-next-line guard-for-in
   for (const browser in browsersToTest) {
     for (const version of browsersToTest[browser]) {
-      for (const os of oses || ['Windows', 'macOS']) {
+      for (const os of oses) {
         spinner.start(`${bcd.browsers[browser].name} ${version} on ${os}`);
 
         try {

--- a/selenium.js
+++ b/selenium.js
@@ -115,7 +115,7 @@ const run = async (browser, version, os) => {
       break;
     case 'macOS':
       capabilities.set('os', 'OS X');
-      if (browser === 'safari') {
+      if (browser === 'safari' && 'saucelabs' in seleniumUrl) {
         capabilities.set('os_version', getSafariOS(version));
       }
       break;

--- a/selenium.js
+++ b/selenium.js
@@ -92,6 +92,8 @@ const buildDriver = async (browser, version, os) => {
       osesToTest = [['OS X', safariOnSauceLabs && getSafariOS(version)]
       ];
       break;
+    default:
+      throw new Error(`Unknown/unsupported OS: ${os}`);
   }
 
   // eslint-disable-next-line guard-for-in

--- a/selenium.js
+++ b/selenium.js
@@ -80,6 +80,7 @@ const getSafariOS = (version) => {
 
 const buildDriver = async (browser, version, os) => {
   let osesToTest = [];
+  const safariOnSauceLabs = browser === 'safari' && 'saucelabs' in seleniumUrl;
 
   switch (os) {
     case 'Windows':
@@ -88,8 +89,7 @@ const buildDriver = async (browser, version, os) => {
       ];
       break;
     case 'macOS':
-      osesToTest = [['OS X', browser === 'safari' &&
-          'saucelabs' in seleniumUrl && getSafariOS(version)]
+      osesToTest = [['OS X', safariOnSauceLabs && getSafariOS(version)]
       ];
       break;
   }

--- a/selenium.js
+++ b/selenium.js
@@ -42,6 +42,10 @@ const seleniumUrl = secrets.selenium.url && secrets.selenium.url
 
 const spinner = ora();
 
+const prettyName = (browser, version, os) => {
+  return `${bcd.browsers[browser].name} ${version} on ${os}`;
+}
+
 const failSpinner = (e) => {
   spinner.fail(spinner.text + ' - ' + e.stack);
 };
@@ -105,8 +109,7 @@ const buildDriver = async (browser, version, os) => {
     );
     capabilities.set(Capability.VERSION, version.split('.')[0]);
     capabilities.set(
-        'name',
-        `mdn-bcd-collector: ${bcd.browsers[browser].name} ${version} on ${os}`
+        'name', `mdn-bcd-collector: ${prettyName(browser, version, os)}`
     );
 
     capabilities.set('os', osName);
@@ -248,7 +251,7 @@ const runAll = async (limitBrowsers, oses) => {
   for (const browser in browsersToTest) {
     for (const version of browsersToTest[browser]) {
       for (const os of oses) {
-        spinner.start(`${bcd.browsers[browser].name} ${version} on ${os}`);
+        spinner.start(prettyName(browser, version, os));
 
         try {
           await run(browser, version, os);

--- a/selenium.js
+++ b/selenium.js
@@ -241,10 +241,11 @@ if (require.main === module) {
               type: 'string',
               choices: ['chrome', 'edge', 'firefox', 'ie', 'safari']
             })
-            .optional('os', {
+            .option('os', {
               describe: 'Limit the os(es) to test',
-              type: 'string',
-              choices: ['Windows', 'macOS']
+              type: 'array',
+              choices: ['Windows', 'macOS'],
+              default: ['Windows', 'macOS']
             });
       }
   );

--- a/selenium.js
+++ b/selenium.js
@@ -44,7 +44,7 @@ const spinner = ora();
 
 const prettyName = (browser, version, os) => {
   return `${bcd.browsers[browser].name} ${version} on ${os}`;
-}
+};
 
 const failSpinner = (e) => {
   spinner.fail(spinner.text + ' - ' + e.stack);

--- a/selenium.js
+++ b/selenium.js
@@ -251,6 +251,11 @@ const runAll = async (limitBrowsers, oses) => {
   for (const browser in browsersToTest) {
     for (const version of browsersToTest[browser]) {
       for (const os of oses) {
+        if (browser === 'safari' && os === 'Windows') {
+          // Don't test Safari on Windows
+          continue;
+        }
+
         spinner.start(prettyName(browser, version, os));
 
         try {


### PR DESCRIPTION
This PR upgrades the Selenium script to enhance testing between OSes and OS versions, by testing browsers in both Windows and macOS (aside from Safari which will only run in macOS), as well as testing in the most recent Windows versions and falling back to older versions when needed.