### PR TITLE
Show app version on homepage

### DIFF
--- a/app.js
+++ b/app.js
@@ -158,7 +158,8 @@ app.post('/api/results/export/github', (req, res) => {
 
 app.get('/', (req, res) => {
   res.render('index', {
-    tests: tests.listEndpoints('/tests')
+    tests: tests.listEndpoints('/tests'),
+    appversion
   });
 });
 
@@ -181,7 +182,7 @@ app.all('/tests/*', (req, res) => {
     });
   } else {
     res.status(404).render('testnotfound', {
-      ident: ident,
+      ident,
       suggestion: tests.didYouMean(ident),
       query: '?' + querystring.encode(req.query)
     });

--- a/static/resources/style.css
+++ b/static/resources/style.css
@@ -136,6 +136,11 @@ input::placeholder {
 }
 /* End */
 
+h1 .version {
+  font-size: 40%;
+  opacity: 0.4;
+}
+
 #homeInfo {
   margin-right: 50px;
 }

--- a/views/index.ejs
+++ b/views/index.ejs
@@ -1,5 +1,5 @@
 <%- contentFor('body') %>
-<h1>mdn-bcd-collector</h1>
+<h1>mdn-bcd-collector <span class="version">v<%- appversion %></span></h1>
 <div id="homeInfo">
   <p>Data collection service for <a href="https://github.com/mdn/browser-compat-data">@mdn/browser-compat-data</a>. This website provides automatic feature detection for Web APIs and CSS properties, to assist in obtaining data for the BCD project.</p>
   <p id="betaNotice" class="notice">Note: this website is in beta; not all feature detection is accurate yet. If you find any errors, please <a href="https://github.com/foolip/mdn-bcd-collector/issues/new">file an issue</a> in the GitHub repository.</p>


### PR DESCRIPTION
This PR includes the app version in the title section on the homepage.  Useful to ensure a production version is successfully deployed.

<img width="339" alt="Screen Shot 2020-10-23 at 16 03 40" src="https://user-images.githubusercontent.com/5179191/97060785-52bf5980-1549-11eb-9ba0-5f26bcdbc7e3.png">
