### PR TITLE
Disable testing Firefox in unittests

### DIFF
--- a/unittest/puppeteer/harness.js
+++ b/unittest/puppeteer/harness.js
@@ -25,7 +25,7 @@ const pti = require('puppeteer-to-istanbul');
 const {app} = require('../../app');
 
 // Firefox is temporarily disabled due to issues on CI
-const products = ['chrome']; //['chrome', 'firefox'];
+const products = ['chrome']; // ['chrome', 'firefox'];
 
 // Workaround for https://github.com/puppeteer/puppeteer/issues/6255
 const consoleLogType = {

--- a/unittest/puppeteer/harness.js
+++ b/unittest/puppeteer/harness.js
@@ -24,7 +24,8 @@ const pti = require('puppeteer-to-istanbul');
 
 const {app} = require('../../app');
 
-const products = ['chrome', 'firefox'];
+// Firefox is temporarily disabled due to issues on CI
+const products = ['chrome']; //['chrome', 'firefox'];
 
 // Workaround for https://github.com/puppeteer/puppeteer/issues/6255
 const consoleLogType = {


### PR DESCRIPTION
Something is causing issues with running Firefox in the Puppeteer unittests on macOS CI (it is working totally fine in local though).  This PR disables testing Firefox in Puppeteer.