### PR TITLE
Check to make sure workers construct properly

### DIFF
--- a/static/resources/harness.js
+++ b/static/resources/harness.js
@@ -195,9 +195,15 @@
 
   function runWorker(callback, results) {
     if ('Worker' in pending) {
-      if ('Worker' in self) {
-        var myWorker = new Worker('/resources/worker.js');
+      var myWorker = null;
 
+      if ('Worker' in self) {
+        try {
+          myWorker = new Worker('/resources/worker.js');
+        } catch (e) {}
+      }
+
+      if (myWorker) {
         myWorker.onmessage = function(event) {
           callback(results.concat(event.data));
         };
@@ -237,9 +243,15 @@
 
   function runSharedWorker(callback, results) {
     if ('SharedWorker' in pending) {
+      var myWorker = null;
+      
       if ('SharedWorker' in self) {
-        var myWorker = new SharedWorker('/resources/sharedworker.js');
+        try {
+          myWorker = new SharedWorker('/resources/sharedworker.js');
+        } catch (e) {}
+      }
 
+      if (myWorker) {
         myWorker.port.onmessage = function(event) {
           callback(results.concat(event.data));
         };

--- a/static/resources/harness.js
+++ b/static/resources/harness.js
@@ -200,7 +200,9 @@
       if ('Worker' in self) {
         try {
           myWorker = new Worker('/resources/worker.js');
-        } catch (e) {}
+        } catch (e) {
+          // eslint-disable-next-rule no-empty
+        }
       }
 
       if (myWorker) {
@@ -244,11 +246,13 @@
   function runSharedWorker(callback, results) {
     if ('SharedWorker' in pending) {
       var myWorker = null;
-      
+
       if ('SharedWorker' in self) {
         try {
           myWorker = new SharedWorker('/resources/sharedworker.js');
-        } catch (e) {}
+        } catch (e) {
+          // eslint-disable-next-rule no-empty
+        }
       }
 
       if (myWorker) {


### PR DESCRIPTION
In Chrome 2-5, the Worker has a frustratingly weird way to indicate lack of support.  Rather than the variable not being defined, attempting to construct it throws a SyntaxError.  To accomodate for it, this PR works the Worker and ServiceWorker testing to try and construct it if it can, if not then classify it as unsupported.