### PR TITLE
Selenium: await status element on test page

### DIFF
--- a/selenium.js
+++ b/selenium.js
@@ -237,6 +237,8 @@ const run = async (browser, version, os) => {
 
     log('Running tests...');
     await awaitPage(driver, `${host}/tests/?hideResults=on`, browser, version);
+
+    await driver.wait(until.elementLocated(By.id('status')), 5000);
     statusEl = await driver.findElement(By.id('status'));
     try {
       await driver.wait(until.elementTextContains(statusEl, 'upload'), 30000);


### PR DESCRIPTION
This PR offsets a nasty Safari WebDriver bug where Safari will report that the URL has changed before it has even unloaded the former page by awaiting for the _element_ to load (rather than just the page alone).