### PR TITLE
Simplify order of browsers to test in Selenium script

### DIFF
--- a/selenium.js
+++ b/selenium.js
@@ -66,7 +66,7 @@ const filterVersions = (data, earliestVersion) => {
     }
   }
 
-  return versions.sort((a, b) => (a - b));
+  return versions.sort((a, b) => (b - a));
 };
 
 const getSafariOS = (version) => {
@@ -334,7 +334,7 @@ const runAll = async (limitBrowsers, oses) => {
   for (const browser in browsersToTest) {
     const browsertasks = [];
 
-    for (const version of browsersToTest[browser].reverse()) {
+    for (const version of browsersToTest[browser]) {
       for (const os of oses) {
         if (os === 'macOS' && ['edge', 'ie'].includes(browser) && version <= 18) {
           // Don't test Internet Explorer / EdgeHTML on macOS


### PR DESCRIPTION
This PR simplifies the order of the browser versions in the Selenium script, by removing the use of .reverse() and simply sorting in the intended direction.