### PR TITLE
Fix tests for HTML element APIs

### DIFF
--- a/custom-tests.json
+++ b/custom-tests.json
@@ -205,232 +205,232 @@
       "__base": "if (!reusableInstances.audioContext) {return false;} var instance = reusableInstances.audioContext.createGain();"
     },
     "HTMLAnchorElement": {
-      "__base": "var instance = document.createElement('a'); if (instance.constructor.name === 'HTMLUnknownElement') {return false;}"
+      "__base": "var instance = document.createElement('a'); if (instance.constructor.name === 'HTMLUnknownElement' || instance.constructor.name === 'HTMLElement') {return false;}"
     },
     "HTMLAreaElement": {
-      "__base": "var instance = document.createElement('area'); if (instance.constructor.name === 'HTMLUnknownElement') {return false;}"
+      "__base": "var instance = document.createElement('area'); if (instance.constructor.name === 'HTMLUnknownElement' || instance.constructor.name === 'HTMLElement') {return false;}"
     },
     "HTMLAudioElement": {
-      "__base": "var instance = document.createElement('audio'); if (instance.constructor.name === 'HTMLUnknownElement') {return false;}"
+      "__base": "var instance = document.createElement('audio'); if (instance.constructor.name === 'HTMLUnknownElement' || instance.constructor.name === 'HTMLElement') {return false;}"
     },
     "HTMLBaseElement": {
-      "__base": "var instance = document.createElement('base'); if (instance.constructor.name === 'HTMLUnknownElement') {return false;}"
+      "__base": "var instance = document.createElement('base'); if (instance.constructor.name === 'HTMLUnknownElement' || instance.constructor.name === 'HTMLElement') {return false;}"
     },
     "HTMLBaseFontElement": {
-      "__base": "var instance = document.createElement('basefont'); if (instance.constructor.name === 'HTMLUnknownElement') {return false;}"
+      "__base": "var instance = document.createElement('basefont'); if (instance.constructor.name === 'HTMLUnknownElement' || instance.constructor.name === 'HTMLElement') {return false;}"
     },
     "HTMLBodyElement": {
-      "__base": "var instance = document.createElement('body'); if (instance.constructor.name === 'HTMLUnknownElement') {return false;}"
+      "__base": "var instance = document.createElement('body'); if (instance.constructor.name === 'HTMLUnknownElement' || instance.constructor.name === 'HTMLElement') {return false;}"
     },
     "HTMLBRElement": {
-      "__base": "var instance = document.createElement('br'); if (instance.constructor.name === 'HTMLUnknownElement') {return false;}"
+      "__base": "var instance = document.createElement('br'); if (instance.constructor.name === 'HTMLUnknownElement' || instance.constructor.name === 'HTMLElement') {return false;}"
     },
     "HTMLButtonElement": {
-      "__base": "var instance = document.createElement('button'); if (instance.constructor.name === 'HTMLUnknownElement') {return false;}"
+      "__base": "var instance = document.createElement('button'); if (instance.constructor.name === 'HTMLUnknownElement' || instance.constructor.name === 'HTMLElement') {return false;}"
     },
     "HTMLCanvasElement": {
-      "__base": "var instance = document.createElement('canvas'); if (instance.constructor.name === 'HTMLUnknownElement') {return false;}"
+      "__base": "var instance = document.createElement('canvas'); if (instance.constructor.name === 'HTMLUnknownElement' || instance.constructor.name === 'HTMLElement') {return false;}"
     },
     "HTMLContentElement": {
-      "__base": "var instance = document.createElement('content'); if (instance.constructor.name === 'HTMLUnknownElement') {return false;}"
+      "__base": "var instance = document.createElement('content'); if (instance.constructor.name === 'HTMLUnknownElement' || instance.constructor.name === 'HTMLElement') {return false;}"
     },
     "HTMLDataElement": {
-      "__base": "var instance = document.createElement('data'); if (instance.constructor.name === 'HTMLUnknownElement') {return false;}"
+      "__base": "var instance = document.createElement('data'); if (instance.constructor.name === 'HTMLUnknownElement' || instance.constructor.name === 'HTMLElement') {return false;}"
     },
     "HTMLDataListElement": {
-      "__base": "var instance = document.createElement('datalist'); if (instance.constructor.name === 'HTMLUnknownElement') {return false;}"
+      "__base": "var instance = document.createElement('datalist'); if (instance.constructor.name === 'HTMLUnknownElement' || instance.constructor.name === 'HTMLElement') {return false;}"
     },
     "HTMLDetailsElement": {
-      "__base": "var instance = document.createElement('details'); if (instance.constructor.name === 'HTMLUnknownElement') {return false;}"
+      "__base": "var instance = document.createElement('details'); if (instance.constructor.name === 'HTMLUnknownElement' || instance.constructor.name === 'HTMLElement') {return false;}"
     },
     "HTMLDialogElement": {
-      "__base": "var instance = document.createElement('dialog'); if (instance.constructor.name === 'HTMLUnknownElement') {return false;}"
+      "__base": "var instance = document.createElement('dialog'); if (instance.constructor.name === 'HTMLUnknownElement' || instance.constructor.name === 'HTMLElement') {return false;}"
     },
     "HTMLDivElement": {
-      "__base": "var instance = document.createElement('div'); if (instance.constructor.name === 'HTMLUnknownElement') {return false;}"
+      "__base": "var instance = document.createElement('div'); if (instance.constructor.name === 'HTMLUnknownElement' || instance.constructor.name === 'HTMLElement') {return false;}"
     },
     "HTMLDListElement": {
-      "__base": "var instance = document.createElement('dl'); if (instance.constructor.name === 'HTMLUnknownElement') {return false;}"
+      "__base": "var instance = document.createElement('dl'); if (instance.constructor.name === 'HTMLUnknownElement' || instance.constructor.name === 'HTMLElement') {return false;}"
     },
     "HTMLElement": {
       "__base": "<%api.HTMLParagraphElement:instance%>"
     },
     "HTMLEmbedElement": {
-      "__base": "var instance = document.createElement('embed'); if (instance.constructor.name === 'HTMLUnknownElement') {return false;}"
+      "__base": "var instance = document.createElement('embed'); if (instance.constructor.name === 'HTMLUnknownElement' || instance.constructor.name === 'HTMLElement') {return false;}"
     },
     "HTMLFieldSetElement": {
-      "__base": "var instance = document.createElement('fieldset'); if (instance.constructor.name === 'HTMLUnknownElement') {return false;}"
+      "__base": "var instance = document.createElement('fieldset'); if (instance.constructor.name === 'HTMLUnknownElement' || instance.constructor.name === 'HTMLElement') {return false;}"
     },
     "HTMLFontElement": {
-      "__base": "var instance = document.createElement('font'); if (instance.constructor.name === 'HTMLUnknownElement') {return false;}"
+      "__base": "var instance = document.createElement('font'); if (instance.constructor.name === 'HTMLUnknownElement' || instance.constructor.name === 'HTMLElement') {return false;}"
     },
     "HTMLFormElement": {
-      "__base": "var instance = document.createElement('form'); if (instance.constructor.name === 'HTMLUnknownElement') {return false;}"
+      "__base": "var instance = document.createElement('form'); if (instance.constructor.name === 'HTMLUnknownElement' || instance.constructor.name === 'HTMLElement') {return false;}"
     },
     "HTMLFrameElement": {
-      "__base": "var instance = document.createElement('frame'); if (instance.constructor.name === 'HTMLUnknownElement') {return false;}"
+      "__base": "var instance = document.createElement('frame'); if (instance.constructor.name === 'HTMLUnknownElement' || instance.constructor.name === 'HTMLElement') {return false;}"
     },
     "HTMLFrameSetElement": {
-      "__base": "var instance = document.createElement('frameset'); if (instance.constructor.name === 'HTMLUnknownElement') {return false;}"
+      "__base": "var instance = document.createElement('frameset'); if (instance.constructor.name === 'HTMLUnknownElement' || instance.constructor.name === 'HTMLElement') {return false;}"
     },
     "HTMLHeadElement": {
-      "__base": "var instance = document.createElement('head'); if (instance.constructor.name === 'HTMLUnknownElement') {return false;}"
+      "__base": "var instance = document.createElement('head'); if (instance.constructor.name === 'HTMLUnknownElement' || instance.constructor.name === 'HTMLElement') {return false;}"
     },
     "HTMLHeadingElement": {
-      "__base": "var instance = document.createElement('h1'); if (instance.constructor.name === 'HTMLUnknownElement') {return false;}"
+      "__base": "var instance = document.createElement('h1'); if (instance.constructor.name === 'HTMLUnknownElement' || instance.constructor.name === 'HTMLElement') {return false;}"
     },
     "HTMLHRElement": {
-      "__base": "var instance = document.createElement('hr'); if (instance.constructor.name === 'HTMLUnknownElement') {return false;}"
+      "__base": "var instance = document.createElement('hr'); if (instance.constructor.name === 'HTMLUnknownElement' || instance.constructor.name === 'HTMLElement') {return false;}"
     },
     "HTMLHtmlElement": {
-      "__base": "var instance = document.createElement('html'); if (instance.constructor.name === 'HTMLUnknownElement') {return false;}"
+      "__base": "var instance = document.createElement('html'); if (instance.constructor.name === 'HTMLUnknownElement' || instance.constructor.name === 'HTMLElement') {return false;}"
     },
     "HTMLIFrameElement": {
-      "__base": "var instance = document.createElement('iframe'); if (instance.constructor.name === 'HTMLUnknownElement') {return false;}"
+      "__base": "var instance = document.createElement('iframe'); if (instance.constructor.name === 'HTMLUnknownElement' || instance.constructor.name === 'HTMLElement') {return false;}"
     },
     "HTMLImageElement": {
-      "__base": "var instance = document.createElement('img'); if (instance.constructor.name === 'HTMLUnknownElement') {return false;}"
+      "__base": "var instance = document.createElement('img'); if (instance.constructor.name === 'HTMLUnknownElement' || instance.constructor.name === 'HTMLElement') {return false;}"
     },
     "HTMLInputElement": {
-      "__base": "var instance = document.createElement('input'); if (instance.constructor.name === 'HTMLUnknownElement') {return false;}"
+      "__base": "var instance = document.createElement('input'); if (instance.constructor.name === 'HTMLUnknownElement' || instance.constructor.name === 'HTMLElement') {return false;}"
     },
     "HTMLIsIndexElement": {
-      "__base": "var instance = document.createElement('isindex'); if (instance.constructor.name === 'HTMLUnknownElement') {return false;}"
+      "__base": "var instance = document.createElement('isindex'); if (instance.constructor.name === 'HTMLUnknownElement' || instance.constructor.name === 'HTMLElement') {return false;}"
     },
     "HTMLKeygenElement": {
-      "__base": "var instance = document.createElement('keygen'); if (instance.constructor.name === 'HTMLUnknownElement') {return false;}"
+      "__base": "var instance = document.createElement('keygen'); if (instance.constructor.name === 'HTMLUnknownElement' || instance.constructor.name === 'HTMLElement') {return false;}"
     },
     "HTMLLabelElement": {
-      "__base": "var instance = document.createElement('label'); if (instance.constructor.name === 'HTMLUnknownElement') {return false;}"
+      "__base": "var instance = document.createElement('label'); if (instance.constructor.name === 'HTMLUnknownElement' || instance.constructor.name === 'HTMLElement') {return false;}"
     },
     "HTMLLegendElement": {
-      "__base": "var instance = document.createElement('legend'); if (instance.constructor.name === 'HTMLUnknownElement') {return false;}"
+      "__base": "var instance = document.createElement('legend'); if (instance.constructor.name === 'HTMLUnknownElement' || instance.constructor.name === 'HTMLElement') {return false;}"
     },
     "HTMLLIElement": {
-      "__base": "var instance = document.createElement('li'); if (instance.constructor.name === 'HTMLUnknownElement') {return false;}"
+      "__base": "var instance = document.createElement('li'); if (instance.constructor.name === 'HTMLUnknownElement' || instance.constructor.name === 'HTMLElement') {return false;}"
     },
     "HTMLLinkElement": {
-      "__base": "var instance = document.createElement('link'); if (instance.constructor.name === 'HTMLUnknownElement') {return false;}"
+      "__base": "var instance = document.createElement('link'); if (instance.constructor.name === 'HTMLUnknownElement' || instance.constructor.name === 'HTMLElement') {return false;}"
     },
     "HTMLMapElement": {
-      "__base": "var instance = document.createElement('map'); if (instance.constructor.name === 'HTMLUnknownElement') {return false;}"
+      "__base": "var instance = document.createElement('map'); if (instance.constructor.name === 'HTMLUnknownElement' || instance.constructor.name === 'HTMLElement') {return false;}"
     },
     "HTMLMarqueeElement": {
-      "__base": "var instance = document.createElement('marquee'); if (instance.constructor.name === 'HTMLUnknownElement') {return false;}"
+      "__base": "var instance = document.createElement('marquee'); if (instance.constructor.name === 'HTMLUnknownElement' || instance.constructor.name === 'HTMLElement') {return false;}"
     },
     "HTMLMediaElement": {
       "__base": "<%api.HTMLVideoElement:instance%>"
     },
     "HTMLMenuElement": {
-      "__base": "var instance = document.createElement('menu'); if (instance.constructor.name === 'HTMLUnknownElement') {return false;}"
+      "__base": "var instance = document.createElement('menu'); if (instance.constructor.name === 'HTMLUnknownElement' || instance.constructor.name === 'HTMLElement') {return false;}"
     },
     "HTMLMenuItemElement": {
-      "__base": "var instance = document.createElement('menuitem'); if (instance.constructor.name === 'HTMLUnknownElement') {return false;}"
+      "__base": "var instance = document.createElement('menuitem'); if (instance.constructor.name === 'HTMLUnknownElement' || instance.constructor.name === 'HTMLElement') {return false;}"
     },
     "HTMLMetaElement": {
-      "__base": "var instance = document.createElement('meta'); if (instance.constructor.name === 'HTMLUnknownElement') {return false;}"
+      "__base": "var instance = document.createElement('meta'); if (instance.constructor.name === 'HTMLUnknownElement' || instance.constructor.name === 'HTMLElement') {return false;}"
     },
     "HTMLMeterElement": {
-      "__base": "var instance = document.createElement('meter'); if (instance.constructor.name === 'HTMLUnknownElement') {return false;}"
+      "__base": "var instance = document.createElement('meter'); if (instance.constructor.name === 'HTMLUnknownElement' || instance.constructor.name === 'HTMLElement') {return false;}"
     },
     "HTMLModElement": {
-      "__base": "var instance = document.createElement('del'); if (instance.constructor.name === 'HTMLUnknownElement') {return false;}"
+      "__base": "var instance = document.createElement('del'); if (instance.constructor.name === 'HTMLUnknownElement' || instance.constructor.name === 'HTMLElement') {return false;}"
     },
     "HTMLObjectElement": {
-      "__base": "var instance = document.createElement('object'); if (instance.constructor.name === 'HTMLUnknownElement') {return false;}"
+      "__base": "var instance = document.createElement('object'); if (instance.constructor.name === 'HTMLUnknownElement' || instance.constructor.name === 'HTMLElement') {return false;}"
     },
     "HTMLOListElement": {
-      "__base": "var instance = document.createElement('ol'); if (instance.constructor.name === 'HTMLUnknownElement') {return false;}"
+      "__base": "var instance = document.createElement('ol'); if (instance.constructor.name === 'HTMLUnknownElement' || instance.constructor.name === 'HTMLElement') {return false;}"
     },
     "HTMLOptGroupElement": {
-      "__base": "var instance = document.createElement('optgroup'); if (instance.constructor.name === 'HTMLUnknownElement') {return false;}"
+      "__base": "var instance = document.createElement('optgroup'); if (instance.constructor.name === 'HTMLUnknownElement' || instance.constructor.name === 'HTMLElement') {return false;}"
     },
     "HTMLOptionElement": {
-      "__base": "var instance = document.createElement('option'); if (instance.constructor.name === 'HTMLUnknownElement') {return false;}"
+      "__base": "var instance = document.createElement('option'); if (instance.constructor.name === 'HTMLUnknownElement' || instance.constructor.name === 'HTMLElement') {return false;}"
     },
     "HTMLOutputElement": {
-      "__base": "var instance = document.createElement('output'); if (instance.constructor.name === 'HTMLUnknownElement') {return false;}"
+      "__base": "var instance = document.createElement('output'); if (instance.constructor.name === 'HTMLUnknownElement' || instance.constructor.name === 'HTMLElement') {return false;}"
     },
     "HTMLParagraphElement": {
-      "__base": "var instance = document.createElement('p'); if (instance.constructor.name === 'HTMLUnknownElement') {return false;}"
+      "__base": "var instance = document.createElement('p'); if (instance.constructor.name === 'HTMLUnknownElement' || instance.constructor.name === 'HTMLElement') {return false;}"
     },
     "HTMLParamElement": {
-      "__base": "var instance = document.createElement('param'); if (instance.constructor.name === 'HTMLUnknownElement') {return false;}"
+      "__base": "var instance = document.createElement('param'); if (instance.constructor.name === 'HTMLUnknownElement' || instance.constructor.name === 'HTMLElement') {return false;}"
     },
     "HTMLPictureElement": {
-      "__base": "var instance = document.createElement('picture'); if (instance.constructor.name === 'HTMLUnknownElement') {return false;}"
+      "__base": "var instance = document.createElement('picture'); if (instance.constructor.name === 'HTMLUnknownElement' || instance.constructor.name === 'HTMLElement') {return false;}"
     },
     "HTMLPreElement": {
-      "__base": "var instance = document.createElement('pre'); if (instance.constructor.name === 'HTMLUnknownElement') {return false;}"
+      "__base": "var instance = document.createElement('pre'); if (instance.constructor.name === 'HTMLUnknownElement' || instance.constructor.name === 'HTMLElement') {return false;}"
     },
     "HTMLProgressElement": {
-      "__base": "var instance = document.createElement('progress'); if (instance.constructor.name === 'HTMLUnknownElement') {return false;}"
+      "__base": "var instance = document.createElement('progress'); if (instance.constructor.name === 'HTMLUnknownElement' || instance.constructor.name === 'HTMLElement') {return false;}"
     },
     "HTMLQuoteElement": {
-      "__base": "var instance = document.createElement('blockquote'); if (instance.constructor.name === 'HTMLUnknownElement') {return false;}"
+      "__base": "var instance = document.createElement('blockquote'); if (instance.constructor.name === 'HTMLUnknownElement' || instance.constructor.name === 'HTMLElement') {return false;}"
     },
     "HTMLScriptElement": {
-      "__base": "var instance = document.createElement('script'); if (instance.constructor.name === 'HTMLUnknownElement') {return false;}"
+      "__base": "var instance = document.createElement('script'); if (instance.constructor.name === 'HTMLUnknownElement' || instance.constructor.name === 'HTMLElement') {return false;}"
     },
     "HTMLSelectElement": {
-      "__base": "var instance = document.createElement('select'); if (instance.constructor.name === 'HTMLUnknownElement') {return false;}"
+      "__base": "var instance = document.createElement('select'); if (instance.constructor.name === 'HTMLUnknownElement' || instance.constructor.name === 'HTMLElement') {return false;}"
     },
     "HTMLShadowElement": {
-      "__base": "var instance = document.createElement('shadow'); if (instance.constructor.name === 'HTMLUnknownElement') {return false;}"
+      "__base": "var instance = document.createElement('shadow'); if (instance.constructor.name === 'HTMLUnknownElement' || instance.constructor.name === 'HTMLElement') {return false;}"
     },
     "HTMLSlotElement": {
-      "__base": "var instance = document.createElement('slot'); if (instance.constructor.name === 'HTMLUnknownElement') {return false;}"
+      "__base": "var instance = document.createElement('slot'); if (instance.constructor.name === 'HTMLUnknownElement' || instance.constructor.name === 'HTMLElement') {return false;}"
     },
     "HTMLSourceElement": {
-      "__base": "var instance = document.createElement('source'); if (instance.constructor.name === 'HTMLUnknownElement') {return false;}"
+      "__base": "var instance = document.createElement('source'); if (instance.constructor.name === 'HTMLUnknownElement' || instance.constructor.name === 'HTMLElement') {return false;}"
     },
     "HTMLSpanElement": {
-      "__base": "var instance = document.createElement('span'); if (instance.constructor.name === 'HTMLUnknownElement') {return false;}"
+      "__base": "var instance = document.createElement('span'); if (instance.constructor.name === 'HTMLUnknownElement' || instance.constructor.name === 'HTMLElement') {return false;}"
     },
     "HTMLStyleElement": {
-      "__base": "var instance = document.createElement('style'); if (instance.constructor.name === 'HTMLUnknownElement') {return false;}"
+      "__base": "var instance = document.createElement('style'); if (instance.constructor.name === 'HTMLUnknownElement' || instance.constructor.name === 'HTMLElement') {return false;}"
     },
     "HTMLTableCaptionElement": {
-      "__base": "var instance = document.createElement('caption'); if (instance.constructor.name === 'HTMLUnknownElement') {return false;}"
+      "__base": "var instance = document.createElement('caption'); if (instance.constructor.name === 'HTMLUnknownElement' || instance.constructor.name === 'HTMLElement') {return false;}"
     },
     "HTMLTableCellElement": {
-      "__base": "var instance = document.createElement('td'); if (instance.constructor.name === 'HTMLUnknownElement') {return false;}"
+      "__base": "var instance = document.createElement('td'); if (instance.constructor.name === 'HTMLUnknownElement' || instance.constructor.name === 'HTMLElement') {return false;}"
     },
     "HTMLTableColElement": {
-      "__base": "var instance = document.createElement('col'); if (instance.constructor.name === 'HTMLUnknownElement') {return false;}"
+      "__base": "var instance = document.createElement('col'); if (instance.constructor.name === 'HTMLUnknownElement' || instance.constructor.name === 'HTMLElement') {return false;}"
     },
     "HTMLTableElement": {
-      "__base": "var instance = document.createElement('table'); if (instance.constructor.name === 'HTMLUnknownElement') {return false;}"
+      "__base": "var instance = document.createElement('table'); if (instance.constructor.name === 'HTMLUnknownElement' || instance.constructor.name === 'HTMLElement') {return false;}"
     },
     "HTMLTableRowElement": {
-      "__base": "var instance = document.createElement('tr'); if (instance.constructor.name === 'HTMLUnknownElement') {return false;}"
+      "__base": "var instance = document.createElement('tr'); if (instance.constructor.name === 'HTMLUnknownElement' || instance.constructor.name === 'HTMLElement') {return false;}"
     },
     "HTMLTableSectionElement": {
-      "__base": "var instance = document.createElement('tbody'); if (instance.constructor.name === 'HTMLUnknownElement') {return false;}"
+      "__base": "var instance = document.createElement('tbody'); if (instance.constructor.name === 'HTMLUnknownElement' || instance.constructor.name === 'HTMLElement') {return false;}"
     },
     "HTMLTemplateElement": {
-      "__base": "var instance = document.createElement('template'); if (instance.constructor.name === 'HTMLUnknownElement') {return false;}"
+      "__base": "var instance = document.createElement('template'); if (instance.constructor.name === 'HTMLUnknownElement' || instance.constructor.name === 'HTMLElement') {return false;}"
     },
     "HTMLTextAreaElement": {
-      "__base": "var instance = document.createElement('textarea'); if (instance.constructor.name === 'HTMLUnknownElement') {return false;}"
+      "__base": "var instance = document.createElement('textarea'); if (instance.constructor.name === 'HTMLUnknownElement' || instance.constructor.name === 'HTMLElement') {return false;}"
     },
     "HTMLTimeElement": {
-      "__base": "var instance = document.createElement('time'); if (instance.constructor.name === 'HTMLUnknownElement') {return false;}"
+      "__base": "var instance = document.createElement('time'); if (instance.constructor.name === 'HTMLUnknownElement' || instance.constructor.name === 'HTMLElement') {return false;}"
     },
     "HTMLTitleElement": {
-      "__base": "var instance = document.createElement('title'); if (instance.constructor.name === 'HTMLUnknownElement') {return false;}"
+      "__base": "var instance = document.createElement('title'); if (instance.constructor.name === 'HTMLUnknownElement' || instance.constructor.name === 'HTMLElement') {return false;}"
     },
     "HTMLTrackElement": {
-      "__base": "var instance = document.createElement('track'); if (instance.constructor.name === 'HTMLUnknownElement') {return false;}"
+      "__base": "var instance = document.createElement('track'); if (instance.constructor.name === 'HTMLUnknownElement' || instance.constructor.name === 'HTMLElement') {return false;}"
     },
     "HTMLUListElement": {
-      "__base": "var instance = document.createElement('ul'); if (instance.constructor.name === 'HTMLUnknownElement') {return false;}"
+      "__base": "var instance = document.createElement('ul'); if (instance.constructor.name === 'HTMLUnknownElement' || instance.constructor.name === 'HTMLElement') {return false;}"
     },
     "HTMLUnknownElement": {
-      "__base": "var instance = document.createElement('unknown');"
+      "__base": "var instance = document.createElement('unknown'); if (instance.constructor.name === 'HTMLElement') {return false;}"
     },
     "HTMLVideoElement": {
-      "__base": "var instance = document.createElement('video'); if (instance.constructor.name === 'HTMLUnknownElement') {return false;}"
+      "__base": "var instance = document.createElement('video'); if (instance.constructor.name === 'HTMLUnknownElement' || instance.constructor.name === 'HTMLElement') {return false;}"
     },
     "IIRFilterNode": {
       "__resources": ["audioContext"],


### PR DESCRIPTION
This PR fixes the HTML element API tests by testing if the constructor is not `HTMLUnknownElement` __or__ `HTMLElement` (before, it only tested if it's not `HTMLUnknownElement`, which causes issues when the browser doesn't support `HTMLUnknownElement`).