### PR TITLE
Add custom tests for CSSFontFaceRule and CSSImportRule

### DIFF
--- a/custom-tests.json
+++ b/custom-tests.json
@@ -121,6 +121,14 @@
     "CryptoKey": {
       "__base": "<%api.SubtleCrypto:subtlecrypto%> var promise = window.crypto.subtle.generateKey({name: 'RSA-OAEP', modulusLength: 4096, publicExponent: new Uint8Array([1, 0, 1]), hash: 'SHA-256' }, true, ['encrypt', 'decrypt']);"
     },
+    "CSSFontFaceRule": {
+      "__resources": ["createStyleSheet"],
+      "__base": "var stylesheet = reusableInstances.createStyleSheet('@font-face {font-family: somefont; src: url(somefont.ttf);}'); var instance = stylesheet.cssRules.item(0);"
+    },
+    "CSSImportRule": {
+      "__resources": ["createStyleSheet"],
+      "__base": "var stylesheet = reusableInstances.createStyleSheet('@import url(/style.css);'); var instance = stylesheet.cssRules.item(0);"
+    },
     "CSSKeyframeRule": {
       "__resources": ["createStyleSheet"],
       "__base": "<%api.CSSKeyframesRule:keyframes%> var instance = keyframes.cssRules.item(0);"


### PR DESCRIPTION
This PR adds custom tests for the CSSFontFaceRule and CSSImportRule APIs, to help add data for https://github.com/vinyldarkscratch/browser-compat-data/pull/23.﻿
