### PR TITLE
Reverse browser version order (collect newest versions first)

### DIFF
--- a/selenium.js
+++ b/selenium.js
@@ -294,7 +294,7 @@ const runAll = async (limitBrowsers, oses) => {
 
   // eslint-disable-next-line guard-for-in
   for (const browser in browsersToTest) {
-    for (const version of browsersToTest[browser]) {
+    for (const version of browsersToTest[browser].reverse()) {
       for (const os of oses) {
         if (browser === 'safari' && os === 'Windows') {
           // Don't test Safari on Windows


### PR DESCRIPTION
This PR reverses the order of browsers when collecting with the Selenium script, so that it collects the results for the newest first.