### PR TITLE
Remove IDL for Element.accessKey

### DIFF
--- a/custom-idl/html.idl
+++ b/custom-idl/html.idl
@@ -59,9 +59,6 @@ partial interface Document {
 };
 
 partial interface Element {
-  // https://github.com/mdn/browser-compat-data/issues/6697
-  readonly attribute DOMString accessKey;
-
   // https://github.com/mdn/browser-compat-data/issues/6683
   readonly attribute DOMString name;
 


### PR DESCRIPTION
This PR removes the temporary IDL for `api.Element.accessKey`, since it has been removed from BCD.﻿
