### PR TITLE
Use git commit hash as version in dev/staging

### DIFF
--- a/app.js
+++ b/app.js
@@ -29,7 +29,7 @@ const {parseUA} = require('./ua-parser');
 
 const appversion = process.env.GAE_VERSION === 'production' ?
   require('./package.json').version :
-  'Dev ' + require('child_process').execSync('git rev-parse HEAD').toString()
+  require('child_process').execSync('git rev-parse HEAD').toString()
       .trim().substr(0, 7);
 
 const PORT = process.env.PORT || 8080;
@@ -79,7 +79,12 @@ const catchError = (err, res, method) => {
 };
 
 const createReport = (results, req) => {
-  return {__version: appversion, results, userAgent: req.get('User-Agent')};
+  return {
+    __dev: process.env.GAE_VERSION !== 'production',
+    __version: appversion,
+    results,
+    userAgent: req.get('User-Agent')
+  };
 };
 
 const app = express();

--- a/app.js
+++ b/app.js
@@ -27,7 +27,10 @@ const logger = require('./logger');
 const storage = require('./storage').getStorage();
 const {parseUA} = require('./ua-parser');
 
-const appversion = require('./package.json').version + (process.env.GAE_VERSION != 'production' ? ' Dev' : '');
+const appversion = process.env.GAE_VERSION === 'production' ?
+  require('./package.json').version :
+  'Dev ' + require('child_process').execSync('git rev-parse HEAD').toString()
+      .trim().substr(0, 7);
 
 const PORT = process.env.PORT || 8080;
 

--- a/github.js
+++ b/github.js
@@ -32,7 +32,7 @@ const github = (options) => {
     const digest = hash.update(buffer).digest('hex').substr(0, 10);
 
     const version = report.__version;
-    const dev = version.includes('Dev');
+    const dev = report.__dev;
     const ua = uaParser(report.userAgent);
     const browser = `${ua.browser.name} ${ua.browser.version}`;
     const os = `${ua.os.name} ${ua.os.version}`;

--- a/unittest/app/app.js
+++ b/unittest/app/app.js
@@ -47,6 +47,7 @@ describe('/api/results', () => {
     const res = await agent.get('/api/results');
     assert.equal(res.status, 200);
     assert.deepEqual(res.body, {
+      __dev: true,
       __version: version,
       results: {},
       userAgent: userAgent
@@ -68,6 +69,7 @@ describe('/api/results', () => {
     const res = await agent.get('/api/results');
     assert.equal(res.status, 200);
     assert.deepEqual(res.body, {
+      __dev: true,
       __version: version,
       results: {[testURL]: {x: 1}},
       userAgent: userAgent
@@ -85,6 +87,7 @@ describe('/api/results', () => {
     const res = await agent.get('/api/results');
     assert.equal(res.status, 200);
     assert.deepEqual(res.body, {
+      __dev: true,
       __version: version,
       results: {[testURL]: {x: 2}},
       userAgent: userAgent
@@ -103,6 +106,7 @@ describe('/api/results', () => {
     const res = await agent.get('/api/results');
     assert.equal(res.status, 200);
     assert.deepEqual(res.body, {
+      __dev: true,
       __version: version,
       results: {[testURL]: {x: 2}, [testURL2]: {y: 3}},
       userAgent: userAgent


### PR DESCRIPTION
This PR configures the appversion to be the trimmed hash of the git HEAD﻿when running in dev or staging builds.
