### PR TITLE
UA parser: more lenient version matching on last version

### DIFF
--- a/ua-parser.js
+++ b/ua-parser.js
@@ -51,22 +51,21 @@ const parseUA = (userAgent, browsers) => {
   // with this, find the pair of versions in |versions| that sandwiches
   // |version|, and use the first of this pair. For example, given |version|
   // "10.1" and |versions| entries "10.0" and "10.2", return "10.0".
-  for (let i = 0; i < versions.length; i++) {
+  for (let i = 0; i < versions.length - 1; i++) {
     const current = versions[i];
     const next = versions[i + 1];
-    if (next) {
-      if (compareVersions.compare(version, current, '>=') &&
-          compareVersions.compare(version, next, '<')) {
-        return {browser, version: current, inBcd: true};
-      }
-    } else {
-      // This is the last entry in |versions|. With no |next| to compare against
-      // we have to match the version more conservatively, requiring major and
-      // minor versions to match. "10.0" and "10" are seen as equivalent.
-      if (getMajorMinorVersion(version) === getMajorMinorVersion(current)) {
-        return {browser, version: current, inBcd: true};
-      }
+    if (compareVersions.compare(version, current, '>=') &&
+        compareVersions.compare(version, next, '<')) {
+      return {browser, version: current, inBcd: true};
     }
+  }
+
+  // This is the last entry in |versions|. With no |next| to compare against
+  // we have to check that the major versions match. Given |version| "10.3"
+  // and |versions| entries "10.0" and "10.2", return "10.2". Given |version|
+  // "11.0", skip.
+  if (version.split('.')[0] === versions[versions.length-1].split('.')[0]) {
+    return {browser, version: current, inBcd: true};
   }
 
   return {browser, version, inBcd: false};

--- a/ua-parser.js
+++ b/ua-parser.js
@@ -65,7 +65,7 @@ const parseUA = (userAgent, browsers) => {
   // and |versions| entries "10.0" and "10.2", return "10.2". Given |version|
   // "11.0", skip.
   if (version.split('.')[0] === versions[versions.length-1].split('.')[0]) {
-    return {browser, version: current, inBcd: true};
+    return {browser, version: versions[versions.length-1], inBcd: true};
   }
 
   return {browser, version, inBcd: false};

--- a/unittest/unit/ua-parser.js
+++ b/unittest/unit/ua-parser.js
@@ -78,8 +78,12 @@ describe('parseUA', () => {
     assert.deepEqual(parseUA('Mozilla/5.0 (Macintosh; Intel Mac OS X 10_15_6) AppleWebKit/605.1.15 (KHTML, like Gecko) Version/14.0 Safari/605.1.15', browsers), {browser: {id: 'safari', name: 'Safari'}, version: '14', inBcd: true});
   });
 
-  it('Safari 14.1 (not in BCD)', () => {
-    assert.deepEqual(parseUA('Mozilla/5.0 (Macintosh; Intel Mac OS X 10_15_6) AppleWebKit/605.1.15 (KHTML, like Gecko) Version/14.1 Safari/605.1.15', browsers), {browser: {id: 'safari', name: 'Safari'}, version: '14.1', inBcd: false});
+  it('Safari 14.1 (read as Safari 14)', () => {
+    assert.deepEqual(parseUA('Mozilla/5.0 (Macintosh; Intel Mac OS X 10_15_6) AppleWebKit/605.1.15 (KHTML, like Gecko) Version/14.1 Safari/605.1.15', browsers), {browser: {id: 'safari', name: 'Safari'}, version: '14', inBcd: true});
+  });
+
+  it('Safari 15 (not in BCD)', () => {
+    assert.deepEqual(parseUA('Mozilla/5.0 (Macintosh; Intel Mac OS X 10_15_6) AppleWebKit/605.1.15 (KHTML, like Gecko) Version/15.0 Safari/605.1.15', browsers), {browser: {id: 'safari', name: 'Safari'}, version: '15.0', inBcd: false});
   });
 
   it('Safari iOS', () => {


### PR DESCRIPTION
This PR makes the UA parser a little more lenient on the last version iteration.  Rather than comparing both major and minor versions, this only compares the major version.  (ex. if we have `["13", "13.3", "14"]`, and our version is `14.2`, return `14`)

Fixes #774.
