### PR TITLE
Fix new import in GitHub Action

### DIFF
--- a/.github/workflows/push.yml
+++ b/.github/workflows/push.yml
@@ -21,7 +21,7 @@ jobs:
     needs: test
     runs-on: ubuntu-latest
     steps:
-    - uses: MontyD/package-json-updated-action
+    - uses: MontyD/package-json-updated-action@1.0.1
       id: version-updated
       with:
         path: package.json


### PR DESCRIPTION
This PR adds the missing Action version number to the new Action changes.