### PR TITLE
Remove redundant timestamp in Selenium script's log() function

### DIFF
--- a/selenium.js
+++ b/selenium.js
@@ -52,7 +52,8 @@ const prettyName = (browser, version, os) => {
 const log = (task, message) => {
   // TODO temporary until https://github.com/SamVerschueren/listr/issues/150 fixed
   task.output = task.output = task.title + ' - ' + message;
-  
+
+  // eslint-disable-next-line max-len
   // task.output = new Date(Date.now()).toLocaleTimeString(undefined, {hour12: false}) + ': ' + message;
 };
 

--- a/selenium.js
+++ b/selenium.js
@@ -50,8 +50,10 @@ const prettyName = (browser, version, os) => {
 };
 
 const log = (task, message) => {
-  task.output = task.title + ' - ' + new Date(Date.now()).toLocaleTimeString(undefined, {hour12: false}) +
-      ': ' + message;
+  // TODO temporary until https://github.com/SamVerschueren/listr/issues/150 fixed
+  task.output = task.output = task.title + ' - ' + message;
+  
+  // task.output = new Date(Date.now()).toLocaleTimeString(undefined, {hour12: false}) + ': ' + message;
 };
 
 const filterVersions = (data, earliestVersion) => {


### PR DESCRIPTION
Turns out that the verbose logger being temporarily used already has timestamps!