### PR TITLE
Return "null" if UA cannot be parsed

### DIFF
--- a/ua-parser.js
+++ b/ua-parser.js
@@ -12,7 +12,7 @@ const parseUA = (userAgent, browsers) => {
   const ua = uaParser(userAgent);
 
   if (!ua.browser.name) {
-    return null;
+    return {browser: {id: null, name: null}, version: null, inBcd: undefined};
   }
 
   const browser = {

--- a/ua-parser.js
+++ b/ua-parser.js
@@ -11,6 +11,10 @@ const getMajorMinorVersion = (version) => {
 const parseUA = (userAgent, browsers) => {
   const ua = uaParser(userAgent);
 
+  if (!ua.browser.name) {
+    return null;
+  }
+
   const browser = {
     id: ua.browser.name.toLowerCase().replace(/ /g, '_'),
     name: ua.browser.name

--- a/unittest/unit/ua-parser.js
+++ b/unittest/unit/ua-parser.js
@@ -101,4 +101,8 @@ describe('parseUA', () => {
   it('Yandex Browser (not in BCD)', () => {
     assert.deepEqual(parseUA('Mozilla/5.0 (Windows NT 6.3) AppleWebKit/537.36 (KHTML, like Gecko) Chrome/58.0.3029.110 YaBrowser/17.6.1.749 Yowser/2.5 Safari/537.36', browsers), {browser: {id: 'yandex', name: 'Yandex'}, version: '17.6', inBcd: undefined});
   });
+
+  it('node-superagent (unparseable)', () => {
+    assert.deepEqual(parseUA('node-superagent/1.2.3'), {browser: {id: null, name: null}, version: null, inBcd: undefined});
+  });
 });

--- a/unittest/unit/update-bcd.js
+++ b/unittest/unit/update-bcd.js
@@ -378,6 +378,19 @@ const reports = [
       ]
     },
     userAgent: 'Mozilla/5.0 (Windows NT 6.1; WOW64) AppleWebKit/537.36 (KHTML, like Gecko) Chrome/1000.1.4183.83 Safari/537.36'
+  },
+  {
+    __version: '0.3.1',
+    results: {
+      'https://mdn-bcd-collector.appspot.com/tests/': [
+        {
+          name: 'api.AbortController',
+          info: {exposure: 'Window'},
+          result: false
+        }
+      ]
+    },
+    userAgent: 'node-superagent/1.2.3'
   }
 ];
 
@@ -538,6 +551,7 @@ describe('BCD updater', () => {
 
       assert.isTrue(logger.warn.calledWith('Ignoring unknown browser Yandex 17.6 (Mozilla/5.0 (Windows NT 6.3) AppleWebKit/537.36 (KHTML, like Gecko) Chrome/58.0.3029.110 YaBrowser/17.6.1.749 Yowser/2.5 Safari/537.36)'));
       assert.isTrue(logger.warn.calledWith('Ignoring unknown Chrome version 1000.1 (Mozilla/5.0 (Windows NT 6.1; WOW64) AppleWebKit/537.36 (KHTML, like Gecko) Chrome/1000.1.4183.83 Safari/537.36)'));
+      assert.isTrue(logger.warn.calledWith('Unable to parse browser from UA node-superagent/1.2.3'));
     });
 
     afterEach(() => {

--- a/update-bcd.js
+++ b/update-bcd.js
@@ -83,8 +83,10 @@ const getSupportMatrix = (browsers, reports) => {
     if (!inBcd) {
       if (inBcd === false) {
         logger.warn(`Ignoring unknown ${browser.name} version ${version} (${report.userAgent})`);
-      } else {
+      } else if (browser.name) {
         logger.warn(`Ignoring unknown browser ${browser.name} ${version} (${report.userAgent})`);
+      } else {
+        logger.warn(`Unable to parse browser from UA ${report.userAgent}`);
       }
 
       continue;


### PR DESCRIPTION
This PR updates the UA parser to return a like-null dictionary when the UA string cannot be parsed (such as in the cases of unittests).
