### PR TITLE
Account for other BrowserStack unsupported error

### DIFF
--- a/selenium.js
+++ b/selenium.js
@@ -167,10 +167,10 @@ const buildDriver = async (browser, version, os) => {
 
       return driver;
     } catch (e) {
-      if ((e.name == 'UnsupportedOperationError' &&
+      if (
         e.message.startsWith('Misconfigured -- Unsupported OS/browser/version/device combo')) ||
-        (e.name == 'WebDriverError' &&
-        e.message.startsWith('OS/Browser combination invalid'))
+        e.message.startsWith('OS/Browser combination invalid') ||
+        e.message.startsWith('Browser/Browser_Version not supported')
       ) {
         // If unsupported config, continue to the next grid configuration
         continue;

--- a/selenium.js
+++ b/selenium.js
@@ -168,7 +168,7 @@ const buildDriver = async (browser, version, os) => {
       return driver;
     } catch (e) {
       if (
-        e.message.startsWith('Misconfigured -- Unsupported OS/browser/version/device combo')) ||
+        e.message.startsWith('Misconfigured -- Unsupported OS/browser/version/device combo') ||
         e.message.startsWith('OS/Browser combination invalid') ||
         e.message.startsWith('Browser/Browser_Version not supported')
       ) {


### PR DESCRIPTION
It turns out that BrowserStack has another error when the browser configuration is unsupported.  This PR updates the Selenium script to account for it.