### PR TITLE
Improve performance for harness.js

### DIFF
--- a/static/resources/harness.js
+++ b/static/resources/harness.js
@@ -332,7 +332,7 @@
       }
 
       if (myWorker) {
-        setCurrentExposure('Shared Worker');
+        setCurrentExposure('SharedWorker');
 
         myWorker.port.onmessage = function(event) {
           callback(results.concat(JSON.parse(event.data)));
@@ -379,7 +379,7 @@
           }).then(function(reg) {
             return window.__waitForSWState(reg, 'activated');
           }).then(navigator.serviceWorker.ready).then(function(reg) {
-            setCurrentExposure('Service Worker');
+            setCurrentExposure('ServiceWorker');
 
             var messageChannel = new MessageChannel();
 
@@ -431,11 +431,26 @@
       }, 20000);
 
       runWindow(function(results) {
+        if (state.completed || state.currentExposure !== 'Window') {
+          consoleError('Warning: Tests for Window exposure were completed multiple times!');
+          return;
+        }
+
         runWorker(function(results) {
+          if (state.completed || state.currentExposure !== 'Worker') {
+            consoleError('Warning: Tests for Worker exposure were completed multiple times!');
+            return;
+          }
+
           runSharedWorker(function(results) {
+            if (state.completed || state.currentExposure !== 'SharedWorker') {
+              consoleError('Warning: Tests for SharedWorker exposure were completed multiple times!');
+              return;
+            }
+
             runServiceWorker(function(results) {
               if (state.completed) {
-                consoleError('Warning: tests have been completed multiple times!');
+                consoleError('Warning: Tests for ServiceWorker exposure were completed multiple times!');
                 return;
               }
 

--- a/static/resources/harness.js
+++ b/static/resources/harness.js
@@ -260,8 +260,9 @@
   }
 
   function runWindow(callback) {
+    setCurrentExposure('Window');
+    
     if (pending.Window) {
-      setCurrentExposure('Window');
       runTests(pending.Window, callback);
     } else {
       callback([]);
@@ -269,6 +270,8 @@
   }
 
   function runWorker(callback) {
+    setCurrentExposure('Worker');
+
     if (pending.Worker) {
       var myWorker = null;
 
@@ -281,8 +284,6 @@
       }
 
       if (myWorker) {
-        setCurrentExposure('Worker');
-
         myWorker.onmessage = function(event) {
           callback(JSON.parse(event.data));
         };
@@ -321,6 +322,8 @@
   }
 
   function runSharedWorker(callback) {
+    setCurrentExposure('SharedWorker');
+
     if (pending.SharedWorker) {
       var myWorker = null;
 
@@ -333,8 +336,6 @@
       }
 
       if (myWorker) {
-        setCurrentExposure('SharedWorker');
-
         myWorker.port.onmessage = function(event) {
           callback(JSON.parse(event.data));
         };
@@ -373,6 +374,8 @@
   }
 
   function runServiceWorker(callback) {
+    setCurrentExposure('ServiceWorker');
+
     if (pending.ServiceWorker) {
       if ('serviceWorker' in navigator) {
         window.__workerCleanup().then(function() {
@@ -381,8 +384,6 @@
           }).then(function(reg) {
             return window.__waitForSWState(reg, 'activated');
           }).then(navigator.serviceWorker.ready).then(function(reg) {
-            setCurrentExposure('ServiceWorker');
-
             var messageChannel = new MessageChannel();
 
             messageChannel.port1.onmessage = function(event) {

--- a/static/resources/harness.js
+++ b/static/resources/harness.js
@@ -29,6 +29,7 @@
   };
   var state = {
     started: false,
+    currentExposure: "",
     completed: false
   };
   var reusableInstances = {};
@@ -77,6 +78,11 @@
     }
 
     consoleLog(statusElement.innerHTML.replace(/<br>/g, '\n'));
+  }
+
+  function setCurrentExposure(exposure) {
+    state.currentExposure = exposure;
+    updateStatus("Running tests for " + exposure + "...");
   }
 
   function addInstance(name, code) {
@@ -252,6 +258,7 @@
 
   function runWindow(callback, results) {
     if (pending.Window) {
+      setCurrentExposure("Window");
       runTests(pending.Window, callback);
     } else {
       callback(results);
@@ -271,6 +278,8 @@
       }
 
       if (myWorker) {
+        setCurrentExposure("Worker");
+
         myWorker.onmessage = function(event) {
           callback(results.concat(JSON.parse(event.data)));
         };
@@ -320,6 +329,8 @@
       }
 
       if (myWorker) {
+        setCurrentExposure("Shared Worker");
+
         myWorker.port.onmessage = function(event) {
           callback(results.concat(JSON.parse(event.data)));
         };
@@ -365,6 +376,8 @@
           }).then(function(reg) {
             return window.__waitForSWState(reg, 'activated');
           }).then(navigator.serviceWorker.ready).then(function(reg) {
+            setCurrentExposure("Service Worker");
+
             var messageChannel = new MessageChannel();
 
             messageChannel.port1.onmessage = function(event) {

--- a/static/resources/harness.js
+++ b/static/resources/harness.js
@@ -419,7 +419,13 @@
         runWorker(function(results) {
           runSharedWorker(function(results) {
             runServiceWorker(function(results) {
+              if (state.completed) {
+                consoleError("Warning: tests have been completed multiple times!");
+                return;
+              }
+
               pending = {};
+              state.completed = true;
 
               if ('serviceWorker' in navigator) {
                 window.__workerCleanup();

--- a/static/resources/harness.js
+++ b/static/resources/harness.js
@@ -428,7 +428,7 @@
 
       var timeout = setTimeout(function() {
         state.timedout = true;
-      }, 30000);
+      }, 20000);
 
       runWindow(function(results) {
         runWorker(function(results) {

--- a/static/resources/harness.js
+++ b/static/resources/harness.js
@@ -29,7 +29,7 @@
   };
   var state = {
     started: false,
-    currentExposure: "",
+    currentExposure: '',
     timedout: false,
     completed: false
   };
@@ -73,7 +73,7 @@
     }
 
     if (state.timedout) {
-      statusElement.innerHTML = newStatus + 
+      statusElement.innerHTML = newStatus +
             '<br />This test seems to be taking a long time; ' +
             'it may have crashed. Check the console for errors.';
     } else {
@@ -85,7 +85,7 @@
 
   function setCurrentExposure(exposure) {
     state.currentExposure = exposure;
-    updateStatus("Running tests for " + exposure + "...");
+    updateStatus('Running tests for ' + exposure + '...');
   }
 
   function addInstance(name, code) {
@@ -261,7 +261,7 @@
 
   function runWindow(callback, results) {
     if (pending.Window) {
-      setCurrentExposure("Window");
+      setCurrentExposure('Window');
       runTests(pending.Window, callback);
     } else {
       callback(results);
@@ -281,7 +281,7 @@
       }
 
       if (myWorker) {
-        setCurrentExposure("Worker");
+        setCurrentExposure('Worker');
 
         myWorker.onmessage = function(event) {
           callback(results.concat(JSON.parse(event.data)));
@@ -332,7 +332,7 @@
       }
 
       if (myWorker) {
-        setCurrentExposure("Shared Worker");
+        setCurrentExposure('Shared Worker');
 
         myWorker.port.onmessage = function(event) {
           callback(results.concat(JSON.parse(event.data)));
@@ -379,7 +379,7 @@
           }).then(function(reg) {
             return window.__waitForSWState(reg, 'activated');
           }).then(navigator.serviceWorker.ready).then(function(reg) {
-            setCurrentExposure("Service Worker");
+            setCurrentExposure('Service Worker');
 
             var messageChannel = new MessageChannel();
 
@@ -435,7 +435,7 @@
           runSharedWorker(function(results) {
             runServiceWorker(function(results) {
               if (state.completed) {
-                consoleError("Warning: tests have been completed multiple times!");
+                consoleError('Warning: tests have been completed multiple times!');
                 return;
               }
 

--- a/static/resources/harness.js
+++ b/static/resources/harness.js
@@ -25,8 +25,11 @@
   var pending = {};
   var resources = {
     required: 0,
-    loaded: 0,
-    testsStarted: false
+    loaded: 0
+  };
+  var state = {
+    started: false,
+    completed: false
   };
   var reusableInstances = {};
 
@@ -405,7 +408,7 @@
 
   function go(callback, resourceCount, hideResults) {
     var startTests = function() {
-      resources.testsStarted = true;
+      state.started = true;
 
       var timeout = setTimeout(function() {
         updateStatus('<br />This test seems to be taking a long time; ' +
@@ -444,7 +447,7 @@
       }, 5000);
 
       var resourceLoaded = function() {
-        if (resources.testsStarted) {
+        if (state.started) {
           // No need to restart the tests
           return;
         }

--- a/static/resources/harness.js
+++ b/static/resources/harness.js
@@ -261,7 +261,7 @@
 
   function runWindow(callback) {
     setCurrentExposure('Window');
-    
+
     if (pending.Window) {
       runTests(pending.Window, callback);
     } else {


### PR DESCRIPTION
This PR performs a number of optimizations, logging increases, and code cleanups to improve the harness.js script.

- Use a "state" variable vs. resources.testsStarted
- Catch multiple test completions and error to console
- Add "current exposure" state
- Add state.timedout
- Decrease timeout to 20 seconds (originally 30)
- Catch multiple test completions per exposure scope
- Don't pass the "results" array through all of the test scopes
- Fix exposure setting to always set regardless of test presence
- Lint
