### PR TITLE
Use <div> vs. <p> to test HTMLElement API

### DIFF
--- a/custom-tests.json
+++ b/custom-tests.json
@@ -269,7 +269,7 @@
       "__test": "if (!instance.constructor.name && Object.prototype.toString.call(instance) === '[object Object]') {return {result: null, message: 'Detection methods unsupported'}} if (instance.constructor.name !== 'HTMLDListElement' && Object.prototype.toString.call(instance) !== '[object HTMLDListElement]') {return false;} return !!instance;"
     },
     "HTMLElement": {
-      "__base": "<%api.HTMLParagraphElement:instance%>"
+      "__base": "<%api.HTMLDivElement:instance%>"
     },
     "HTMLEmbedElement": {
       "__base": "var instance = document.createElement('embed');",


### PR DESCRIPTION
Since some properties are implemented on the `<p>` element that aren't everywhere in older browser versions, this PR updates our tests to use the `<div>` element for testing instead.