### PR TITLE
Remove caret in version for "didyoumean"

### DIFF
--- a/package.json
+++ b/package.json
@@ -33,7 +33,7 @@
     "@google-cloud/storage": "5.3.0",
     "@octokit/rest": "18.0.6",
     "cookie-parser": "1.4.5",
-    "didyoumean": "^1.2.1",
+    "didyoumean": "1.2.1",
     "ejs": "3.1.5",
     "express": "4.17.1",
     "express-ejs-layouts": "2.5.0",


### PR DESCRIPTION
This PR fixes the version number for the `didyoumean` dependency by removing the caret, making it consistent with the other dependencies.﻿
