### PR TITLE
Use "Dev" as version on local/staging versions

### DIFF
--- a/app.js
+++ b/app.js
@@ -76,12 +76,7 @@ const catchError = (err, res, method) => {
 };
 
 const createReport = (results, req) => {
-  return {
-    __dev: process.env.GAE_VERSION !== 'production',
-    __version: appversion,
-    results,
-    userAgent: req.get('User-Agent')
-  };
+  return {__version: appversion, results, userAgent: req.get('User-Agent')};
 };
 
 const app = express();

--- a/app.js
+++ b/app.js
@@ -29,12 +29,7 @@ const {parseUA} = require('./ua-parser');
 
 const PORT = process.env.PORT || 8080;
 
-/* istanbul ignore next */
-// const appversion = process.env.GAE_VERSION === 'production' ?
-//   require('./package.json').version :
-//   require('child_process').execSync('git rev-parse HEAD').toString()
-//       .trim().substr(0, 7);
-const appversion = require('./package.json').version;
+const appversion = process.env.GAE_VERSION === 'production' ? require('./package.json').version : 'Dev';
 
 /* istanbul ignore next */
 const secrets = process.env.NODE_ENV === 'test' ?

--- a/github.js
+++ b/github.js
@@ -32,27 +32,25 @@ const github = (options) => {
     const digest = hash.update(buffer).digest('hex').substr(0, 10);
 
     const version = report.__version;
-    const dev = report.__dev;
     const ua = uaParser(report.userAgent);
     const browser = `${ua.browser.name} ${ua.browser.version}`;
     const os = `${ua.os.name} ${ua.os.version}`;
     const desc = `${browser} / ${os}`;
     const title = `Results from ${desc} / Collector v${version}`;
 
-    const slug = `${version}-${slugify(desc, {lower: true})}-${digest}`;
+    const slug = `${version.toLowerCase()}-${slugify(desc, {lower: true})}-${digest}`;
     const filename = `${slug}.json`;
     const branch = `collector/${slug}`;
 
     return {
-      json, buffer, digest, dev, ua, browser,
-      os, desc, title, slug, filename, branch
+      json, buffer, digest, ua, browser, os, desc, title, slug, filename, branch
     };
   };
 
   const createBody = (meta) => {
     return `User Agent: ${meta.ua.ua}\nBrowser: ${meta.browser} (on ${meta.os})` +
             `\nHash Digest: ${meta.digest}\n` +
-            (meta.dev ? '\n**WARNING:** this PR was created from a development/staging version!' : '');
+            (meta.version == 'Dev' ? '\n**WARNING:** this PR was created from a development/staging version!' : '');
   };
 
   const exportAsPR = async (report) => {

--- a/unittest/app/app.js
+++ b/unittest/app/app.js
@@ -47,7 +47,6 @@ describe('/api/results', () => {
     const res = await agent.get('/api/results');
     assert.equal(res.status, 200);
     assert.deepEqual(res.body, {
-      __dev: true,
       __version: version,
       results: {},
       userAgent: userAgent
@@ -74,7 +73,6 @@ describe('/api/results', () => {
     const res = await agent.get('/api/results');
     assert.equal(res.status, 200);
     assert.deepEqual(res.body, {
-      __dev: true,
       __version: version,
       results: {[testURL]: {x: 1}},
       userAgent: userAgent
@@ -92,7 +90,6 @@ describe('/api/results', () => {
     const res = await agent.get('/api/results');
     assert.equal(res.status, 200);
     assert.deepEqual(res.body, {
-      __dev: true,
       __version: version,
       results: {[testURL]: {x: 2}},
       userAgent: userAgent
@@ -111,7 +108,6 @@ describe('/api/results', () => {
     const res = await agent.get('/api/results');
     assert.equal(res.status, 200);
     assert.deepEqual(res.body, {
-      __dev: true,
       __version: version,
       results: {[testURL]: {x: 2}, [testURL2]: {y: 3}},
       userAgent: userAgent

--- a/unittest/unit/github.js
+++ b/unittest/unit/github.js
@@ -23,28 +23,24 @@ const {Octokit} = require('@octokit/rest');
 const REPORTS = [
   {
     report: {
-      __dev: false,
       __version: '1.2.3',
       results: {},
       userAgent: 'Mozilla/5.0 (Macintosh; Intel Mac OS X 10_14) AppleWebKit/605.1.15 (KHTML, like Gecko) Version/12.0 Safari/605.1.15'
     },
     expected: {
-      slug: '1.2.3-safari-12.0-mac-os-10.14-95b1ec9f25',
-      sha: '753c6ed8e991e9729353a63d650ff0f5bd902b69',
+      slug: '1.2.3-safari-12.0-mac-os-10.14-0aed9f1f74',
       title: 'Results from Safari 12.0 / Mac OS 10.14 / Collector v1.2.3'
     }
   },
   {
     report: {
-      __dev: true,
-      __version: 'abcdef0',
+      __version: 'Dev',
       results: {},
       userAgent: 'Mozilla/5.0 (Macintosh; Intel Mac OS X 11_0_0) AppleWebKit/537.36 (KHTML, like Gecko) Chrome/86.0.4240.198 Safari/537.36'
     },
     expected: {
-      slug: 'abcdef0-chrome-86.0.4240.198-mac-os-11.0.0-ca3393fa01',
-      sha: '753c6ed8e991e9729353a63d650ff0f5bd902b69',
-      title: 'Results from Chrome 86.0.4240.198 / Mac OS 11.0.0 / Collector vabcdef0'
+      slug: 'dev-chrome-86.0.4240.198-mac-os-11.0.0-4c53c96588',
+      title: 'Results from Chrome 86.0.4240.198 / Mac OS 11.0.0 / Collector vDev'
     }
   }
 ];
@@ -90,7 +86,7 @@ describe('GitHub export', () => {
           owner: 'foolip',
           ref: `refs/heads/collector/${expected.slug}`,
           repo: 'mdn-bcd-results',
-          sha: expected.sha
+          sha: '753c6ed8e991e9729353a63d650ff0f5bd902b69'
         });
 
         mock.repos.expects('createOrUpdateFileContents')


### PR DESCRIPTION
Looks like we can't get the git commit hash on staging, so this simply uses "Dev" as the version.﻿
