### PR TITLE
Compat fixes

### DIFF
--- a/app.js
+++ b/app.js
@@ -139,7 +139,7 @@ app.post('/api/results/export/github', (req, res) => {
   storage.getAll(req.sessionID)
       .then(async (results) => {
         if (Object.entries(results).length === 0) {
-          res.status(204).end();
+          res.status(412).end();
           return;
         }
 

--- a/app.js
+++ b/app.js
@@ -139,7 +139,7 @@ app.post('/api/results/export/github', (req, res) => {
   storage.getAll(req.sessionID)
       .then(async (results) => {
         if (Object.entries(results).length === 0) {
-          res.status(204).send('No results to export');
+          res.status(204).end();
           return;
         }
 

--- a/app.js
+++ b/app.js
@@ -69,7 +69,7 @@ const catchError = (err, res, method) => {
   if (method === 'json') {
     res.json({error: errorToDisplay});
   } else {
-    res.text(errorToDisplay);
+    res.send(errorToDisplay);
   }
 };
 
@@ -139,19 +139,19 @@ app.post('/api/results/export/github', (req, res) => {
   storage.getAll(req.sessionID)
       .then(async (results) => {
         if (Object.entries(results).length === 0) {
-          res.json({error: 'No results to export'});
+          res.status(204).send('No results to export');
           return;
         }
 
         const report = createReport(results, req);
         const response = await github.exportAsPR(report);
         if (response) {
-          res.json(response);
+          res.send(response.html_url);
         } else {
-          res.status(500).json({error: 'Server error'});
+          res.status(500).send('Server error');
         }
       })
-      .catch(/* istanbul ignore next */ (err) => catchError(err, res, 'json'));
+      .catch(/* istanbul ignore next */ (err) => catchError(err, res, 'text'));
 });
 
 // Views

--- a/views/results.ejs
+++ b/views/results.ejs
@@ -31,7 +31,9 @@ function exportGitHub() {
   status.innerHTML = 'Exporting...';
   client.onreadystatechange = function() {
     if (client.readyState == 4) {
-      if (client.status >= 200 && client.status <= 299 && client.status != 204) {
+      if (client.status == 204) {
+        status.innerHTML = 'No results to export';
+      } else if (client.status >= 200 && client.status <= 299) {
         status.innerHTML = 'Exported to';
         link.href = link.innerHTML = client.responseText;
       } else {

--- a/views/results.ejs
+++ b/views/results.ejs
@@ -31,11 +31,11 @@ function exportGitHub() {
   status.innerHTML = 'Exporting...';
   client.onreadystatechange = function() {
     if (client.readyState == 4) {
-      if (client.status == 204) {
-        status.innerHTML = 'No results to export';
-      } else if (client.status >= 200 && client.status <= 299) {
+      if (client.status >= 200 && client.status <= 299) {
         status.innerHTML = 'Exported to';
         link.href = link.innerHTML = client.responseText;
+      } else if (client.status == 412) {
+        status.innerHTML = 'No results to export';
       } else {
         status.innerHTML = 'Failed to export: ' + client.responseText;
       }

--- a/views/results.ejs
+++ b/views/results.ejs
@@ -28,7 +28,7 @@ function exportGitHub() {
   }
 
   client.open('POST', '/api/results/export/github', true);
-  client.send();
+  client.send('');
   status.innerHTML = 'Exporting...';
   client.onreadystatechange = function() {
     if (client.readyState == 4) {

--- a/views/results.ejs
+++ b/views/results.ejs
@@ -9,7 +9,6 @@
 <div>
   <a href="/">Back to start page</a>
 </div>
-<script src="/resources/json3.min.js"></script>
 <script>
 function exportGitHub() {
   var status = document.getElementById('status');
@@ -32,19 +31,11 @@ function exportGitHub() {
   status.innerHTML = 'Exporting...';
   client.onreadystatechange = function() {
     if (client.readyState == 4) {
-      var response = {};
-
-      try {
-        response = JSON.parse(client.responseText);
-      } catch (e) {
-        response.error = client.responseText;
-      }
-
-      if (response.error) {
-        status.innerHTML = 'Failed to export: ' + response.error;
-      } else {
+      if (client.status >= 200 && client.status <= 299 && client.status != 204) {
         status.innerHTML = 'Exported to';
-        link.href = link.innerHTML = response.html_url;
+        link.href = link.innerHTML = client.responseText;
+      } else {
+        status.innerHTML = 'Failed to export: ' + client.responseText;
       }
     }
   }


### PR DESCRIPTION
This PR provides a few compatibility fixes that improve support for Firefox 1-4 and Internet Explorer by performing the following:

- Adds the apparently-required `body` argument to the `XMLHttpRequest.send()` command
- Removes JSON exchange and uses status codes + strings for results and GitHub export page