### PR TITLE
Selenium fix

### DIFF
--- a/selenium.js
+++ b/selenium.js
@@ -151,7 +151,9 @@ const buildDriver = async (browser, version, os) => {
       }
     } else {
       capabilities.set('os', osName);
-      capabilities.set('os_version', osVersion);
+      if (browser !== 'safari') {
+        capabilities.set('os_version', osVersion);
+      }
     }
 
     const prefs = new logging.Preferences();

--- a/selenium.js
+++ b/selenium.js
@@ -85,7 +85,7 @@ const filterVersions = (data, earliestVersion) => {
     }
   }
 
-  return versions;
+  return versions.sort((a, b) => (a - b));
 };
 
 const getSafariOS = (version) => {


### PR DESCRIPTION
This PR fixes two issues with the Selenium script:

1) BrowserStack was setting an OS version for Safari, however Safari is dependent on the OS version -- this makes sure BrowserStack won't enforce an OS version for Safari
2) Versions to test weren't sorted properly (particularly for Safari) -- this fixes the sorting