### PR TITLE
Switch webref branch back to foolip's fork

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -6965,8 +6965,8 @@
       "dev": true
     },
     "webref": {
-      "version": "github:vinyldarkscratch/webref#6c6bc8f5b51c3f2a10030c3c8b9d7020966f03f0",
-      "from": "github:vinyldarkscratch/webref#mdn-bcd-updater-fixes",
+      "version": "github:foolip/webref#6c6bc8f5b51c3f2a10030c3c8b9d7020966f03f0",
+      "from": "github:foolip/webref#mdn-bcd-updater-fixes-2",
       "dev": true
     },
     "which": {

--- a/package.json
+++ b/package.json
@@ -78,6 +78,6 @@
     "selenium-webdriver": "3.6.0",
     "sinon": "9.2.0",
     "webidl2": "23.13.0",
-    "webref": "github:vinyldarkscratch/webref#mdn-bcd-updater-fixes"
+    "webref": "github:foolip/webref#mdn-bcd-updater-fixes-2"
   }
 }


### PR DESCRIPTION
This PR switches the source of `webref` back to @foolip's fork, selecting the new update branch that was recently pushed.﻿
