### PR TITLE
Add blacklist functionality to disable certain tests

### DIFF
--- a/app.js
+++ b/app.js
@@ -176,7 +176,8 @@ app.all('/tests/*', (req, res) => {
       title: `${ident || 'All Tests'}`,
       layout: false,
       tests: foundTests,
-      hideResults: req.query.hideResults
+      hideResults: req.query.hideResults,
+      blacklist: (req.query.blacklist ? req.query.blacklist.split(',') : [])
     });
   } else {
     res.status(404).render('testnotfound', {

--- a/views/tests.ejs
+++ b/views/tests.ejs
@@ -54,7 +54,9 @@
         bcd.addInstance("<%- instanceId %>", "<%- instance.src %>");
       <% }; %>
       <% tests.forEach(function(test) { %>
-        bcd.addTest("<%- test.ident %>", <%- JSON.stringify(test.tests) %>, "<%- test.exposure %>");
+        <% if (!blacklist.includes(test.ident)) { %>
+          bcd.addTest("<%- test.ident %>", <%- JSON.stringify(test.tests) %>, "<%- test.exposure %>");
+        <% } %>
       <% }); %>
       window.onload = function() {
         bcd.run(undefined, <%-Object.entries(resources)


### PR DESCRIPTION
This PR adds a `blacklist` parameter to the test running URL to disable specific tests when running all of them.  This is to allow us to disable certain APIs for Chrome versions when they crash the browser, so we can still obtain other data for the other APIs.