### PR TITLE
Expose reusable instances globally

### DIFF
--- a/static/resources/harness.js
+++ b/static/resources/harness.js
@@ -534,7 +534,7 @@
   }
 
   global.stringify = stringify;
-
+  global.reusableInstances = reusableInstances;
   global.bcd = {
     testConstructor: testConstructor,
     addInstance: addInstance,


### PR DESCRIPTION
This PR exposes the `reusableInstances` variable to make it easier to debug issues in the console.