### PR TITLE
Use process.env.npm_package_version vs. require('./package.json').version

### DIFF
--- a/app.js
+++ b/app.js
@@ -27,8 +27,6 @@ const logger = require('./logger');
 const storage = require('./storage').getStorage();
 const {parseUA} = require('./ua-parser');
 
-const appversion = require('./package.json').version;
-
 const PORT = process.env.PORT || 8080;
 
 /* istanbul ignore next */
@@ -76,7 +74,7 @@ const catchError = (err, res, method) => {
 };
 
 const createReport = (results, req) => {
-  return {__version: appversion, results, userAgent: req.get('User-Agent')};
+  return {__version: process.env.npm_package_version, results, userAgent: req.get('User-Agent')};
 };
 
 const app = express();
@@ -96,7 +94,7 @@ app.use(express.static('static'));
 app.use(express.static('generated'));
 
 app.use((req, res, next) => {
-  app.locals.appversion = appversion;
+  app.locals.appversion = process.env.npm_package_version;
   app.locals.browser = parseUA(req.get('User-Agent'), bcdBrowsers);
   next();
 });
@@ -204,10 +202,7 @@ app.use((req, res) => {
   });
 });
 
-module.exports = {
-  app,
-  version: appversion
-};
+module.exports = {app};
 
 /* istanbul ignore if */
 if (require.main === module) {

--- a/unittest/app/app.js
+++ b/unittest/app/app.js
@@ -20,7 +20,7 @@ chai.use(chaiHttp);
 const assert = chai.assert;
 const expect = chai.expect;
 
-const {app, version} = require('../../app');
+const {app} = require('../../app');
 const agent = chai.request.agent(app);
 
 const tests = Object.entries(require('../../tests.json'));
@@ -47,7 +47,7 @@ describe('/api/results', () => {
     const res = await agent.get('/api/results');
     assert.equal(res.status, 200);
     assert.deepEqual(res.body, {
-      __version: version,
+      __version: process.env.npm_package_version,
       results: {},
       userAgent: userAgent
     });
@@ -68,7 +68,7 @@ describe('/api/results', () => {
     const res = await agent.get('/api/results');
     assert.equal(res.status, 200);
     assert.deepEqual(res.body, {
-      __version: version,
+      __version: process.env.npm_package_version,
       results: {[testURL]: {x: 1}},
       userAgent: userAgent
     });
@@ -85,7 +85,7 @@ describe('/api/results', () => {
     const res = await agent.get('/api/results');
     assert.equal(res.status, 200);
     assert.deepEqual(res.body, {
-      __version: version,
+      __version: process.env.npm_package_version,
       results: {[testURL]: {x: 2}},
       userAgent: userAgent
     });
@@ -103,7 +103,7 @@ describe('/api/results', () => {
     const res = await agent.get('/api/results');
     assert.equal(res.status, 200);
     assert.deepEqual(res.body, {
-      __version: version,
+      __version: process.env.npm_package_version,
       results: {[testURL]: {x: 2}, [testURL2]: {y: 3}},
       userAgent: userAgent
     });


### PR DESCRIPTION
The package version is exposed on the environment, I found -- this PR simplifies our code to use the environment variable.