### PR TITLE
Throw a console.error in build.js if custom test is malformed

### DIFF
--- a/build.js
+++ b/build.js
@@ -67,7 +67,11 @@ const compileCustomTest = (code, format = true) => {
     }
 
     // Format
-    code = prettier.format(code, {singleQuote: true, parser: 'babel'}).trim();
+    try {
+      code = prettier.format(code, {singleQuote: true, parser: 'babel'}).trim();
+    } catch (e) {
+      return `throw 'Test is malformed: ${e}'`;
+    }
   }
 
   return code;
@@ -110,8 +114,13 @@ const getCustomTestAPI = (name, member) => {
     return false;
   }
 
+  test = compileCustomTest(test);
 
-  return compileCustomTest(test);
+  if (test.includes('Test is malformed')) {
+    console.error(`api.${name}${member ? `.${member}` : ''}: ${test.replace('throw ', '')}`);
+  }
+
+  return test;
 };
 
 const getCustomSubtestsAPI = (name) => {


### PR DESCRIPTION
This PR adds a console error when build.js determines a custom test is malformed for any reason (syntax errors, bad import, etc.), along with rather than just crashing the build on a syntax error.