### PR TITLE
Ignore versions BrowserStack doesn't support but remaps instead

### DIFF
--- a/selenium.js
+++ b/selenium.js
@@ -97,6 +97,18 @@ const getSafariOS = (version) => {
 
 const buildDriver = async (browser, version, os) => {
   for (const [service, seleniumUrl] of Object.entries(secrets.selenium)) {
+    if (service === 'browserstack') {
+      if (browser === 'edge' && ['12', '13', '14'].includes(version)) {
+        // BrowserStack remaps Edge 12-14 as Edge 15
+        continue;
+      }
+
+      if (browser === 'safari' && ['10', '11', '12', '13'].includes(version)) {
+        // BrowserStack doesn't support the Safari x.0 versions
+        continue;
+      }
+    }
+
     let osesToTest = [];
 
     switch (os) {


### PR DESCRIPTION
BrowserStack doesn't support Edge 12-14 or Safari x.0 versions.  However, instead of returning an "unsupported" error, instead it remaps them to the closest match (Edge 12-14 -> Edge 15, and Safari x.0 -> x.1).  This PR includes a few if clauses to mitigate these issues.