### PR TITLE
Upgrade Selenium to auto-hide results

### DIFF
--- a/app.js
+++ b/app.js
@@ -114,7 +114,7 @@ app.use((req, res, next) => {
 app.post('/api/get', (req, res) => {
   const testSelection = (req.body.testSelection || '').replace(/\./g, '/');
   const queryParams = {
-    ...(req.body.hideResults && {hideResults: req.body.hideResults}),
+    ...(req.body.selenium && {selenium: req.body.selenium}),
     ...(req.body.limitExposure && {exposure: req.body.limitExposure})
   };
   const query = querystring.encode(queryParams);
@@ -187,7 +187,8 @@ app.get('/eventstream', (req, res) => {
 
 app.get('/', (req, res) => {
   res.render('index', {
-    tests: tests.listEndpoints('/tests')
+    tests: tests.listEndpoints('/tests'),
+    selenium: req.query.selenium
   });
 });
 
@@ -205,7 +206,7 @@ app.all('/tests/*', (req, res) => {
     res.render('tests', {
       title: `${ident || 'All Tests'}`,
       tests: foundTests,
-      hideResults: req.query.hideResults,
+      selenium: req.query.selenium,
       ignore: (req.query.ignore ? req.query.ignore.split(',') : [])
     });
   } else {

--- a/selenium.js
+++ b/selenium.js
@@ -252,12 +252,11 @@ const run = async (browser, version, os, showlogs) => {
 
   try {
     log('Loading homepage...');
-    await goToPage(driver, browser, version, host);
-    await driver.executeScript(`document.getElementById('hide-results').click()`);
+    await goToPage(driver, browser, version, `${host}/?selenium=true`);
     await click(driver, browser, 'start');
 
     log('Running tests...');
-    await awaitPage(driver, browser, version, `${host}/tests/?hideResults=on`);
+    await awaitPage(driver, browser, version, `${host}/tests/?selenium=true`);
 
     await driver.wait(until.elementLocated(By.id('status')), 5000);
     statusEl = await driver.findElement(By.id('status'));
@@ -302,10 +301,8 @@ const run = async (browser, version, os, showlogs) => {
       statusEl = await driver.findElement(By.id('status'));
       await driver.wait(until.elementTextContains(statusEl, 'to'));
 
-      if (!testenv) {
-        if ((await statusEl.getText()).search('Failed') !== -1) {
-          throw new Error('Pull request failed to submit');
-        }
+      if ((await statusEl.getText()).search('Failed') !== -1) {
+        throw new Error('Pull request failed to submit');
       }
 
       warn('Exported to GitHub');

--- a/static/resources/style.css
+++ b/static/resources/style.css
@@ -175,10 +175,6 @@ hr {
   width: 70%;
 }
 
-#hide-results {
-  display: none;
-}
-
 #supported-browsers {
   margin-top: 2em;
   padding-top: 0.5em;

--- a/unittest/app/app.js
+++ b/unittest/app/app.js
@@ -166,14 +166,14 @@ describe('/api/get', () => {
 
   it('get specific test, hide results', async () => {
     const res = await agent.post('/api/get')
-        .send({testSelection: 'api.AbortController.signal', limitExposure: '', hideResults: true});
-    expect(res).to.redirectTo(/\/tests\/api\/AbortController\/signal\?hideResults=true$/);
+        .send({testSelection: 'api.AbortController.signal', limitExposure: '', selenium: true});
+    expect(res).to.redirectTo(/\/tests\/api\/AbortController\/signal\?selenium=true$/);
   });
 
   it('get specific test, limit exposure and hide results', async () => {
     const res = await agent.post('/api/get')
-        .send({testSelection: 'api.AbortController.signal', limitExposure: 'Window', hideResults: true});
-    expect(res).to.redirectTo(/\/tests\/api\/AbortController\/signal\?hideResults=true&exposure=Window$/);
+        .send({testSelection: 'api.AbortController.signal', limitExposure: 'Window', selenium: true});
+    expect(res).to.redirectTo(/\/tests\/api\/AbortController\/signal\?selenium=true&exposure=Window$/);
   });
 });
 

--- a/views/index.ejs
+++ b/views/index.ejs
@@ -25,7 +25,9 @@
         <option value="ServiceWorker">Service Worker</option>
       </select>
     </div>
-    <input id="hide-results" name="hideResults" type="checkbox" />
+    <% if (selenium) { %>
+      <input id="selenium" name="selenium" type="hidden" value="true" />
+    <% } %>
   </form>
 </div>
 

--- a/views/tests.ejs
+++ b/views/tests.ejs
@@ -40,6 +40,6 @@
     <% } %>
   <% }); %>
   window.onload = function() {
-    bcd.go(undefined, <%-resourceCount%>, <%- !!hideResults %>)
+    bcd.go(undefined, <%-resourceCount%>, <%- !!selenium %>)
   };
 </script>


### PR DESCRIPTION
This PR replaces the hidden `hide-results` checkbox with a `hidden` input that is added when `?selenium=true` is present on loading the homepage.﻿
