### PR TITLE
Update prepare stage, Nodemon rules, and npm run start-dev

### DIFF
--- a/README.md
+++ b/README.md
@@ -12,10 +12,6 @@ See [DESIGN.md](./DESIGN.md) for details of how this service works.
 npm install
 ```
 
-Before you can run or deploy, copy `secrets.sample.json` to `secrets.json`.
-
-(The tests can be run without a `secrets.json`.)
-
 ## Running locally
 
 ```sh

--- a/nodemon.json
+++ b/nodemon.json
@@ -6,6 +6,7 @@
     "views/*",
     "tests.json",
     "find-missing.js",
+    "scripts.js",
     "selenium.js",
     "update-bcd.js"
   ]

--- a/package.json
+++ b/package.json
@@ -20,7 +20,7 @@
     "gcp-build": "npm run build",
     "deploy": "gcloud app deploy",
     "start": "node app.js",
-    "start-dev": "nodemon --exec \"npm run build && npm start\"",
+    "start-dev": "npm i && nodemon --exec \"npm run build && npm start\"",
     "unittest": "node scripts.js unittest",
     "coverage": "nyc report -r lcov && open-cli coverage/lcov-report/index.html",
     "test": "npm run lint && npm run unittest",

--- a/scripts.js
+++ b/scripts.js
@@ -14,7 +14,7 @@
 
 const childProcess = require('child_process');
 const path = require('path');
-const fs = require('fs-extra');
+const fs = require('fs');
 
 const exec = (cmd, env) => {
   env = {...process.env, ...env};

--- a/scripts.js
+++ b/scripts.js
@@ -28,7 +28,7 @@ const prepare = () => {
   const secretsSamplePath = path.join(__dirname, 'secrets.sample.json');
 
   if (!fs.existsSync(secretsPath)) {
-    fs.copyFile(secretsSamplePath, secretsPath);
+    fs.copyFileSync(secretsSamplePath, secretsPath);
   }
 
   // Install Firefox for Puppeteer

--- a/scripts.js
+++ b/scripts.js
@@ -13,6 +13,8 @@
 // limitations under the License.
 
 const childProcess = require('child_process');
+const path = require('path');
+const fs = require('fs-extra');
 
 const exec = (cmd, env) => {
   env = {...process.env, ...env};
@@ -21,6 +23,15 @@ const exec = (cmd, env) => {
 };
 
 const prepare = () => {
+  // Copy secrets.sample.json to secrets.json if needed
+  const secretsPath = path.join(__dirname, 'secrets.json');
+  const secretsSamplePath = path.join(__dirname, 'secrets.sample.json');
+
+  if (!fs.existsSync(secretsPath)) {
+    fs.copyFile(secretsSamplePath, secretsPath);
+  }
+
+  // Install Firefox for Puppeteer
   try {
     process.chdir('node_modules/puppeteer');
   } catch (e) {


### PR DESCRIPTION
This PR provides some updates to improve development, such as auto-copying `secrets.sample.json` to `secrets.json` when needed, ignoring `scripts.js` on the dev server rebuild watcher, and running `npm i` before starting the dev server.