### PR TITLE
Various fixes

### DIFF
--- a/custom-tests.json
+++ b/custom-tests.json
@@ -78,7 +78,7 @@
     },
     "AudioWorkletNode": {
       "__resources": ["audioContext"],
-      "__base": "if (!reusableInstances.audioContext) {return false;} if (!reusableInstances.audioContext.audioWorklet) {return false;} var promise = reusableInstances.audioContext.audioWorklet.addModule('/resources/custom-tests/api/AudioWorkletNode/WhiteNoiseProcessor.js').then(function() {return new AudioWorkletNode(reusableInstances.audioContext, 'white-noise-processor')});"
+      "__base": "if (!reusableInstances.audioContext) {return false;} if (!reusableInstances.audioContext.audioWorklet) {return false;} var promise = reusableInstances.audioContext.audioWorklet.addModule('/resources/custom-tests/api/AudioWorkletNode/WhiteNoiseProcessor.js').then(function() {return new AudioWorkletNode(reusableInstances.audioContext, 'white-noise-processor')}); promise.then(function() {});"
     },
     "BatteryManager": {
       "__base": "var promise = navigator.getBattery();"
@@ -603,7 +603,7 @@
       "__base": "var instance = new MediaSource();"
     },
     "MediaStream": {
-      "__base": "<%api.MediaDevices:mediaDevices%> var promise = mediaDevices.getUserMedia({video: true});"
+      "__base": "<%api.MediaDevices:mediaDevices%> var promise = mediaDevices.getUserMedia({video: true}); promise.then(function() {});"
     },
     "MediaStreamAudioDestinationNode": {
       "__resources": ["audioContext"],

--- a/custom-tests.json
+++ b/custom-tests.json
@@ -116,10 +116,10 @@
       "__base": "if (!reusableInstances.audioContext) {return false;} var instance = reusableInstances.audioContext.createConvolver();"
     },
     "Crypto": {
-      "__base": "var instance = window.crypto;"
+      "__base": "if (!('crypto' in self)) {return false}; var instance = crypto;"
     },
     "CryptoKey": {
-      "__base": "<%api.SubtleCrypto:subtlecrypto%> var promise = window.crypto.subtle.generateKey({name: 'RSA-OAEP', modulusLength: 4096, publicExponent: new Uint8Array([1, 0, 1]), hash: 'SHA-256' }, true, ['encrypt', 'decrypt']);"
+      "__base": "<%api.SubtleCrypto:subtlecrypto%> var promise = subtlecrypto.generateKey({name: 'RSA-OAEP', modulusLength: 4096, publicExponent: new Uint8Array([1, 0, 1]), hash: 'SHA-256' }, true, ['encrypt', 'decrypt']);"
     },
     "CSSFontFaceRule": {
       "__resources": ["createStyleSheet"],

--- a/selenium.js
+++ b/selenium.js
@@ -320,7 +320,7 @@ const run = async (browser, version, os, showlogs) => {
 
   try {
     driver.quit();
-  } catch(e) {
+  } catch (e) {
     // The driver will expire on its own
   }
 };

--- a/selenium.js
+++ b/selenium.js
@@ -318,7 +318,11 @@ const run = async (browser, version, os, showlogs) => {
     }
   }
 
-  await driver.quit();
+  try {
+    driver.quit();
+  } catch(e) {
+    // The driver will expire on its own
+  }
 };
 
 const runAll = async (limitBrowsers, oses, showlogs) => {

--- a/static/resources/harness.js
+++ b/static/resources/harness.js
@@ -401,7 +401,7 @@
       var timeout = setTimeout(function() {
         updateStatus('<br />This test seems to be taking a long time; ' +
             'it may have crashed. Check the console for errors.', true);
-      }, 20000);
+      }, 30000);
 
       runWindow(function(results) {
         runWorker(function(results) {

--- a/static/resources/harness.js
+++ b/static/resources/harness.js
@@ -409,7 +409,10 @@
           runSharedWorker(function(results) {
             runServiceWorker(function(results) {
               pending = {};
-              window.__workerCleanup();
+
+              if ('serviceWorker' in navigator) {
+                window.__workerCleanup();
+              }
 
               clearTimeout(timeout);
               if (typeof callback == 'function') {

--- a/static/resources/harness.js
+++ b/static/resources/harness.js
@@ -230,12 +230,12 @@
 
       if (completedTests >= tests.length) {
         callback(results);
-      } else {
-        runTest(tests[completedTests], 0, oncomplete);
       }
     };
 
-    runTest(tests[0], 0, oncomplete);
+    for (var i = 0; i < tests.length; i++) {
+      runTest(tests[i], 0, oncomplete);
+    }
   }
 
   function runWindow(callback, results) {

--- a/static/resources/harness.js
+++ b/static/resources/harness.js
@@ -409,6 +409,7 @@
           runSharedWorker(function(results) {
             runServiceWorker(function(results) {
               pending = {};
+              window.__workerCleanup();
 
               clearTimeout(timeout);
               if (typeof callback == 'function') {

--- a/static/resources/harness.js
+++ b/static/resources/harness.js
@@ -207,7 +207,8 @@
             function(fail) {
               processTestResult(new Error(fail), data, i, callback);
             }
-        ).catch(
+        );
+        value['catch'](
             function(err) {
               processTestResult(err, data, i, callback);
             }


### PR DESCRIPTION
This PR provides a number of compatibility and stability fixes, especially around promises.

- Asynchronously quit drivers in Selenium
- Update Crypto + CryptoKey code
- Increase timeout before showing possible failure message
- Call runTest in parallel
- Accommodate for dumb IE8 parsing issue
- Cleanup service worker after test completion
- Call promise.then(() => {}) on promises used in imports
- Only cleanup when needed
- Fix linting
