### PR TITLE
Don't double-load style.css after test run

### DIFF
--- a/static/resources/harness.js
+++ b/static/resources/harness.js
@@ -474,16 +474,6 @@
     consoleLog('Tests complete');
     updateStatus('Posting results to server...');
 
-    var css = document.createElement('link');
-    css.rel = 'stylesheet';
-    css.type = 'text/css';
-    css.href = '/resources/style.css';
-    try {
-      document.head.appendChild(css);
-    } catch (e) {
-      // If we fail to import the CSS, it's not a big deal
-    }
-
     try {
       var body = JSON.stringify(results);
 


### PR DESCRIPTION
In the styling updates, I had set the test running pages to use the main layout.  Initially, we wanted to ensure that we're not loading too many resources before running the tests, however a) since users visit the homepage as it is, the CSS is already cached and loaded, and b) some older browsers were actually crashing trying to re-render the page after changing fonts.  I initially forgot to remove the loading code that loads the CSS styling after tests run.