### PR TITLE
Fix test for api.EventSource

### DIFF
--- a/app.js
+++ b/app.js
@@ -195,6 +195,11 @@ app.all('/tests/*', (req, res) => {
   }
 });
 
+app.get('/eventstream', (req, res) => {
+  res.header("Content-Type", "text/event-stream");
+  res.send('event: ping\ndata: Hello world!\ndata: {"foo": "bar"}\ndata: Goodbye world!');
+});
+
 // Page Not Found Handler
 app.use((req, res) => {
   res.status(404).render('error', {

--- a/app.js
+++ b/app.js
@@ -166,7 +166,7 @@ app.post('/api/results/export/github', (req, res) => {
 
 // api.EventSource
 app.get('/eventstream', (req, res) => {
-  res.header("Content-Type", "text/event-stream");
+  res.header('Content-Type', 'text/event-stream');
   res.send('event: ping\ndata: Hello world!\ndata: {"foo": "bar"}\ndata: Goodbye world!');
 });
 

--- a/app.js
+++ b/app.js
@@ -162,6 +162,14 @@ app.post('/api/results/export/github', (req, res) => {
       .catch(/* istanbul ignore next */ (err) => catchError(err, res, 'text'));
 });
 
+// Test Resources
+
+// api.EventSource
+app.get('/eventstream', (req, res) => {
+  res.header("Content-Type", "text/event-stream");
+  res.send('event: ping\ndata: Hello world!\ndata: {"foo": "bar"}\ndata: Goodbye world!');
+});
+
 // Views
 
 app.get('/', (req, res) => {
@@ -193,11 +201,6 @@ app.all('/tests/*', (req, res) => {
       query: '?' + querystring.encode(req.query)
     });
   }
-});
-
-app.get('/eventstream', (req, res) => {
-  res.header("Content-Type", "text/event-stream");
-  res.send('event: ping\ndata: Hello world!\ndata: {"foo": "bar"}\ndata: Goodbye world!');
 });
 
 // Page Not Found Handler

--- a/custom-tests.json
+++ b/custom-tests.json
@@ -201,7 +201,7 @@
       "__base": "try {var instance = new Event('Event');} catch(e) {var instance = Event.createEvent('Event');}"
     },
     "EventSource": {
-      "__base": "var instance = new EventSource('/');"
+      "__base": "var instance = new EventSource('/eventstream');"
     },
     "EXT_blend_minmax": {
       "__resources": ["webGL"],


### PR DESCRIPTION
Though not required as the tests will run regardless, this PR adds a `text/event-stream` resource that is loaded by `api.EventSource`, which gets rid of the annoying "wrong content type" errors.