### PR TITLE
Fix macOS version for Safari 12.0 in Selenium script

### DIFF
--- a/selenium.js
+++ b/selenium.js
@@ -88,6 +88,7 @@ const getSafariOS = (version) => {
     case '11':
       return 'macOS 10.12';
     case '12':
+      return 'macOS 10.14';
     case '13':
       return 'macOS 10.13';
     default:


### PR DESCRIPTION
This PR fixes the OS version selection for Safari 12.0.  Apparently, SauceLabs set 12.0 to macOS Mojave, rather than High Sierra.﻿
