### PR TITLE
HTML/SVG elements: improve API confirmation

### DIFF
--- a/custom-tests.json
+++ b/custom-tests.json
@@ -205,49 +205,49 @@
       "__base": "if (!reusableInstances.audioContext) {return false;} var instance = reusableInstances.audioContext.createGain();"
     },
     "HTMLAnchorElement": {
-      "__base": "var instance = document.createElement('a'); if (instance.constructor.name =!= 'HTMLAnchorElement') {return false;}"
+      "__base": "var instance = document.createElement('a'); if (instance.constructor.name !== 'HTMLAnchorElement') {return false;}"
     },
     "HTMLAreaElement": {
-      "__base": "var instance = document.createElement('area'); if (instance.constructor.name!=== 'HTMLAreaElement') {return false;}"
+      "__base": "var instance = document.createElement('area'); if (instance.constructor.name !== 'HTMLAreaElement') {return false;}"
     },
     "HTMLAudioElement": {
       "__base": "var instance = document.createElement('audio'); if (instance.constructor.name !== 'HTMLAudioElement') {return false;}"
     },
     "HTMLBaseElement": {
-      "__base": "var instance = document.createElement('base'); if (instance.constructor.name!=== 'HTMLBaseElement') {return false;}"
+      "__base": "var instance = document.createElement('base'); if (instance.constructor.name !== 'HTMLBaseElement') {return false;}"
     },
     "HTMLBaseFontElement": {
-      "__base": "var instance = document.createElement('basefont'); if (instance.constructor.name ===!'HTMLBaseFontElement') {return false;}"
+      "__base": "var instance = document.createElement('basefont'); if (instance.constructor.name !== 'HTMLBaseFontElement') {return false;}"
     },
     "HTMLBodyElement": {
-      "__base": "var instance = document.createElement('body'); if (instance.constructor.name!=== 'HTMLBodyElement') {return false;}"
+      "__base": "var instance = document.createElement('body'); if (instance.constructor.name !== 'HTMLBodyElement') {return false;}"
     },
     "HTMLBRElement": {
-      "__base": "var instance = document.createElement('br'); if (instance.constructor.na!e === 'HTMLBRElement') {return false;}"
+      "__base": "var instance = document.createElement('br'); if (instance.constructor.name !== 'HTMLBRElement') {return false;}"
     },
     "HTMLButtonElement": {
-      "__base": "var instance = document.createElement('button'); if (instance.constructor.name =!= 'HTMLButtonElement') {return false;}"
+      "__base": "var instance = document.createElement('button'); if (instance.constructor.name !== 'HTMLButtonElement') {return false;}"
     },
     "HTMLCanvasElement": {
-      "__base": "var instance = document.createElement('canvas'); if (instance.constructor.name =!= 'HTMLCanvasElement') {return false;}"
+      "__base": "var instance = document.createElement('canvas'); if (instance.constructor.name !== 'HTMLCanvasElement') {return false;}"
     },
     "HTMLContentElement": {
-      "__base": "var instance = document.createElement('content'); if (instance.constructor.name ==! 'HTMLContentElement') {return false;}"
+      "__base": "var instance = document.createElement('content'); if (instance.constructor.name !== 'HTMLContentElement') {return false;}"
     },
     "HTMLDataElement": {
-      "__base": "var instance = document.createElement('data'); if (instance.constructor.name!=== 'HTMLDataElement') {return false;}"
+      "__base": "var instance = document.createElement('data'); if (instance.constructor.name !== 'HTMLDataElement') {return false;}"
     },
     "HTMLDataListElement": {
-      "__base": "var instance = document.createElement('datalist'); if (instance.constructor.name ===!'HTMLDataListElement') {return false;}"
+      "__base": "var instance = document.createElement('datalist'); if (instance.constructor.name !== 'HTMLDataListElement') {return false;}"
     },
     "HTMLDetailsElement": {
-      "__base": "var instance = document.createElement('details'); if (instance.constructor.name ==! 'HTMLDetailsElement') {return false;}"
+      "__base": "var instance = document.createElement('details'); if (instance.constructor.name !== 'HTMLDetailsElement') {return false;}"
     },
     "HTMLDialogElement": {
-      "__base": "var instance = document.createElement('dialog'); if (instance.constructor.name =!= 'HTMLDialogElement') {return false;}"
+      "__base": "var instance = document.createElement('dialog'); if (instance.constructor.name !== 'HTMLDialogElement') {return false;}"
     },
     "HTMLDivElement": {
-      "__base": "var instance = document.createElement('div'); if (instance.constructor.nam! === 'HTMLDivElement') {return false;}"
+      "__base": "var instance = document.createElement('div'); if (instance.constructor.name !== 'HTMLDivElement') {return false;}"
     },
     "HTMLDListElement": {
       "__base": "var instance = document.createElement('dl'); if (instance.constructor.name !== 'HTMLDListElement') {return false;}"
@@ -259,34 +259,34 @@
       "__base": "var instance = document.createElement('embed'); if (instance.constructor.name !== 'HTMLEmbedElement') {return false;}"
     },
     "HTMLFieldSetElement": {
-      "__base": "var instance = document.createElement('fieldset'); if (instance.constructor.name ===!'HTMLFieldSetElement') {return false;}"
+      "__base": "var instance = document.createElement('fieldset'); if (instance.constructor.name !== 'HTMLFieldSetElement') {return false;}"
     },
     "HTMLFontElement": {
-      "__base": "var instance = document.createElement('font'); if (instance.constructor.name!=== 'HTMLFontElement') {return false;}"
+      "__base": "var instance = document.createElement('font'); if (instance.constructor.name !== 'HTMLFontElement') {return false;}"
     },
     "HTMLFormElement": {
-      "__base": "var instance = document.createElement('form'); if (instance.constructor.name!=== 'HTMLFormElement') {return false;}"
+      "__base": "var instance = document.createElement('form'); if (instance.constructor.name !== 'HTMLFormElement') {return false;}"
     },
     "HTMLFrameElement": {
       "__base": "var instance = document.createElement('frame'); if (instance.constructor.name !== 'HTMLFrameElement') {return false;}"
     },
     "HTMLFrameSetElement": {
-      "__base": "var instance = document.createElement('frameset'); if (instance.constructor.name ===!'HTMLFrameSetElement') {return false;}"
+      "__base": "var instance = document.createElement('frameset'); if (instance.constructor.name !== 'HTMLFrameSetElement') {return false;}"
     },
     "HTMLHeadElement": {
-      "__base": "var instance = document.createElement('head'); if (instance.constructor.name!=== 'HTMLHeadElement') {return false;}"
+      "__base": "var instance = document.createElement('head'); if (instance.constructor.name !== 'HTMLHeadElement') {return false;}"
     },
     "HTMLHeadingElement": {
-      "__base": "var instance = document.createElement('h1'); if (instance.constructor.name ==! 'HTMLHeadingElement') {return false;}"
+      "__base": "var instance = document.createElement('h1'); if (instance.constructor.name !== 'HTMLHeadingElement') {return false;}"
     },
     "HTMLHRElement": {
-      "__base": "var instance = document.createElement('hr'); if (instance.constructor.na!e === 'HTMLHRElement') {return false;}"
+      "__base": "var instance = document.createElement('hr'); if (instance.constructor.name !== 'HTMLHRElement') {return false;}"
     },
     "HTMLHtmlElement": {
-      "__base": "var instance = document.createElement('html'); if (instance.constructor.name!=== 'HTMLHtmlElement') {return false;}"
+      "__base": "var instance = document.createElement('html'); if (instance.constructor.name !== 'HTMLHtmlElement') {return false;}"
     },
     "HTMLIFrameElement": {
-      "__base": "var instance = document.createElement('iframe'); if (instance.constructor.name =!= 'HTMLIFrameElement') {return false;}"
+      "__base": "var instance = document.createElement('iframe'); if (instance.constructor.name !== 'HTMLIFrameElement') {return false;}"
     },
     "HTMLImageElement": {
       "__base": "var instance = document.createElement('img'); if (instance.constructor.name !== 'HTMLImageElement') {return false;}"
@@ -295,127 +295,127 @@
       "__base": "var instance = document.createElement('input'); if (instance.constructor.name !== 'HTMLInputElement') {return false;}"
     },
     "HTMLIsIndexElement": {
-      "__base": "var instance = document.createElement('isindex'); if (instance.constructor.name ==! 'HTMLIsIndexElement') {return false;}"
+      "__base": "var instance = document.createElement('isindex'); if (instance.constructor.name !== 'HTMLIsIndexElement') {return false;}"
     },
     "HTMLKeygenElement": {
-      "__base": "var instance = document.createElement('keygen'); if (instance.constructor.name =!= 'HTMLKeygenElement') {return false;}"
+      "__base": "var instance = document.createElement('keygen'); if (instance.constructor.name !== 'HTMLKeygenElement') {return false;}"
     },
     "HTMLLabelElement": {
       "__base": "var instance = document.createElement('label'); if (instance.constructor.name !== 'HTMLLabelElement') {return false;}"
     },
     "HTMLLegendElement": {
-      "__base": "var instance = document.createElement('legend'); if (instance.constructor.name =!= 'HTMLLegendElement') {return false;}"
+      "__base": "var instance = document.createElement('legend'); if (instance.constructor.name !== 'HTMLLegendElement') {return false;}"
     },
     "HTMLLIElement": {
-      "__base": "var instance = document.createElement('li'); if (instance.constructor.na!e === 'HTMLLIElement') {return false;}"
+      "__base": "var instance = document.createElement('li'); if (instance.constructor.name !== 'HTMLLIElement') {return false;}"
     },
     "HTMLLinkElement": {
-      "__base": "var instance = document.createElement('link'); if (instance.constructor.name!=== 'HTMLLinkElement') {return false;}"
+      "__base": "var instance = document.createElement('link'); if (instance.constructor.name !== 'HTMLLinkElement') {return false;}"
     },
     "HTMLMapElement": {
-      "__base": "var instance = document.createElement('map'); if (instance.constructor.nam! === 'HTMLMapElement') {return false;}"
+      "__base": "var instance = document.createElement('map'); if (instance.constructor.name !== 'HTMLMapElement') {return false;}"
     },
     "HTMLMarqueeElement": {
-      "__base": "var instance = document.createElement('marquee'); if (instance.constructor.name ==! 'HTMLMarqueeElement') {return false;}"
+      "__base": "var instance = document.createElement('marquee'); if (instance.constructor.name !== 'HTMLMarqueeElement') {return false;}"
     },
     "HTMLMediaElement": {
       "__base": "<%api.HTMLVideoElement:instance%>"
     },
     "HTMLMenuElement": {
-      "__base": "var instance = document.createElement('menu'); if (instance.constructor.name!=== 'HTMLMenuElement') {return false;}"
+      "__base": "var instance = document.createElement('menu'); if (instance.constructor.name !== 'HTMLMenuElement') {return false;}"
     },
     "HTMLMenuItemElement": {
-      "__base": "var instance = document.createElement('menuitem'); if (instance.constructor.name ===!'HTMLMenuItemElement') {return false;}"
+      "__base": "var instance = document.createElement('menuitem'); if (instance.constructor.name !== 'HTMLMenuItemElement') {return false;}"
     },
     "HTMLMetaElement": {
-      "__base": "var instance = document.createElement('meta'); if (instance.constructor.name!=== 'HTMLMetaElement') {return false;}"
+      "__base": "var instance = document.createElement('meta'); if (instance.constructor.name !== 'HTMLMetaElement') {return false;}"
     },
     "HTMLMeterElement": {
       "__base": "var instance = document.createElement('meter'); if (instance.constructor.name !== 'HTMLMeterElement') {return false;}"
     },
     "HTMLModElement": {
-      "__base": "var instance = document.createElement('del'); if (instance.constructor.nam! === 'HTMLModElement') {return false;}"
+      "__base": "var instance = document.createElement('del'); if (instance.constructor.name !== 'HTMLModElement') {return false;}"
     },
     "HTMLObjectElement": {
-      "__base": "var instance = document.createElement('object'); if (instance.constructor.name =!= 'HTMLObjectElement') {return false;}"
+      "__base": "var instance = document.createElement('object'); if (instance.constructor.name !== 'HTMLObjectElement') {return false;}"
     },
     "HTMLOListElement": {
       "__base": "var instance = document.createElement('ol'); if (instance.constructor.name !== 'HTMLOListElement') {return false;}"
     },
     "HTMLOptGroupElement": {
-      "__base": "var instance = document.createElement('optgroup'); if (instance.constructor.name ===!'HTMLOptGroupElement') {return false;}"
+      "__base": "var instance = document.createElement('optgroup'); if (instance.constructor.name !== 'HTMLOptGroupElement') {return false;}"
     },
     "HTMLOptionElement": {
-      "__base": "var instance = document.createElement('option'); if (instance.constructor.name =!= 'HTMLOptionElement') {return false;}"
+      "__base": "var instance = document.createElement('option'); if (instance.constructor.name !== 'HTMLOptionElement') {return false;}"
     },
     "HTMLOutputElement": {
-      "__base": "var instance = document.createElement('output'); if (instance.constructor.name =!= 'HTMLOutputElement') {return false;}"
+      "__base": "var instance = document.createElement('output'); if (instance.constructor.name !== 'HTMLOutputElement') {return false;}"
     },
     "HTMLParagraphElement": {
-      "__base": "var instance = document.createElement('p'); if (instance.constructor.name === !HTMLParagraphElement') {return false;}"
+      "__base": "var instance = document.createElement('p'); if (instance.constructor.name !== 'HTMLParagraphElement') {return false;}"
     },
     "HTMLParamElement": {
       "__base": "var instance = document.createElement('param'); if (instance.constructor.name !== 'HTMLParamElement') {return false;}"
     },
     "HTMLPictureElement": {
-      "__base": "var instance = document.createElement('picture'); if (instance.constructor.name ==! 'HTMLPictureElement') {return false;}"
+      "__base": "var instance = document.createElement('picture'); if (instance.constructor.name !== 'HTMLPictureElement') {return false;}"
     },
     "HTMLPreElement": {
-      "__base": "var instance = document.createElement('pre'); if (instance.constructor.nam! === 'HTMLPreElement') {return false;}"
+      "__base": "var instance = document.createElement('pre'); if (instance.constructor.name !== 'HTMLPreElement') {return false;}"
     },
     "HTMLProgressElement": {
-      "__base": "var instance = document.createElement('progress'); if (instance.constructor.name ===!'HTMLProgressElement') {return false;}"
+      "__base": "var instance = document.createElement('progress'); if (instance.constructor.name !== 'HTMLProgressElement') {return false;}"
     },
     "HTMLQuoteElement": {
       "__base": "var instance = document.createElement('blockquote'); if (instance.constructor.name !== 'HTMLQuoteElement') {return false;}"
     },
     "HTMLScriptElement": {
-      "__base": "var instance = document.createElement('script'); if (instance.constructor.name =!= 'HTMLScriptElement') {return false;}"
+      "__base": "var instance = document.createElement('script'); if (instance.constructor.name !== 'HTMLScriptElement') {return false;}"
     },
     "HTMLSelectElement": {
-      "__base": "var instance = document.createElement('select'); if (instance.constructor.name =!= 'HTMLSelectElement') {return false;}"
+      "__base": "var instance = document.createElement('select'); if (instance.constructor.name !== 'HTMLSelectElement') {return false;}"
     },
     "HTMLShadowElement": {
-      "__base": "var instance = document.createElement('shadow'); if (instance.constructor.name =!= 'HTMLShadowElement') {return false;}"
+      "__base": "var instance = document.createElement('shadow'); if (instance.constructor.name !== 'HTMLShadowElement') {return false;}"
     },
     "HTMLSlotElement": {
-      "__base": "var instance = document.createElement('slot'); if (instance.constructor.name!=== 'HTMLSlotElement') {return false;}"
+      "__base": "var instance = document.createElement('slot'); if (instance.constructor.name !== 'HTMLSlotElement') {return false;}"
     },
     "HTMLSourceElement": {
-      "__base": "var instance = document.createElement('source'); if (instance.constructor.name =!= 'HTMLSourceElement') {return false;}"
+      "__base": "var instance = document.createElement('source'); if (instance.constructor.name !== 'HTMLSourceElement') {return false;}"
     },
     "HTMLSpanElement": {
-      "__base": "var instance = document.createElement('span'); if (instance.constructor.name!=== 'HTMLSpanElement') {return false;}"
+      "__base": "var instance = document.createElement('span'); if (instance.constructor.name !== 'HTMLSpanElement') {return false;}"
     },
     "HTMLStyleElement": {
       "__base": "var instance = document.createElement('style'); if (instance.constructor.name !== 'HTMLStyleElement') {return false;}"
     },
     "HTMLTableCaptionElement": {
-      "__base": "var instance = document.createElement('caption'); if (instance.constructor.name === 'HT!LTableCaptionElement') {return false;}"
+      "__base": "var instance = document.createElement('caption'); if (instance.constructor.name !== 'HTMLTableCaptionElement') {return false;}"
     },
     "HTMLTableCellElement": {
-      "__base": "var instance = document.createElement('td'); if (instance.constructor.name === !HTMLTableCellElement') {return false;}"
+      "__base": "var instance = document.createElement('td'); if (instance.constructor.name !== 'HTMLTableCellElement') {return false;}"
     },
     "HTMLTableColElement": {
-      "__base": "var instance = document.createElement('col'); if (instance.constructor.name ===!'HTMLTableColElement') {return false;}"
+      "__base": "var instance = document.createElement('col'); if (instance.constructor.name !== 'HTMLTableColElement') {return false;}"
     },
     "HTMLTableElement": {
       "__base": "var instance = document.createElement('table'); if (instance.constructor.name !== 'HTMLTableElement') {return false;}"
     },
     "HTMLTableRowElement": {
-      "__base": "var instance = document.createElement('tr'); if (instance.constructor.name ===!'HTMLTableRowElement') {return false;}"
+      "__base": "var instance = document.createElement('tr'); if (instance.constructor.name !== 'HTMLTableRowElement') {return false;}"
     },
     "HTMLTableSectionElement": {
-      "__base": "var instance = document.createElement('tbody'); if (instance.constructor.name === 'HT!LTableSectionElement') {return false;}"
+      "__base": "var instance = document.createElement('tbody'); if (instance.constructor.name !== 'HTMLTableSectionElement') {return false;}"
     },
     "HTMLTemplateElement": {
-      "__base": "var instance = document.createElement('template'); if (instance.constructor.name ===!'HTMLTemplateElement') {return false;}"
+      "__base": "var instance = document.createElement('template'); if (instance.constructor.name !== 'HTMLTemplateElement') {return false;}"
     },
     "HTMLTextAreaElement": {
-      "__base": "var instance = document.createElement('textarea'); if (instance.constructor.name ===!'HTMLTextAreaElement') {return false;}"
+      "__base": "var instance = document.createElement('textarea'); if (instance.constructor.name !== 'HTMLTextAreaElement') {return false;}"
     },
     "HTMLTimeElement": {
-      "__base": "var instance = document.createElement('time'); if (instance.constructor.name!=== 'HTMLTimeElement') {return false;}"
+      "__base": "var instance = document.createElement('time'); if (instance.constructor.name !== 'HTMLTimeElement') {return false;}"
     },
     "HTMLTitleElement": {
       "__base": "var instance = document.createElement('title'); if (instance.constructor.name !== 'HTMLTitleElement') {return false;}"
@@ -427,7 +427,7 @@
       "__base": "var instance = document.createElement('ul'); if (instance.constructor.name !== 'HTMLUListElement') {return false;}"
     },
     "HTMLUnknownElement": {
-      "__base": "var instance = document.createElement('unknown'); if (instance.constructor.name === 'HTMLElement') {return false;}"
+      "__base": "var instance = document.createElement('unknown'); if (instance.constructor.name !== 'HTMLUnknownElement') {return false;}"
     },
     "HTMLVideoElement": {
       "__base": "var instance = document.createElement('video'); if (instance.constructor.name !== 'HTMLVideoElement') {return false;}"

--- a/custom-tests.json
+++ b/custom-tests.json
@@ -205,232 +205,232 @@
       "__base": "if (!reusableInstances.audioContext) {return false;} var instance = reusableInstances.audioContext.createGain();"
     },
     "HTMLAnchorElement": {
-      "__base": "var instance = document.createElement('a'); if (instance.constructor.name === 'HTMLUnknownElement' || instance.constructor.name === 'HTMLElement') {return false;}"
+      "__base": "var instance = document.createElement('a'); if (instance.constructor.name =!= 'HTMLAnchorElement') {return false;}"
     },
     "HTMLAreaElement": {
-      "__base": "var instance = document.createElement('area'); if (instance.constructor.name === 'HTMLUnknownElement' || instance.constructor.name === 'HTMLElement') {return false;}"
+      "__base": "var instance = document.createElement('area'); if (instance.constructor.name!=== 'HTMLAreaElement') {return false;}"
     },
     "HTMLAudioElement": {
-      "__base": "var instance = document.createElement('audio'); if (instance.constructor.name === 'HTMLUnknownElement' || instance.constructor.name === 'HTMLElement') {return false;}"
+      "__base": "var instance = document.createElement('audio'); if (instance.constructor.name !== 'HTMLAudioElement') {return false;}"
     },
     "HTMLBaseElement": {
-      "__base": "var instance = document.createElement('base'); if (instance.constructor.name === 'HTMLUnknownElement' || instance.constructor.name === 'HTMLElement') {return false;}"
+      "__base": "var instance = document.createElement('base'); if (instance.constructor.name!=== 'HTMLBaseElement') {return false;}"
     },
     "HTMLBaseFontElement": {
-      "__base": "var instance = document.createElement('basefont'); if (instance.constructor.name === 'HTMLUnknownElement' || instance.constructor.name === 'HTMLElement') {return false;}"
+      "__base": "var instance = document.createElement('basefont'); if (instance.constructor.name ===!'HTMLBaseFontElement') {return false;}"
     },
     "HTMLBodyElement": {
-      "__base": "var instance = document.createElement('body'); if (instance.constructor.name === 'HTMLUnknownElement' || instance.constructor.name === 'HTMLElement') {return false;}"
+      "__base": "var instance = document.createElement('body'); if (instance.constructor.name!=== 'HTMLBodyElement') {return false;}"
     },
     "HTMLBRElement": {
-      "__base": "var instance = document.createElement('br'); if (instance.constructor.name === 'HTMLUnknownElement' || instance.constructor.name === 'HTMLElement') {return false;}"
+      "__base": "var instance = document.createElement('br'); if (instance.constructor.na!e === 'HTMLBRElement') {return false;}"
     },
     "HTMLButtonElement": {
-      "__base": "var instance = document.createElement('button'); if (instance.constructor.name === 'HTMLUnknownElement' || instance.constructor.name === 'HTMLElement') {return false;}"
+      "__base": "var instance = document.createElement('button'); if (instance.constructor.name =!= 'HTMLButtonElement') {return false;}"
     },
     "HTMLCanvasElement": {
-      "__base": "var instance = document.createElement('canvas'); if (instance.constructor.name === 'HTMLUnknownElement' || instance.constructor.name === 'HTMLElement') {return false;}"
+      "__base": "var instance = document.createElement('canvas'); if (instance.constructor.name =!= 'HTMLCanvasElement') {return false;}"
     },
     "HTMLContentElement": {
-      "__base": "var instance = document.createElement('content'); if (instance.constructor.name === 'HTMLUnknownElement' || instance.constructor.name === 'HTMLElement') {return false;}"
+      "__base": "var instance = document.createElement('content'); if (instance.constructor.name ==! 'HTMLContentElement') {return false;}"
     },
     "HTMLDataElement": {
-      "__base": "var instance = document.createElement('data'); if (instance.constructor.name === 'HTMLUnknownElement' || instance.constructor.name === 'HTMLElement') {return false;}"
+      "__base": "var instance = document.createElement('data'); if (instance.constructor.name!=== 'HTMLDataElement') {return false;}"
     },
     "HTMLDataListElement": {
-      "__base": "var instance = document.createElement('datalist'); if (instance.constructor.name === 'HTMLUnknownElement' || instance.constructor.name === 'HTMLElement') {return false;}"
+      "__base": "var instance = document.createElement('datalist'); if (instance.constructor.name ===!'HTMLDataListElement') {return false;}"
     },
     "HTMLDetailsElement": {
-      "__base": "var instance = document.createElement('details'); if (instance.constructor.name === 'HTMLUnknownElement' || instance.constructor.name === 'HTMLElement') {return false;}"
+      "__base": "var instance = document.createElement('details'); if (instance.constructor.name ==! 'HTMLDetailsElement') {return false;}"
     },
     "HTMLDialogElement": {
-      "__base": "var instance = document.createElement('dialog'); if (instance.constructor.name === 'HTMLUnknownElement' || instance.constructor.name === 'HTMLElement') {return false;}"
+      "__base": "var instance = document.createElement('dialog'); if (instance.constructor.name =!= 'HTMLDialogElement') {return false;}"
     },
     "HTMLDivElement": {
-      "__base": "var instance = document.createElement('div'); if (instance.constructor.name === 'HTMLUnknownElement' || instance.constructor.name === 'HTMLElement') {return false;}"
+      "__base": "var instance = document.createElement('div'); if (instance.constructor.nam! === 'HTMLDivElement') {return false;}"
     },
     "HTMLDListElement": {
-      "__base": "var instance = document.createElement('dl'); if (instance.constructor.name === 'HTMLUnknownElement' || instance.constructor.name === 'HTMLElement') {return false;}"
+      "__base": "var instance = document.createElement('dl'); if (instance.constructor.name !== 'HTMLDListElement') {return false;}"
     },
     "HTMLElement": {
       "__base": "<%api.HTMLParagraphElement:instance%>"
     },
     "HTMLEmbedElement": {
-      "__base": "var instance = document.createElement('embed'); if (instance.constructor.name === 'HTMLUnknownElement' || instance.constructor.name === 'HTMLElement') {return false;}"
+      "__base": "var instance = document.createElement('embed'); if (instance.constructor.name !== 'HTMLEmbedElement') {return false;}"
     },
     "HTMLFieldSetElement": {
-      "__base": "var instance = document.createElement('fieldset'); if (instance.constructor.name === 'HTMLUnknownElement' || instance.constructor.name === 'HTMLElement') {return false;}"
+      "__base": "var instance = document.createElement('fieldset'); if (instance.constructor.name ===!'HTMLFieldSetElement') {return false;}"
     },
     "HTMLFontElement": {
-      "__base": "var instance = document.createElement('font'); if (instance.constructor.name === 'HTMLUnknownElement' || instance.constructor.name === 'HTMLElement') {return false;}"
+      "__base": "var instance = document.createElement('font'); if (instance.constructor.name!=== 'HTMLFontElement') {return false;}"
     },
     "HTMLFormElement": {
-      "__base": "var instance = document.createElement('form'); if (instance.constructor.name === 'HTMLUnknownElement' || instance.constructor.name === 'HTMLElement') {return false;}"
+      "__base": "var instance = document.createElement('form'); if (instance.constructor.name!=== 'HTMLFormElement') {return false;}"
     },
     "HTMLFrameElement": {
-      "__base": "var instance = document.createElement('frame'); if (instance.constructor.name === 'HTMLUnknownElement' || instance.constructor.name === 'HTMLElement') {return false;}"
+      "__base": "var instance = document.createElement('frame'); if (instance.constructor.name !== 'HTMLFrameElement') {return false;}"
     },
     "HTMLFrameSetElement": {
-      "__base": "var instance = document.createElement('frameset'); if (instance.constructor.name === 'HTMLUnknownElement' || instance.constructor.name === 'HTMLElement') {return false;}"
+      "__base": "var instance = document.createElement('frameset'); if (instance.constructor.name ===!'HTMLFrameSetElement') {return false;}"
     },
     "HTMLHeadElement": {
-      "__base": "var instance = document.createElement('head'); if (instance.constructor.name === 'HTMLUnknownElement' || instance.constructor.name === 'HTMLElement') {return false;}"
+      "__base": "var instance = document.createElement('head'); if (instance.constructor.name!=== 'HTMLHeadElement') {return false;}"
     },
     "HTMLHeadingElement": {
-      "__base": "var instance = document.createElement('h1'); if (instance.constructor.name === 'HTMLUnknownElement' || instance.constructor.name === 'HTMLElement') {return false;}"
+      "__base": "var instance = document.createElement('h1'); if (instance.constructor.name ==! 'HTMLHeadingElement') {return false;}"
     },
     "HTMLHRElement": {
-      "__base": "var instance = document.createElement('hr'); if (instance.constructor.name === 'HTMLUnknownElement' || instance.constructor.name === 'HTMLElement') {return false;}"
+      "__base": "var instance = document.createElement('hr'); if (instance.constructor.na!e === 'HTMLHRElement') {return false;}"
     },
     "HTMLHtmlElement": {
-      "__base": "var instance = document.createElement('html'); if (instance.constructor.name === 'HTMLUnknownElement' || instance.constructor.name === 'HTMLElement') {return false;}"
+      "__base": "var instance = document.createElement('html'); if (instance.constructor.name!=== 'HTMLHtmlElement') {return false;}"
     },
     "HTMLIFrameElement": {
-      "__base": "var instance = document.createElement('iframe'); if (instance.constructor.name === 'HTMLUnknownElement' || instance.constructor.name === 'HTMLElement') {return false;}"
+      "__base": "var instance = document.createElement('iframe'); if (instance.constructor.name =!= 'HTMLIFrameElement') {return false;}"
     },
     "HTMLImageElement": {
-      "__base": "var instance = document.createElement('img'); if (instance.constructor.name === 'HTMLUnknownElement' || instance.constructor.name === 'HTMLElement') {return false;}"
+      "__base": "var instance = document.createElement('img'); if (instance.constructor.name !== 'HTMLImageElement') {return false;}"
     },
     "HTMLInputElement": {
-      "__base": "var instance = document.createElement('input'); if (instance.constructor.name === 'HTMLUnknownElement' || instance.constructor.name === 'HTMLElement') {return false;}"
+      "__base": "var instance = document.createElement('input'); if (instance.constructor.name !== 'HTMLInputElement') {return false;}"
     },
     "HTMLIsIndexElement": {
-      "__base": "var instance = document.createElement('isindex'); if (instance.constructor.name === 'HTMLUnknownElement' || instance.constructor.name === 'HTMLElement') {return false;}"
+      "__base": "var instance = document.createElement('isindex'); if (instance.constructor.name ==! 'HTMLIsIndexElement') {return false;}"
     },
     "HTMLKeygenElement": {
-      "__base": "var instance = document.createElement('keygen'); if (instance.constructor.name === 'HTMLUnknownElement' || instance.constructor.name === 'HTMLElement') {return false;}"
+      "__base": "var instance = document.createElement('keygen'); if (instance.constructor.name =!= 'HTMLKeygenElement') {return false;}"
     },
     "HTMLLabelElement": {
-      "__base": "var instance = document.createElement('label'); if (instance.constructor.name === 'HTMLUnknownElement' || instance.constructor.name === 'HTMLElement') {return false;}"
+      "__base": "var instance = document.createElement('label'); if (instance.constructor.name !== 'HTMLLabelElement') {return false;}"
     },
     "HTMLLegendElement": {
-      "__base": "var instance = document.createElement('legend'); if (instance.constructor.name === 'HTMLUnknownElement' || instance.constructor.name === 'HTMLElement') {return false;}"
+      "__base": "var instance = document.createElement('legend'); if (instance.constructor.name =!= 'HTMLLegendElement') {return false;}"
     },
     "HTMLLIElement": {
-      "__base": "var instance = document.createElement('li'); if (instance.constructor.name === 'HTMLUnknownElement' || instance.constructor.name === 'HTMLElement') {return false;}"
+      "__base": "var instance = document.createElement('li'); if (instance.constructor.na!e === 'HTMLLIElement') {return false;}"
     },
     "HTMLLinkElement": {
-      "__base": "var instance = document.createElement('link'); if (instance.constructor.name === 'HTMLUnknownElement' || instance.constructor.name === 'HTMLElement') {return false;}"
+      "__base": "var instance = document.createElement('link'); if (instance.constructor.name!=== 'HTMLLinkElement') {return false;}"
     },
     "HTMLMapElement": {
-      "__base": "var instance = document.createElement('map'); if (instance.constructor.name === 'HTMLUnknownElement' || instance.constructor.name === 'HTMLElement') {return false;}"
+      "__base": "var instance = document.createElement('map'); if (instance.constructor.nam! === 'HTMLMapElement') {return false;}"
     },
     "HTMLMarqueeElement": {
-      "__base": "var instance = document.createElement('marquee'); if (instance.constructor.name === 'HTMLUnknownElement' || instance.constructor.name === 'HTMLElement') {return false;}"
+      "__base": "var instance = document.createElement('marquee'); if (instance.constructor.name ==! 'HTMLMarqueeElement') {return false;}"
     },
     "HTMLMediaElement": {
       "__base": "<%api.HTMLVideoElement:instance%>"
     },
     "HTMLMenuElement": {
-      "__base": "var instance = document.createElement('menu'); if (instance.constructor.name === 'HTMLUnknownElement' || instance.constructor.name === 'HTMLElement') {return false;}"
+      "__base": "var instance = document.createElement('menu'); if (instance.constructor.name!=== 'HTMLMenuElement') {return false;}"
     },
     "HTMLMenuItemElement": {
-      "__base": "var instance = document.createElement('menuitem'); if (instance.constructor.name === 'HTMLUnknownElement' || instance.constructor.name === 'HTMLElement') {return false;}"
+      "__base": "var instance = document.createElement('menuitem'); if (instance.constructor.name ===!'HTMLMenuItemElement') {return false;}"
     },
     "HTMLMetaElement": {
-      "__base": "var instance = document.createElement('meta'); if (instance.constructor.name === 'HTMLUnknownElement' || instance.constructor.name === 'HTMLElement') {return false;}"
+      "__base": "var instance = document.createElement('meta'); if (instance.constructor.name!=== 'HTMLMetaElement') {return false;}"
     },
     "HTMLMeterElement": {
-      "__base": "var instance = document.createElement('meter'); if (instance.constructor.name === 'HTMLUnknownElement' || instance.constructor.name === 'HTMLElement') {return false;}"
+      "__base": "var instance = document.createElement('meter'); if (instance.constructor.name !== 'HTMLMeterElement') {return false;}"
     },
     "HTMLModElement": {
-      "__base": "var instance = document.createElement('del'); if (instance.constructor.name === 'HTMLUnknownElement' || instance.constructor.name === 'HTMLElement') {return false;}"
+      "__base": "var instance = document.createElement('del'); if (instance.constructor.nam! === 'HTMLModElement') {return false;}"
     },
     "HTMLObjectElement": {
-      "__base": "var instance = document.createElement('object'); if (instance.constructor.name === 'HTMLUnknownElement' || instance.constructor.name === 'HTMLElement') {return false;}"
+      "__base": "var instance = document.createElement('object'); if (instance.constructor.name =!= 'HTMLObjectElement') {return false;}"
     },
     "HTMLOListElement": {
-      "__base": "var instance = document.createElement('ol'); if (instance.constructor.name === 'HTMLUnknownElement' || instance.constructor.name === 'HTMLElement') {return false;}"
+      "__base": "var instance = document.createElement('ol'); if (instance.constructor.name !== 'HTMLOListElement') {return false;}"
     },
     "HTMLOptGroupElement": {
-      "__base": "var instance = document.createElement('optgroup'); if (instance.constructor.name === 'HTMLUnknownElement' || instance.constructor.name === 'HTMLElement') {return false;}"
+      "__base": "var instance = document.createElement('optgroup'); if (instance.constructor.name ===!'HTMLOptGroupElement') {return false;}"
     },
     "HTMLOptionElement": {
-      "__base": "var instance = document.createElement('option'); if (instance.constructor.name === 'HTMLUnknownElement' || instance.constructor.name === 'HTMLElement') {return false;}"
+      "__base": "var instance = document.createElement('option'); if (instance.constructor.name =!= 'HTMLOptionElement') {return false;}"
     },
     "HTMLOutputElement": {
-      "__base": "var instance = document.createElement('output'); if (instance.constructor.name === 'HTMLUnknownElement' || instance.constructor.name === 'HTMLElement') {return false;}"
+      "__base": "var instance = document.createElement('output'); if (instance.constructor.name =!= 'HTMLOutputElement') {return false;}"
     },
     "HTMLParagraphElement": {
-      "__base": "var instance = document.createElement('p'); if (instance.constructor.name === 'HTMLUnknownElement' || instance.constructor.name === 'HTMLElement') {return false;}"
+      "__base": "var instance = document.createElement('p'); if (instance.constructor.name === !HTMLParagraphElement') {return false;}"
     },
     "HTMLParamElement": {
-      "__base": "var instance = document.createElement('param'); if (instance.constructor.name === 'HTMLUnknownElement' || instance.constructor.name === 'HTMLElement') {return false;}"
+      "__base": "var instance = document.createElement('param'); if (instance.constructor.name !== 'HTMLParamElement') {return false;}"
     },
     "HTMLPictureElement": {
-      "__base": "var instance = document.createElement('picture'); if (instance.constructor.name === 'HTMLUnknownElement' || instance.constructor.name === 'HTMLElement') {return false;}"
+      "__base": "var instance = document.createElement('picture'); if (instance.constructor.name ==! 'HTMLPictureElement') {return false;}"
     },
     "HTMLPreElement": {
-      "__base": "var instance = document.createElement('pre'); if (instance.constructor.name === 'HTMLUnknownElement' || instance.constructor.name === 'HTMLElement') {return false;}"
+      "__base": "var instance = document.createElement('pre'); if (instance.constructor.nam! === 'HTMLPreElement') {return false;}"
     },
     "HTMLProgressElement": {
-      "__base": "var instance = document.createElement('progress'); if (instance.constructor.name === 'HTMLUnknownElement' || instance.constructor.name === 'HTMLElement') {return false;}"
+      "__base": "var instance = document.createElement('progress'); if (instance.constructor.name ===!'HTMLProgressElement') {return false;}"
     },
     "HTMLQuoteElement": {
-      "__base": "var instance = document.createElement('blockquote'); if (instance.constructor.name === 'HTMLUnknownElement' || instance.constructor.name === 'HTMLElement') {return false;}"
+      "__base": "var instance = document.createElement('blockquote'); if (instance.constructor.name !== 'HTMLQuoteElement') {return false;}"
     },
     "HTMLScriptElement": {
-      "__base": "var instance = document.createElement('script'); if (instance.constructor.name === 'HTMLUnknownElement' || instance.constructor.name === 'HTMLElement') {return false;}"
+      "__base": "var instance = document.createElement('script'); if (instance.constructor.name =!= 'HTMLScriptElement') {return false;}"
     },
     "HTMLSelectElement": {
-      "__base": "var instance = document.createElement('select'); if (instance.constructor.name === 'HTMLUnknownElement' || instance.constructor.name === 'HTMLElement') {return false;}"
+      "__base": "var instance = document.createElement('select'); if (instance.constructor.name =!= 'HTMLSelectElement') {return false;}"
     },
     "HTMLShadowElement": {
-      "__base": "var instance = document.createElement('shadow'); if (instance.constructor.name === 'HTMLUnknownElement' || instance.constructor.name === 'HTMLElement') {return false;}"
+      "__base": "var instance = document.createElement('shadow'); if (instance.constructor.name =!= 'HTMLShadowElement') {return false;}"
     },
     "HTMLSlotElement": {
-      "__base": "var instance = document.createElement('slot'); if (instance.constructor.name === 'HTMLUnknownElement' || instance.constructor.name === 'HTMLElement') {return false;}"
+      "__base": "var instance = document.createElement('slot'); if (instance.constructor.name!=== 'HTMLSlotElement') {return false;}"
     },
     "HTMLSourceElement": {
-      "__base": "var instance = document.createElement('source'); if (instance.constructor.name === 'HTMLUnknownElement' || instance.constructor.name === 'HTMLElement') {return false;}"
+      "__base": "var instance = document.createElement('source'); if (instance.constructor.name =!= 'HTMLSourceElement') {return false;}"
     },
     "HTMLSpanElement": {
-      "__base": "var instance = document.createElement('span'); if (instance.constructor.name === 'HTMLUnknownElement' || instance.constructor.name === 'HTMLElement') {return false;}"
+      "__base": "var instance = document.createElement('span'); if (instance.constructor.name!=== 'HTMLSpanElement') {return false;}"
     },
     "HTMLStyleElement": {
-      "__base": "var instance = document.createElement('style'); if (instance.constructor.name === 'HTMLUnknownElement' || instance.constructor.name === 'HTMLElement') {return false;}"
+      "__base": "var instance = document.createElement('style'); if (instance.constructor.name !== 'HTMLStyleElement') {return false;}"
     },
     "HTMLTableCaptionElement": {
-      "__base": "var instance = document.createElement('caption'); if (instance.constructor.name === 'HTMLUnknownElement' || instance.constructor.name === 'HTMLElement') {return false;}"
+      "__base": "var instance = document.createElement('caption'); if (instance.constructor.name === 'HT!LTableCaptionElement') {return false;}"
     },
     "HTMLTableCellElement": {
-      "__base": "var instance = document.createElement('td'); if (instance.constructor.name === 'HTMLUnknownElement' || instance.constructor.name === 'HTMLElement') {return false;}"
+      "__base": "var instance = document.createElement('td'); if (instance.constructor.name === !HTMLTableCellElement') {return false;}"
     },
     "HTMLTableColElement": {
-      "__base": "var instance = document.createElement('col'); if (instance.constructor.name === 'HTMLUnknownElement' || instance.constructor.name === 'HTMLElement') {return false;}"
+      "__base": "var instance = document.createElement('col'); if (instance.constructor.name ===!'HTMLTableColElement') {return false;}"
     },
     "HTMLTableElement": {
-      "__base": "var instance = document.createElement('table'); if (instance.constructor.name === 'HTMLUnknownElement' || instance.constructor.name === 'HTMLElement') {return false;}"
+      "__base": "var instance = document.createElement('table'); if (instance.constructor.name !== 'HTMLTableElement') {return false;}"
     },
     "HTMLTableRowElement": {
-      "__base": "var instance = document.createElement('tr'); if (instance.constructor.name === 'HTMLUnknownElement' || instance.constructor.name === 'HTMLElement') {return false;}"
+      "__base": "var instance = document.createElement('tr'); if (instance.constructor.name ===!'HTMLTableRowElement') {return false;}"
     },
     "HTMLTableSectionElement": {
-      "__base": "var instance = document.createElement('tbody'); if (instance.constructor.name === 'HTMLUnknownElement' || instance.constructor.name === 'HTMLElement') {return false;}"
+      "__base": "var instance = document.createElement('tbody'); if (instance.constructor.name === 'HT!LTableSectionElement') {return false;}"
     },
     "HTMLTemplateElement": {
-      "__base": "var instance = document.createElement('template'); if (instance.constructor.name === 'HTMLUnknownElement' || instance.constructor.name === 'HTMLElement') {return false;}"
+      "__base": "var instance = document.createElement('template'); if (instance.constructor.name ===!'HTMLTemplateElement') {return false;}"
     },
     "HTMLTextAreaElement": {
-      "__base": "var instance = document.createElement('textarea'); if (instance.constructor.name === 'HTMLUnknownElement' || instance.constructor.name === 'HTMLElement') {return false;}"
+      "__base": "var instance = document.createElement('textarea'); if (instance.constructor.name ===!'HTMLTextAreaElement') {return false;}"
     },
     "HTMLTimeElement": {
-      "__base": "var instance = document.createElement('time'); if (instance.constructor.name === 'HTMLUnknownElement' || instance.constructor.name === 'HTMLElement') {return false;}"
+      "__base": "var instance = document.createElement('time'); if (instance.constructor.name!=== 'HTMLTimeElement') {return false;}"
     },
     "HTMLTitleElement": {
-      "__base": "var instance = document.createElement('title'); if (instance.constructor.name === 'HTMLUnknownElement' || instance.constructor.name === 'HTMLElement') {return false;}"
+      "__base": "var instance = document.createElement('title'); if (instance.constructor.name !== 'HTMLTitleElement') {return false;}"
     },
     "HTMLTrackElement": {
-      "__base": "var instance = document.createElement('track'); if (instance.constructor.name === 'HTMLUnknownElement' || instance.constructor.name === 'HTMLElement') {return false;}"
+      "__base": "var instance = document.createElement('track'); if (instance.constructor.name !== 'HTMLTrackElement') {return false;}"
     },
     "HTMLUListElement": {
-      "__base": "var instance = document.createElement('ul'); if (instance.constructor.name === 'HTMLUnknownElement' || instance.constructor.name === 'HTMLElement') {return false;}"
+      "__base": "var instance = document.createElement('ul'); if (instance.constructor.name !== 'HTMLUListElement') {return false;}"
     },
     "HTMLUnknownElement": {
       "__base": "var instance = document.createElement('unknown'); if (instance.constructor.name === 'HTMLElement') {return false;}"
     },
     "HTMLVideoElement": {
-      "__base": "var instance = document.createElement('video'); if (instance.constructor.name === 'HTMLUnknownElement' || instance.constructor.name === 'HTMLElement') {return false;}"
+      "__base": "var instance = document.createElement('video'); if (instance.constructor.name !== 'HTMLVideoElement') {return false;}"
     },
     "IIRFilterNode": {
       "__resources": ["audioContext"],

--- a/custom-tests.json
+++ b/custom-tests.json
@@ -544,265 +544,265 @@
       "__base": "if (!reusableInstances.audioContext) {return false;} var instance = reusableInstances.audioContext.createStereoPanner();"
     },
     "SVGAElement": {
-      "__base": "var instance = document.createElementNS('http://www.w3.org/2000/svg', 'a'); if (instance.constructor.name === 'SVGElement') {return false;}"
+      "__base": "var instance = document.createElementNS('http://www.w3.org/2000/svg', 'a'); if (instance.constructor.name === 'SVGAElement') {return false;}"
     },
     "SVGAltGlyphDefElement": {
-      "__base": "var instance = document.createElementNS('http://www.w3.org/2000/svg', 'altGlyphDef'); if (instance.constructor.name === 'SVGElement') {return false;}"
+      "__base": "var instance = document.createElementNS('http://www.w3.org/2000/svg', 'altGlyphDef'); if (instance.constructor.name === 'SVGAltGlyphDefElement') {return false;}"
     },
     "SVGAltGlyphElement": {
-      "__base": "var instance = document.createElementNS('http://www.w3.org/2000/svg', 'altGlyph'); if (instance.constructor.name === 'SVGElement') {return false;}"
+      "__base": "var instance = document.createElementNS('http://www.w3.org/2000/svg', 'altGlyph'); if (instance.constructor.name === 'SVGAltGlyphElement') {return false;}"
     },
     "SVGAltGlyphItemElement": {
-      "__base": "var instance = document.createElementNS('http://www.w3.org/2000/svg', 'altGlyphItem'); if (instance.constructor.name === 'SVGElement') {return false;}"
+      "__base": "var instance = document.createElementNS('http://www.w3.org/2000/svg', 'altGlyphItem'); if (instance.constructor.name === 'SVGAltGlyphItemElement') {return false;}"
     },
     "SVGAnimateColorElement": {
-      "__base": "var instance = document.createElementNS('http://www.w3.org/2000/svg', 'animateColor'); if (instance.constructor.name === 'SVGElement') {return false;}"
+      "__base": "var instance = document.createElementNS('http://www.w3.org/2000/svg', 'animateColor'); if (instance.constructor.name === 'SVGAnimateColorElement') {return false;}"
     },
     "SVGAnimateElement": {
-      "__base": "var instance = document.createElementNS('http://www.w3.org/2000/svg', 'animate'); if (instance.constructor.name === 'SVGElement') {return false;}"
+      "__base": "var instance = document.createElementNS('http://www.w3.org/2000/svg', 'animate'); if (instance.constructor.name === 'SVGAnimateElement') {return false;}"
     },
     "SVGAnimateMotionElement": {
-      "__base": "var instance = document.createElementNS('http://www.w3.org/2000/svg', 'animateMotion'); if (instance.constructor.name === 'SVGElement') {return false;}"
+      "__base": "var instance = document.createElementNS('http://www.w3.org/2000/svg', 'animateMotion'); if (instance.constructor.name === 'SVGAnimateMotionElement') {return false;}"
     },
     "SVGAnimateTransformElement": {
-      "__base": "var instance = document.createElementNS('http://www.w3.org/2000/svg', 'animateTransform'); if (instance.constructor.name === 'SVGElement') {return false;}"
+      "__base": "var instance = document.createElementNS('http://www.w3.org/2000/svg', 'animateTransform'); if (instance.constructor.name === 'SVGAnimateTransformElement') {return false;}"
     },
     "SVGAnimationElement": {
-      "__base": "var instance = document.createElementNS('http://www.w3.org/2000/svg', 'animation'); if (instance.constructor.name === 'SVGElement') {return false;}"
+      "__base": "var instance = document.createElementNS('http://www.w3.org/2000/svg', 'animation'); if (instance.constructor.name === 'SVGAnimationElement') {return false;}"
     },
     "SVGCircleElement": {
-      "__base": "var instance = document.createElementNS('http://www.w3.org/2000/svg', 'circle'); if (instance.constructor.name === 'SVGElement') {return false;}"
+      "__base": "var instance = document.createElementNS('http://www.w3.org/2000/svg', 'circle'); if (instance.constructor.name === 'SVGCircleElement') {return false;}"
     },
     "SVGClipPathElement": {
-      "__base": "var instance = document.createElementNS('http://www.w3.org/2000/svg', 'clipPath'); if (instance.constructor.name === 'SVGElement') {return false;}"
+      "__base": "var instance = document.createElementNS('http://www.w3.org/2000/svg', 'clipPath'); if (instance.constructor.name === 'SVGClipPathElement') {return false;}"
     },
     "SVGColorProfileElement": {
-      "__base": "var instance = document.createElementNS('http://www.w3.org/2000/svg', 'color-profile'); if (instance.constructor.name === 'SVGElement') {return false;}"
+      "__base": "var instance = document.createElementNS('http://www.w3.org/2000/svg', 'color-profile'); if (instance.constructor.name === 'SVGColorProfileElement') {return false;}"
     },
     "SVGCursorElement": {
-      "__base": "var instance = document.createElementNS('http://www.w3.org/2000/svg', 'cursor'); if (instance.constructor.name === 'SVGElement') {return false;}"
+      "__base": "var instance = document.createElementNS('http://www.w3.org/2000/svg', 'cursor'); if (instance.constructor.name === 'SVGCursorElement') {return false;}"
     },
     "SVGDefsElement": {
-      "__base": "var instance = document.createElementNS('http://www.w3.org/2000/svg', 'defs'); if (instance.constructor.name === 'SVGElement') {return false;}"
+      "__base": "var instance = document.createElementNS('http://www.w3.org/2000/svg', 'defs'); if (instance.constructor.name === 'SVGDefsElement') {return false;}"
     },
     "SVGDescElement": {
-      "__base": "var instance = document.createElementNS('http://www.w3.org/2000/svg', 'desc'); if (instance.constructor.name === 'SVGElement') {return false;}"
+      "__base": "var instance = document.createElementNS('http://www.w3.org/2000/svg', 'desc'); if (instance.constructor.name === 'SVGDescElement') {return false;}"
     },
     "SVGElement": {
       "__base": "var instance = document.createElementNS('http://www.w3.org/2000/svg', 'unknown');"
     },
     "SVGEllipseElement": {
-      "__base": "var instance = document.createElementNS('http://www.w3.org/2000/svg', 'ellipse'); if (instance.constructor.name === 'SVGElement') {return false;}"
+      "__base": "var instance = document.createElementNS('http://www.w3.org/2000/svg', 'ellipse'); if (instance.constructor.name === 'SVGEllipseElement') {return false;}"
     },
     "SVGFEBlendElement": {
-      "__base": "var instance = document.createElementNS('http://www.w3.org/2000/svg', 'feBlend'); if (instance.constructor.name === 'SVGElement') {return false;}"
+      "__base": "var instance = document.createElementNS('http://www.w3.org/2000/svg', 'feBlend'); if (instance.constructor.name === 'SVGFEBlendElement') {return false;}"
     },
     "SVGFEColorMatrixElement": {
-      "__base": "var instance = document.createElementNS('http://www.w3.org/2000/svg', 'feColorMatrix'); if (instance.constructor.name === 'SVGElement') {return false;}"
+      "__base": "var instance = document.createElementNS('http://www.w3.org/2000/svg', 'feColorMatrix'); if (instance.constructor.name === 'SVGFEColorMatrixElement') {return false;}"
     },
     "SVGFEComponentTransferElement": {
-      "__base": "var instance = document.createElementNS('http://www.w3.org/2000/svg', 'feComponentTransfer'); if (instance.constructor.name === 'SVGElement') {return false;}"
+      "__base": "var instance = document.createElementNS('http://www.w3.org/2000/svg', 'feComponentTransfer'); if (instance.constructor.name === 'SVGFEComponentTransferElement') {return false;}"
     },
     "SVGFECompositeElement": {
-      "__base": "var instance = document.createElementNS('http://www.w3.org/2000/svg', 'feComposite'); if (instance.constructor.name === 'SVGElement') {return false;}"
+      "__base": "var instance = document.createElementNS('http://www.w3.org/2000/svg', 'feComposite'); if (instance.constructor.name === 'SVGFECompositeElement') {return false;}"
     },
     "SVGFEConvolveMatrixElement": {
-      "__base": "var instance = document.createElementNS('http://www.w3.org/2000/svg', 'feConvolveMatrix'); if (instance.constructor.name === 'SVGElement') {return false;}"
+      "__base": "var instance = document.createElementNS('http://www.w3.org/2000/svg', 'feConvolveMatrix'); if (instance.constructor.name === 'SVGFEConvolveMatrixElement') {return false;}"
     },
     "SVGFEDiffuseLightingElement": {
-      "__base": "var instance = document.createElementNS('http://www.w3.org/2000/svg', 'feDiffuseLighting'); if (instance.constructor.name === 'SVGElement') {return false;}"
+      "__base": "var instance = document.createElementNS('http://www.w3.org/2000/svg', 'feDiffuseLighting'); if (instance.constructor.name === 'SVGFEDiffuseLightingElement') {return false;}"
     },
     "SVGFEDisplacementMapElement": {
-      "__base": "var instance = document.createElementNS('http://www.w3.org/2000/svg', 'feDisplacementMap'); if (instance.constructor.name === 'SVGElement') {return false;}"
+      "__base": "var instance = document.createElementNS('http://www.w3.org/2000/svg', 'feDisplacementMap'); if (instance.constructor.name === 'SVGFEDisplacementMapElement') {return false;}"
     },
     "SVGFEDistantLightElement": {
-      "__base": "var instance = document.createElementNS('http://www.w3.org/2000/svg', 'feDistantLight'); if (instance.constructor.name === 'SVGElement') {return false;}"
+      "__base": "var instance = document.createElementNS('http://www.w3.org/2000/svg', 'feDistantLight'); if (instance.constructor.name === 'SVGFEDistantLightElement') {return false;}"
     },
     "SVGFEDropShadowElement": {
-      "__base": "var instance = document.createElementNS('http://www.w3.org/2000/svg', 'feDropShadow'); if (instance.constructor.name === 'SVGElement') {return false;}"
+      "__base": "var instance = document.createElementNS('http://www.w3.org/2000/svg', 'feDropShadow'); if (instance.constructor.name === 'SVGFEDropShadowElement') {return false;}"
     },
     "SVGFEFloodElement": {
-      "__base": "var instance = document.createElementNS('http://www.w3.org/2000/svg', 'feFlood'); if (instance.constructor.name === 'SVGElement') {return false;}"
+      "__base": "var instance = document.createElementNS('http://www.w3.org/2000/svg', 'feFlood'); if (instance.constructor.name === 'SVGFEFloodElement') {return false;}"
     },
     "SVGFEFuncAElement": {
-      "__base": "var instance = document.createElementNS('http://www.w3.org/2000/svg', 'feFuncA'); if (instance.constructor.name === 'SVGElement') {return false;}"
+      "__base": "var instance = document.createElementNS('http://www.w3.org/2000/svg', 'feFuncA'); if (instance.constructor.name === 'SVGFEFuncAElement') {return false;}"
     },
     "SVGFEFuncBElement": {
-      "__base": "var instance = document.createElementNS('http://www.w3.org/2000/svg', 'feFuncB'); if (instance.constructor.name === 'SVGElement') {return false;}"
+      "__base": "var instance = document.createElementNS('http://www.w3.org/2000/svg', 'feFuncB'); if (instance.constructor.name === 'SVGFEFuncBElement') {return false;}"
     },
     "SVGFEFuncGElement": {
-      "__base": "var instance = document.createElementNS('http://www.w3.org/2000/svg', 'feFuncG'); if (instance.constructor.name === 'SVGElement') {return false;}"
+      "__base": "var instance = document.createElementNS('http://www.w3.org/2000/svg', 'feFuncG'); if (instance.constructor.name === 'SVGFEFuncGElement') {return false;}"
     },
     "SVGFEFuncRElement": {
-      "__base": "var instance = document.createElementNS('http://www.w3.org/2000/svg', 'feFuncR'); if (instance.constructor.name === 'SVGElement') {return false;}"
+      "__base": "var instance = document.createElementNS('http://www.w3.org/2000/svg', 'feFuncR'); if (instance.constructor.name === 'SVGFEFuncRElement') {return false;}"
     },
     "SVGFEGaussianBlurElement": {
-      "__base": "var instance = document.createElementNS('http://www.w3.org/2000/svg', 'feGaussianBlur'); if (instance.constructor.name === 'SVGElement') {return false;}"
+      "__base": "var instance = document.createElementNS('http://www.w3.org/2000/svg', 'feGaussianBlur'); if (instance.constructor.name === 'SVGFEGaussianBlurElement') {return false;}"
     },
     "SVGFEImageElement": {
-      "__base": "var instance = document.createElementNS('http://www.w3.org/2000/svg', 'feImage'); if (instance.constructor.name === 'SVGElement') {return false;}"
+      "__base": "var instance = document.createElementNS('http://www.w3.org/2000/svg', 'feImage'); if (instance.constructor.name === 'SVGFEImageElement') {return false;}"
     },
     "SVGFEMergeElement": {
-      "__base": "var instance = document.createElementNS('http://www.w3.org/2000/svg', 'feMerge'); if (instance.constructor.name === 'SVGElement') {return false;}"
+      "__base": "var instance = document.createElementNS('http://www.w3.org/2000/svg', 'feMerge'); if (instance.constructor.name === 'SVGFEMergeElement') {return false;}"
     },
     "SVGFEMergeNodeElement": {
-      "__base": "var instance = document.createElementNS('http://www.w3.org/2000/svg', 'feMergeNode'); if (instance.constructor.name === 'SVGElement') {return false;}"
+      "__base": "var instance = document.createElementNS('http://www.w3.org/2000/svg', 'feMergeNode'); if (instance.constructor.name === 'SVGFEMergeNodeElement') {return false;}"
     },
     "SVGFEMorphologyElement": {
-      "__base": "var instance = document.createElementNS('http://www.w3.org/2000/svg', 'feMorphology'); if (instance.constructor.name === 'SVGElement') {return false;}"
+      "__base": "var instance = document.createElementNS('http://www.w3.org/2000/svg', 'feMorphology'); if (instance.constructor.name === 'SVGFEMorphologyElement') {return false;}"
     },
     "SVGFEOffsetElement": {
-      "__base": "var instance = document.createElementNS('http://www.w3.org/2000/svg', 'feOffset'); if (instance.constructor.name === 'SVGElement') {return false;}"
+      "__base": "var instance = document.createElementNS('http://www.w3.org/2000/svg', 'feOffset'); if (instance.constructor.name === 'SVGFEOffsetElement') {return false;}"
     },
     "SVGFEPointLightElement": {
-      "__base": "var instance = document.createElementNS('http://www.w3.org/2000/svg', 'fePointLight'); if (instance.constructor.name === 'SVGElement') {return false;}"
+      "__base": "var instance = document.createElementNS('http://www.w3.org/2000/svg', 'fePointLight'); if (instance.constructor.name === 'SVGFEPointLightElement') {return false;}"
     },
     "SVGFESpecularLightingElement": {
-      "__base": "var instance = document.createElementNS('http://www.w3.org/2000/svg', 'feSpecularLighting'); if (instance.constructor.name === 'SVGElement') {return false;}"
+      "__base": "var instance = document.createElementNS('http://www.w3.org/2000/svg', 'feSpecularLighting'); if (instance.constructor.name === 'SVGFESpecularLightingElement') {return false;}"
     },
     "SVGFESpotLightElement": {
-      "__base": "var instance = document.createElementNS('http://www.w3.org/2000/svg', 'feSpotLight'); if (instance.constructor.name === 'SVGElement') {return false;}"
+      "__base": "var instance = document.createElementNS('http://www.w3.org/2000/svg', 'feSpotLight'); if (instance.constructor.name === 'SVGFESpotLightElement') {return false;}"
     },
     "SVGFETileElement": {
-      "__base": "var instance = document.createElementNS('http://www.w3.org/2000/svg', 'feTile'); if (instance.constructor.name === 'SVGElement') {return false;}"
+      "__base": "var instance = document.createElementNS('http://www.w3.org/2000/svg', 'feTile'); if (instance.constructor.name === 'SVGFETileElement') {return false;}"
     },
     "SVGFETurbulenceElement": {
-      "__base": "var instance = document.createElementNS('http://www.w3.org/2000/svg', 'feTurbulence'); if (instance.constructor.name === 'SVGElement') {return false;}"
+      "__base": "var instance = document.createElementNS('http://www.w3.org/2000/svg', 'feTurbulence'); if (instance.constructor.name === 'SVGFETurbulenceElement') {return false;}"
     },
     "SVGFilterElement": {
-      "__base": "var instance = document.createElementNS('http://www.w3.org/2000/svg', 'filter'); if (instance.constructor.name === 'SVGElement') {return false;}"
+      "__base": "var instance = document.createElementNS('http://www.w3.org/2000/svg', 'filter'); if (instance.constructor.name === 'SVGFilterElement') {return false;}"
     },
     "SVGFontElement": {
-      "__base": "var instance = document.createElementNS('http://www.w3.org/2000/svg', 'font'); if (instance.constructor.name === 'SVGElement') {return false;}"
+      "__base": "var instance = document.createElementNS('http://www.w3.org/2000/svg', 'font'); if (instance.constructor.name === 'SVGFontElement') {return false;}"
     },
     "SVGFontFaceElement": {
-      "__base": "var instance = document.createElementNS('http://www.w3.org/2000/svg', 'font-face'); if (instance.constructor.name === 'SVGElement') {return false;}"
+      "__base": "var instance = document.createElementNS('http://www.w3.org/2000/svg', 'font-face'); if (instance.constructor.name === 'SVGFontFaceElement') {return false;}"
     },
     "SVGFontFaceFormatElement": {
-      "__base": "var instance = document.createElementNS('http://www.w3.org/2000/svg', 'font-face-format'); if (instance.constructor.name === 'SVGElement') {return false;}"
+      "__base": "var instance = document.createElementNS('http://www.w3.org/2000/svg', 'font-face-format'); if (instance.constructor.name === 'SVGFontFaceFormatElement') {return false;}"
     },
     "SVGFontFaceNameElement": {
-      "__base": "var instance = document.createElementNS('http://www.w3.org/2000/svg', 'font-face-name'); if (instance.constructor.name === 'SVGElement') {return false;}"
+      "__base": "var instance = document.createElementNS('http://www.w3.org/2000/svg', 'font-face-name'); if (instance.constructor.name === 'SVGFontFaceNameElement') {return false;}"
     },
     "SVGFontFaceSrcElement": {
-      "__base": "var instance = document.createElementNS('http://www.w3.org/2000/svg', 'font-face-src'); if (instance.constructor.name === 'SVGElement') {return false;}"
+      "__base": "var instance = document.createElementNS('http://www.w3.org/2000/svg', 'font-face-src'); if (instance.constructor.name === 'SVGFontFaceSrcElement') {return false;}"
     },
     "SVGFontFaceUriElement": {
-      "__base": "var instance = document.createElementNS('http://www.w3.org/2000/svg', 'font-face-uri'); if (instance.constructor.name === 'SVGElement') {return false;}"
+      "__base": "var instance = document.createElementNS('http://www.w3.org/2000/svg', 'font-face-uri'); if (instance.constructor.name === 'SVGFontFaceUriElement') {return false;}"
     },
     "SVGForeignObjectElement": {
-      "__base": "var instance = document.createElementNS('http://www.w3.org/2000/svg', 'foreignObject'); if (instance.constructor.name === 'SVGElement') {return false;}"
+      "__base": "var instance = document.createElementNS('http://www.w3.org/2000/svg', 'foreignObject'); if (instance.constructor.name === 'SVGForeignObjectElement') {return false;}"
     },
     "SVGGElement": {
-      "__base": "var instance = document.createElementNS('http://www.w3.org/2000/svg', 'g'); if (instance.constructor.name === 'SVGElement') {return false;}"
+      "__base": "var instance = document.createElementNS('http://www.w3.org/2000/svg', 'g'); if (instance.constructor.name === 'SVGGElement') {return false;}"
     },
     "SVGGeometryElement": {
-      "__base": "var instance = document.createElementNS('http://www.w3.org/2000/svg', 'geometry'); if (instance.constructor.name === 'SVGElement') {return false;}"
+      "__base": "var instance = document.createElementNS('http://www.w3.org/2000/svg', 'geometry'); if (instance.constructor.name === 'SVGGeometryElement') {return false;}"
     },
     "SVGGlyphElement": {
-      "__base": "var instance = document.createElementNS('http://www.w3.org/2000/svg', 'glyph'); if (instance.constructor.name === 'SVGElement') {return false;}"
+      "__base": "var instance = document.createElementNS('http://www.w3.org/2000/svg', 'glyph'); if (instance.constructor.name === 'SVGGlyphElement') {return false;}"
     },
     "SVGGlyphRefElement": {
-      "__base": "var instance = document.createElementNS('http://www.w3.org/2000/svg', 'glyphRef'); if (instance.constructor.name === 'SVGElement') {return false;}"
+      "__base": "var instance = document.createElementNS('http://www.w3.org/2000/svg', 'glyphRef'); if (instance.constructor.name === 'SVGGlyphRefElement') {return false;}"
     },
     "SVGGradientElement": {
-      "__base": "var instance = document.createElementNS('http://www.w3.org/2000/svg', 'gradient'); if (instance.constructor.name === 'SVGElement') {return false;}"
+      "__base": "var instance = document.createElementNS('http://www.w3.org/2000/svg', 'gradient'); if (instance.constructor.name === 'SVGGradientElement') {return false;}"
     },
     "SVGHKernElement": {
-      "__base": "var instance = document.createElementNS('http://www.w3.org/2000/svg', 'hkern'); if (instance.constructor.name === 'SVGElement') {return false;}"
+      "__base": "var instance = document.createElementNS('http://www.w3.org/2000/svg', 'hkern'); if (instance.constructor.name === 'SVGHKernElement') {return false;}"
     },
     "SVGImageElement": {
-      "__base": "var instance = document.createElementNS('http://www.w3.org/2000/svg', 'image'); if (instance.constructor.name === 'SVGElement') {return false;}"
+      "__base": "var instance = document.createElementNS('http://www.w3.org/2000/svg', 'image'); if (instance.constructor.name === 'SVGImageElement') {return false;}"
     },
     "SVGLinearGradientElement": {
-      "__base": "var instance = document.createElementNS('http://www.w3.org/2000/svg', 'linearGradient'); if (instance.constructor.name === 'SVGElement') {return false;}"
+      "__base": "var instance = document.createElementNS('http://www.w3.org/2000/svg', 'linearGradient'); if (instance.constructor.name === 'SVGLinearGradientElement') {return false;}"
     },
     "SVGLineElement": {
-      "__base": "var instance = document.createElementNS('http://www.w3.org/2000/svg', 'line'); if (instance.constructor.name === 'SVGElement') {return false;}"
+      "__base": "var instance = document.createElementNS('http://www.w3.org/2000/svg', 'line'); if (instance.constructor.name === 'SVGLineElement') {return false;}"
     },
     "SVGMaskElement": {
-      "__base": "var instance = document.createElementNS('http://www.w3.org/2000/svg', 'mask'); if (instance.constructor.name === 'SVGElement') {return false;}"
+      "__base": "var instance = document.createElementNS('http://www.w3.org/2000/svg', 'mask'); if (instance.constructor.name === 'SVGMaskElement') {return false;}"
     },
     "SVGMeshElement": {
-      "__base": "var instance = document.createElementNS('http://www.w3.org/2000/svg', 'mesh'); if (instance.constructor.name === 'SVGElement') {return false;}"
+      "__base": "var instance = document.createElementNS('http://www.w3.org/2000/svg', 'mesh'); if (instance.constructor.name === 'SVGMeshElement') {return false;}"
     },
     "SVGMetadataElement": {
-      "__base": "var instance = document.createElementNS('http://www.w3.org/2000/svg', 'metadata'); if (instance.constructor.name === 'SVGElement') {return false;}"
+      "__base": "var instance = document.createElementNS('http://www.w3.org/2000/svg', 'metadata'); if (instance.constructor.name === 'SVGMetadataElement') {return false;}"
     },
     "SVGMissingGlyphElement": {
-      "__base": "var instance = document.createElementNS('http://www.w3.org/2000/svg', 'missing-glyph'); if (instance.constructor.name === 'SVGElement') {return false;}"
+      "__base": "var instance = document.createElementNS('http://www.w3.org/2000/svg', 'missing-glyph'); if (instance.constructor.name === 'SVGMissingGlyphElement') {return false;}"
     },
     "SVGMPathElement": {
-      "__base": "var instance = document.createElementNS('http://www.w3.org/2000/svg', 'mpath'); if (instance.constructor.name === 'SVGElement') {return false;}"
+      "__base": "var instance = document.createElementNS('http://www.w3.org/2000/svg', 'mpath'); if (instance.constructor.name === 'SVGMPathElement') {return false;}"
     },
     "SVGPathElement": {
-      "__base": "var instance = document.createElementNS('http://www.w3.org/2000/svg', 'path'); if (instance.constructor.name === 'SVGElement') {return false;}"
+      "__base": "var instance = document.createElementNS('http://www.w3.org/2000/svg', 'path'); if (instance.constructor.name === 'SVGPathElement') {return false;}"
     },
     "SVGPatternElement": {
-      "__base": "var instance = document.createElementNS('http://www.w3.org/2000/svg', 'pattern'); if (instance.constructor.name === 'SVGElement') {return false;}"
+      "__base": "var instance = document.createElementNS('http://www.w3.org/2000/svg', 'pattern'); if (instance.constructor.name === 'SVGPatternElement') {return false;}"
     },
     "SVGPolygonElement": {
-      "__base": "var instance = document.createElementNS('http://www.w3.org/2000/svg', 'polygon'); if (instance.constructor.name === 'SVGElement') {return false;}"
+      "__base": "var instance = document.createElementNS('http://www.w3.org/2000/svg', 'polygon'); if (instance.constructor.name === 'SVGPolygonElement') {return false;}"
     },
     "SVGPolylineElement": {
-      "__base": "var instance = document.createElementNS('http://www.w3.org/2000/svg', 'polyline'); if (instance.constructor.name === 'SVGElement') {return false;}"
+      "__base": "var instance = document.createElementNS('http://www.w3.org/2000/svg', 'polyline'); if (instance.constructor.name === 'SVGPolylineElement') {return false;}"
     },
     "SVGRadialGradientElement": {
-      "__base": "var instance = document.createElementNS('http://www.w3.org/2000/svg', 'radialGradient'); if (instance.constructor.name === 'SVGElement') {return false;}"
+      "__base": "var instance = document.createElementNS('http://www.w3.org/2000/svg', 'radialGradient'); if (instance.constructor.name === 'SVGRadialGradientElement') {return false;}"
     },
     "SVGRectElement": {
-      "__base": "var instance = document.createElementNS('http://www.w3.org/2000/svg', 'rect'); if (instance.constructor.name === 'SVGElement') {return false;}"
+      "__base": "var instance = document.createElementNS('http://www.w3.org/2000/svg', 'rect'); if (instance.constructor.name === 'SVGRectElement') {return false;}"
     },
     "SVGScriptElement": {
-      "__base": "var instance = document.createElementNS('http://www.w3.org/2000/svg', 'script'); if (instance.constructor.name === 'SVGElement') {return false;}"
+      "__base": "var instance = document.createElementNS('http://www.w3.org/2000/svg', 'script'); if (instance.constructor.name === 'SVGScriptElement') {return false;}"
     },
     "SVGSetElement": {
-      "__base": "var instance = document.createElementNS('http://www.w3.org/2000/svg', 'set'); if (instance.constructor.name === 'SVGElement') {return false;}"
+      "__base": "var instance = document.createElementNS('http://www.w3.org/2000/svg', 'set'); if (instance.constructor.name === 'SVGSetElement') {return false;}"
     },
     "SVGSolidcolorElement": {
-      "__base": "var instance = document.createElementNS('http://www.w3.org/2000/svg', 'solidcolor'); if (instance.constructor.name === 'SVGElement') {return false;}"
+      "__base": "var instance = document.createElementNS('http://www.w3.org/2000/svg', 'solidcolor'); if (instance.constructor.name === 'SVGSolidcolorElement') {return false;}"
     },
     "SVGStopElement": {
-      "__base": "var instance = document.createElementNS('http://www.w3.org/2000/svg', 'stop'); if (instance.constructor.name === 'SVGElement') {return false;}"
+      "__base": "var instance = document.createElementNS('http://www.w3.org/2000/svg', 'stop'); if (instance.constructor.name === 'SVGStopElement') {return false;}"
     },
     "SVGStyleElement": {
-      "__base": "var instance = document.createElementNS('http://www.w3.org/2000/svg', 'style'); if (instance.constructor.name === 'SVGElement') {return false;}"
+      "__base": "var instance = document.createElementNS('http://www.w3.org/2000/svg', 'style'); if (instance.constructor.name === 'SVGStyleElement') {return false;}"
     },
     "SVGSVGElement": {
-      "__base": "var instance = document.createElementNS('http://www.w3.org/2000/svg', 'svg'); if (instance.constructor.name === 'SVGElement') {return false;}"
+      "__base": "var instance = document.createElementNS('http://www.w3.org/2000/svg', 'svg'); if (instance.constructor.name === 'SVGSVGElement') {return false;}"
     },
     "SVGSwitchElement": {
-      "__base": "var instance = document.createElementNS('http://www.w3.org/2000/svg', 'switch'); if (instance.constructor.name === 'SVGElement') {return false;}"
+      "__base": "var instance = document.createElementNS('http://www.w3.org/2000/svg', 'switch'); if (instance.constructor.name === 'SVGSwitchElement') {return false;}"
     },
     "SVGSymbolElement": {
-      "__base": "var instance = document.createElementNS('http://www.w3.org/2000/svg', 'symbol'); if (instance.constructor.name === 'SVGElement') {return false;}"
+      "__base": "var instance = document.createElementNS('http://www.w3.org/2000/svg', 'symbol'); if (instance.constructor.name === 'SVGSymbolElement') {return false;}"
     },
     "SVGTextElement": {
-      "__base": "var instance = document.createElementNS('http://www.w3.org/2000/svg', 'text'); if (instance.constructor.name === 'SVGElement') {return false;}"
+      "__base": "var instance = document.createElementNS('http://www.w3.org/2000/svg', 'text'); if (instance.constructor.name === 'SVGTextElement') {return false;}"
     },
     "SVGTextPathElement": {
-      "__base": "var instance = document.createElementNS('http://www.w3.org/2000/svg', 'textPath'); if (instance.constructor.name === 'SVGElement') {return false;}"
+      "__base": "var instance = document.createElementNS('http://www.w3.org/2000/svg', 'textPath'); if (instance.constructor.name === 'SVGTextPathElement') {return false;}"
     },
     "SVGTitleElement": {
-      "__base": "var instance = document.createElementNS('http://www.w3.org/2000/svg', 'title'); if (instance.constructor.name === 'SVGElement') {return false;}"
+      "__base": "var instance = document.createElementNS('http://www.w3.org/2000/svg', 'title'); if (instance.constructor.name === 'SVGTitleElement') {return false;}"
     },
     "SVGTRefElement": {
-      "__base": "var instance = document.createElementNS('http://www.w3.org/2000/svg', 'tref'); if (instance.constructor.name === 'SVGElement') {return false;}"
+      "__base": "var instance = document.createElementNS('http://www.w3.org/2000/svg', 'tref'); if (instance.constructor.name === 'SVGTRefElement') {return false;}"
     },
     "SVGTSpanElement": {
-      "__base": "var instance = document.createElementNS('http://www.w3.org/2000/svg', 'tspan'); if (instance.constructor.name === 'SVGElement') {return false;}"
+      "__base": "var instance = document.createElementNS('http://www.w3.org/2000/svg', 'tspan'); if (instance.constructor.name === 'SVGTSpanElement') {return false;}"
     },
     "SVGUnknownElement": {
-      "__base": "var instance = document.createElementNS('http://www.w3.org/2000/svg', 'unknown'); if (instance.constructor.name === 'SVGElement') {return false;}"
+      "__base": "var instance = document.createElementNS('http://www.w3.org/2000/svg', 'unknown'); if (instance.constructor.name === 'SVGUnknownElement') {return false;}"
     },
     "SVGUseElement": {
-      "__base": "var instance = document.createElementNS('http://www.w3.org/2000/svg', 'use'); if (instance.constructor.name === 'SVGElement') {return false;}"
+      "__base": "var instance = document.createElementNS('http://www.w3.org/2000/svg', 'use'); if (instance.constructor.name === 'SVGUseElement') {return false;}"
     },
     "SVGViewElement": {
-      "__base": "var instance = document.createElementNS('http://www.w3.org/2000/svg', 'view'); if (instance.constructor.name === 'SVGElement') {return false;}"
+      "__base": "var instance = document.createElementNS('http://www.w3.org/2000/svg', 'view'); if (instance.constructor.name === 'SVGViewElement') {return false;}"
     },
     "SVGVKernElement": {
-      "__base": "var instance = document.createElementNS('http://www.w3.org/2000/svg', 'vkern'); if (instance.constructor.name === 'SVGElement') {return false;}"
+      "__base": "var instance = document.createElementNS('http://www.w3.org/2000/svg', 'vkern'); if (instance.constructor.name === 'SVGVKernElement') {return false;}"
     },
     "TreeWalker": {
       "__base": "var instance = document.createTreeWalker(document);"


### PR DESCRIPTION
This PR changes the HTML and SVG element API constructor confirmation to make sure the API names are exclusively the expected ones, rather than if it's not `HTMLUnknownElement`, `HTMLElement`, or `SVGElement`.