### PR TITLE
Improve error when a report has no results

### DIFF
--- a/unittest/unit/update-bcd.js
+++ b/unittest/unit/update-bcd.js
@@ -451,8 +451,8 @@ describe('BCD updater', () => {
 
     it('no results', () => {
       assert.throws(() => {
-        getSupportMap({results: {}});
-      }, Error, 'No results!');
+        getSupportMap({results: {}, userAgent: 'abc/1.2.3-beta'});
+      }, Error, 'Report for "abc/1.2.3-beta" has no results!');
     });
   });
 

--- a/update-bcd.js
+++ b/update-bcd.js
@@ -36,7 +36,7 @@ const getSupportMap = (report) => {
   }
 
   if (testMap.size === 0) {
-    throw new Error('No results!');
+    throw new Error(`Report for "${report.userAgent}" has no results!`);
   }
 
   // Transform `testMap` to map from test name (BCD path) to flattened support.


### PR DESCRIPTION
This PR improves the error thrown when a report has no results, including the user agent so that we can narrow down which report is the problematic report.