### PR TITLE
Optimize Element and HTMLElement custom tests

### DIFF
--- a/custom-tests.json
+++ b/custom-tests.json
@@ -150,7 +150,7 @@
       }
     },
     "Element": {
-      "__base": "<%api.HTMLElement:instance%>"
+      "__base": "var instance =  document.createElementNS('', 'p');"
     },
     "DynamicsCompressorNode": {
       "__resources": ["audioContext"],
@@ -269,7 +269,7 @@
       "__test": "if (!instance.constructor.name && Object.prototype.toString.call(instance) === '[object Object]') {return {result: null, message: 'Detection methods unsupported'}} if (instance.constructor.name !== 'HTMLDListElement' && Object.prototype.toString.call(instance) !== '[object HTMLDListElement]') {return false;} return !!instance;"
     },
     "HTMLElement": {
-      "__base": "<%api.HTMLParagraphElement:instance%>"
+      "__base": "var instance = document.createElement('element');"
     },
     "HTMLEmbedElement": {
       "__base": "var instance = document.createElement('embed');",


### PR DESCRIPTION
This PR optimizes the custom tests for the `Element` and `HTMLElement` APIs.

For `HTMLElement`, by specifying a non-existent tag name, we're able to confirm what is supported on the `HTMLElement` API, rather than a specific element's API.

For `Element`, by specifying an empty namespace on `document.createElementNS()`, it will just create a generic element (non-HTML), so we can confirm what's on the `Element` API and not just the `HTMLElement` API.