### PR TITLE
Deploy new prod on version bump

### DIFF
--- a/.github/workflows/push.yml
+++ b/.github/workflows/push.yml
@@ -2,7 +2,6 @@ on:
   push:
     branches:
     - main
-    - prod
 name: Push
 jobs:
   test:
@@ -22,6 +21,12 @@ jobs:
     needs: test
     runs-on: ubuntu-latest
     steps:
+    - uses: MontyD/package-json-updated-action
+      id: version-updated
+      with:
+        path: package.json
+      env:
+        GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}
     - uses: actions/checkout@v2
     - uses: GoogleCloudPlatform/github-actions/setup-gcloud@master
       with:
@@ -31,9 +36,12 @@ jobs:
     - run: echo "$SECRETS_JSON" | base64 --decode > secrets.json
       env:
         SECRETS_JSON: ${{ secrets.SECRETS_JSON }}
-    - if: ${{ github.ref == 'refs/heads/main' }}
-      run: gcloud app deploy --version=staging --no-promote
-    - if: ${{ github.ref == 'refs/heads/prod' }}
-      run: gcloud app deploy --version=production --promote
+    - run: gcloud app deploy --version=staging --no-promote
+    - if: steps.version-updated.outputs.has-updated
+      run: |
+        git branch prod -f
+        git checkout prod
+        git push
+        gcloud app deploy --version=production --promote
 env:
   FORCE_COLOR: 3


### PR DESCRIPTION
This PR reworks the `push` GitHub Action to deploy a new production version every time that the version number is bumped in the `main` branch.  Now, rather than pushing to `prod` ourselves, the GitHub Action will push to `prod` to let us know where it's at.