### PR TITLE
Fix custom test for HTMLTableCellElement for IE

### DIFF
--- a/custom-tests.json
+++ b/custom-tests.json
@@ -456,7 +456,7 @@
     },
     "HTMLTableCellElement": {
       "__base": "var instance = document.createElement('td');",
-      "__test": "if (!instance.constructor.name && Object.prototype.toString.call(instance) === '[object Object]') {return {result: null, message: 'Detection methods unsupported'}} if (instance.constructor.name !== 'HTMLTableCellElement' && Object.prototype.toString.call(instance) !== '[object HTMLTableCellElement]') {return false;} return !!instance;"
+      "__test": "if (!instance.constructor.name && Object.prototype.toString.call(instance) === '[object Object]') {return {result: null, message: 'Detection methods unsupported'}} if (instance.constructor.name !== 'HTMLTableCellElement' && Object.prototype.toString.call(instance) !== '[object HTMLTableCellElement]' && Object.prototype.toString.call(instance) !== '[object HTMLTableDataCellElement]') {return false;} return !!instance;"
     },
     "HTMLTableColElement": {
       "__base": "var instance = document.createElement('col');",


### PR DESCRIPTION
This PR updates the custom test for the `HTMLTableCellElement` API for better IE/Edge support.  Turns out that IE calls the API `HTMLTableDataCellElement` instead; this test accommodates for this other name.﻿
