### PR TITLE
Improve testing code for better promise support

### DIFF
--- a/build.js
+++ b/build.js
@@ -41,7 +41,7 @@ const compileCustomTest = (code, format = true) => {
       );
       if (instancevar !== 'instance' && instancevar !== 'promise') {
         if (promise) {
-          importcode += ` if (!${instancevar}) {reject();}`;
+          importcode += ` if (!${instancevar}) {resolve(false);}`;
         } else {
           importcode += ` if (!${instancevar}) {return false;}`;
         }

--- a/build.js
+++ b/build.js
@@ -40,11 +40,7 @@ const compileCustomTest = (code, format = true) => {
           /var (instance|promise)/g, `var ${instancevar}`
       );
       if (instancevar !== 'instance' && instancevar !== 'promise') {
-        if (promise) {
-          importcode += ` if (!${instancevar}) {resolve(false);}`;
-        } else {
-          importcode += ` if (!${instancevar}) {return false;}`;
-        }
+        importcode += ` if (!${instancevar}) {return false;}`;
       }
       return importcode;
     }
@@ -55,9 +51,7 @@ const compileCustomTest = (code, format = true) => {
 
   if (format) {
     // Wrap in a function
-    if (promise) {
-      code = `new Promise(function(resolve, reject) {${code}})`;
-    } else {
+    if (!promise) {
       code = `(function () {${code}})()`;
     }
 
@@ -83,7 +77,7 @@ const getCustomTestAPI = (name, member) => {
         test = testbase + customTests.api[name].__test;
       } else {
         test = testbase ? testbase + (
-          promise ? 'promise.then(function(instance) {resolve(!!instance)});' : 'return !!instance;'
+          promise ? 'promise.then(function(instance) {return !!instance});' : 'return !!instance;'
         ) : false;
       }
     } else {
@@ -98,7 +92,7 @@ const getCustomTestAPI = (name, member) => {
           test = false;
         } else {
           test = testbase ? testbase + (
-            promise ? `promise.then(function(instance) {resolve('${member}' in instance)});` : `return '${member}' in instance;`
+            promise ? `promise.then(function(instance) {return '${member}' in instance});` : `return '${member}' in instance;`
           ) : false;
         }
       }

--- a/static/resources/harness.js
+++ b/static/resources/harness.js
@@ -131,7 +131,7 @@
     return result;
   }
 
-  function processTestResult(value, data, test, i, callback) {
+  function processTestResult(value, data, i, callback) {
     var result = {name: data.name, info: {}};
 
     if (value && typeof value === 'object' && 'result' in value) {
@@ -150,9 +150,9 @@
     }
 
     if (result.result !== false) {
-      result.info.code = test.code;
-      if (test.prefix) {
-        result.info.prefix = test.prefix;
+      result.info.code = data.tests[i].code;
+      if (data.tests[i].prefix) {
+        result.info.prefix = data.tests[i].prefix;
       }
     } else {
       result.info.code = data.tests[0].code;
@@ -200,17 +200,17 @@
       if ('Promise' in self && value instanceof Promise) {
         Promise.resolve(value).then(
             function(value) {
-              processTestResult(value, data, test, i, callback);
+              processTestResult(value, data, i, callback);
             },
             function(fail) {
-              processTestResult(new Error(fail), data, test, i, callback);
+              processTestResult(new Error(fail), data, i, callback);
             }
         );
       } else {
-        processTestResult(value, data, test, i, callback);
+        processTestResult(value, data, i, callback);
       }
     } catch (err) {
-      processTestResult(err, data, test, i, callback);
+      processTestResult(err, data, i, callback);
     }
   }
 

--- a/static/resources/harness.js
+++ b/static/resources/harness.js
@@ -199,7 +199,7 @@
     try {
       var value = eval(test.code);
 
-      if (typeof value === 'object' && typeof value.then === 'function') {
+      if (typeof value === 'object' && value !== null && typeof value.then === 'function') {
         value.then(
             function(value) {
               processTestResult(value, data, i, callback);

--- a/static/resources/harness.js
+++ b/static/resources/harness.js
@@ -135,7 +135,7 @@
   // This function then compiles a result object from the given result value,
   // and then passes the result to `callback()` (or if the result is not true
   // and there are more test variants, run the next test variant).
-  // 
+  //
   // If the test result is an error or non-boolean, the result value is set to
   // `null` and the original value is mentioned in the result message.
   //

--- a/static/resources/harness.js
+++ b/static/resources/harness.js
@@ -199,8 +199,8 @@
     try {
       var value = eval(test.code);
 
-      if ('Promise' in self && value instanceof Promise) {
-        Promise.resolve(value).then(
+      if (typeof value === 'object' && typeof value.then === 'function') {
+        value.then(
             function(value) {
               processTestResult(value, data, i, callback);
             },

--- a/static/resources/harness.js
+++ b/static/resources/harness.js
@@ -131,6 +131,24 @@
     return result;
   }
 
+  // Once a test is evaluated and run, it calls this function with the result.
+  // This function then compiles a result object from the given result value,
+  // and then passes the result to `callback()` (or if the result is not true
+  // and there are more test variants, run the next test variant).
+  // 
+  // If the test result is an error or non-boolean, the result value is set to
+  // `null` and the original value is mentioned in the result message.
+  //
+  // Test results are mapped into objects like this:
+  // {
+  //   "name": "api.Attr.localName",
+  //   "result": true,
+  //   "prefix": "",
+  //   "info": {
+  //     "code": "'localName' in Attr.prototype",
+  //     "exposure": "Window"
+  //   }
+  // }
   function processTestResult(value, data, i, callback) {
     var result = {name: data.name, info: {}};
 
@@ -175,22 +193,6 @@
     }
   }
 
-  // Each test is mapped to an object like this:
-  // {
-  //   "name": "api.Attr.localName",
-  //   "result": true,
-  //   "prefix": "",
-  //   "info": {
-  //     "code": "'localName' in Attr.prototype",
-  //     "exposure": "Window"
-  //   }
-  // }
-  //
-  // If the test doesn't return true or false, or if it throws, `result` will
-  // be null and a `message` property is set to an explanation.
-  //
-  // Once the test is complete, it will call `callback(result)` with the test
-  // result as the argument.
   function runTest(data, i, callback) {
     var test = data.tests[i];
 

--- a/static/resources/serviceworker.js
+++ b/static/resources/serviceworker.js
@@ -44,7 +44,7 @@ self.addEventListener('message', function(event) {
     };
 
     for (var i = 0; i < pending.length; i++) {
-      bcd.test(pending[i], oncomplete);
+      bcd.runTest(pending[i], 0, oncomplete);
     }
   } else {
     event.ports[0].postMessage(results);

--- a/static/resources/sharedworker.js
+++ b/static/resources/sharedworker.js
@@ -35,7 +35,7 @@ self.onconnect = function(connectEvent) {
       };
 
       for (var i = 0; i < pending.length; i++) {
-        bcd.test(pending[i], oncomplete);
+        bcd.runTest(pending[i], 0, oncomplete);
       }
     } else {
       port.postMessage(results);

--- a/static/resources/worker.js
+++ b/static/resources/worker.js
@@ -33,7 +33,7 @@ self.onmessage = function(event) {
     };
 
     for (var i = 0; i < pending.length; i++) {
-      bcd.test(pending[i], oncomplete);
+      bcd.runTest(pending[i], 0, oncomplete);
     }
   } else {
     self.postMessage(results);


### PR DESCRIPTION
This PR improves the test code for better Promise-based support, by doing the following:

- Consolidating and flattening functions, thus simplifying their code
- Processing a promise rejection as an error
- Check for a thenable object, rather than explicitly a promise
- Remove redundant Promise.resolve()
- Remove redundant promise wrapping