### PR TITLE
Fix issues with testing with promises

### DIFF
--- a/build.js
+++ b/build.js
@@ -26,8 +26,6 @@ const specData = require('./spec-data');
 const generatedDir = path.join(__dirname, 'generated');
 
 const compileCustomTest = (code, format = true) => {
-  const promise = code.includes('var promise');
-
   // Import code from other tests
   code = code.replace(/<%(\w+)\.(\w+)(?:\.(\w+))?:(\w+)%> ?/g, (match, category, name, member, instancevar) => {
     if (category === 'api') {

--- a/build.js
+++ b/build.js
@@ -51,9 +51,7 @@ const compileCustomTest = (code, format = true) => {
 
   if (format) {
     // Wrap in a function
-    if (!promise) {
-      code = `(function () {${code}})()`;
-    }
+    code = `(function () {${code}})()`;
 
     // Format
     try {
@@ -77,7 +75,7 @@ const getCustomTestAPI = (name, member) => {
         test = testbase + customTests.api[name].__test;
       } else {
         test = testbase ? testbase + (
-          promise ? 'promise.then(function(instance) {return !!instance});' : 'return !!instance;'
+          promise ? 'return promise.then(function(instance) {return !!instance});' : 'return !!instance;'
         ) : false;
       }
     } else {
@@ -92,7 +90,7 @@ const getCustomTestAPI = (name, member) => {
           test = false;
         } else {
           test = testbase ? testbase + (
-            promise ? `promise.then(function(instance) {return '${member}' in instance});` : `return '${member}' in instance;`
+            promise ? `return promise.then(function(instance) {return '${member}' in instance});` : `return '${member}' in instance;`
           ) : false;
         }
       }

--- a/static/resources/harness.js
+++ b/static/resources/harness.js
@@ -207,6 +207,10 @@
             function(fail) {
               processTestResult(new Error(fail), data, i, callback);
             }
+        ).catch(
+            function(err) {
+              processTestResult(err, data, i, callback);
+            }
         );
       } else {
         processTestResult(value, data, i, callback);


### PR DESCRIPTION
This PR fixes some issues around testing with promises, by doing two things:
- Catches when a promise fails (using .catch())
- Wraps _everything_ in functions, for when promise and non-promise code is combined
