### PR TITLE
Add support for LegacyFactoryFunction constructors

### DIFF
--- a/build.js
+++ b/build.js
@@ -352,6 +352,12 @@ const flattenMembers = (iface) => {
     // Test generation doesn't use constructor arguments, so they aren't copied
     members.push({name: iface.name, type: 'constructor'});
   }
+  if (getExtAttr(iface, 'LegacyFactoryFunction')) {
+    members.push({
+      name: getExtAttr(iface, 'LegacyFactoryFunction').rhs.value,
+      type: 'constructor'
+    });
+  }
 
   return members.sort((a, b) => a.name.localeCompare(b.name));
 };


### PR DESCRIPTION
This PR adds support for the `LegacyFactoryFunction` extended attribute, which can have constructors under names different from the interface name.  (An example of this is `api.HTMLAudioElement.Audio`, where the interface defines the `Audio()` constructor.)﻿
