### PR TITLE
Compress results JSON with GZip compression

### DIFF
--- a/github.js
+++ b/github.js
@@ -30,7 +30,7 @@ const github = (options) => {
     /* eslint-disable-next-line max-len */
     // like https://github.com/web-platform-tests/wpt.fyi/blob/26805a0122ea01076ac22c0a96313c1cf5cc30d6/results-processor/wptreport.py#L79
     const hash = crypto.createHash('sha1');
-    const digest = hash.update(buffer).digest('hex').substr(0, 10);
+    const digest = hash.update(Buffer.from(json)).digest('hex').substr(0, 10);
 
     const version = report.__version;
     const ua = uaParser(report.userAgent);

--- a/github.js
+++ b/github.js
@@ -19,13 +19,14 @@ const {Octokit} = require('@octokit/rest');
 const slugify = require('slugify');
 const uaParser = require('ua-parser-js');
 const stringify = require('json-stable-stringify');
+const zlib = require('zlib');
 
 const github = (options) => {
   const octokit = new Octokit(options);
 
   const getReportMeta = (report) => {
     const json = stringify(report, {space: 2}) + '\n';
-    const buffer = Buffer.from(json);
+    const buffer = zlib.gzipSync(json);
     /* eslint-disable-next-line max-len */
     // like https://github.com/web-platform-tests/wpt.fyi/blob/26805a0122ea01076ac22c0a96313c1cf5cc30d6/results-processor/wptreport.py#L79
     const hash = crypto.createHash('sha1');
@@ -39,7 +40,7 @@ const github = (options) => {
     const title = `Results from ${desc} / Collector v${version}`;
 
     const slug = `${version.toLowerCase()}-${slugify(desc, {lower: true})}-${digest}`;
-    const filename = `${slug}.json`;
+    const filename = `${slug}.json.gz`;
     const branch = `collector/${slug}`;
 
     return {

--- a/selenium.js
+++ b/selenium.js
@@ -285,10 +285,8 @@ const run = async (browser, version, os, ctx, task) => {
 
       if (!ctx.testenv) {
         const report = JSON.parse(reportString);
-        const {filename} = github.getReportMeta(report);
-        await fs.writeJson(
-            path.join(resultsDir, filename), report, {spaces: 2}
-        );
+        const {filename, buffer} = github.getReportMeta(report);
+        await fs.writeFile(path.join(resultsDir, filename), buffer);
       }
     } catch (e) {
       // If we can't download the results, fallback to GitHub

--- a/unittest/unit/github.js
+++ b/unittest/unit/github.js
@@ -28,7 +28,7 @@ const REPORTS = [
       userAgent: 'Mozilla/5.0 (Macintosh; Intel Mac OS X 10_14) AppleWebKit/605.1.15 (KHTML, like Gecko) Version/12.0 Safari/605.1.15'
     },
     expected: {
-      slug: '1.2.3-safari-12.0-mac-os-10.14-8fbee54a20',
+      slug: '1.2.3-safari-12.0-mac-os-10.14-0aed9f1f74',
       title: 'Results from Safari 12.0 / Mac OS 10.14 / Collector v1.2.3'
     }
   },
@@ -39,7 +39,7 @@ const REPORTS = [
       userAgent: 'Mozilla/5.0 (Macintosh; Intel Mac OS X 11_0_0) AppleWebKit/537.36 (KHTML, like Gecko) Chrome/86.0.4240.198 Safari/537.36'
     },
     expected: {
-      slug: 'dev-chrome-86.0.4240.198-mac-os-11.0.0-ece7bd2b1b',
+      slug: 'dev-chrome-86.0.4240.198-mac-os-11.0.0-4c53c96588',
       title: 'Results from Chrome 86.0.4240.198 / Mac OS 11.0.0 / Collector vDev'
     }
   }

--- a/unittest/unit/github.js
+++ b/unittest/unit/github.js
@@ -28,7 +28,7 @@ const REPORTS = [
       userAgent: 'Mozilla/5.0 (Macintosh; Intel Mac OS X 10_14) AppleWebKit/605.1.15 (KHTML, like Gecko) Version/12.0 Safari/605.1.15'
     },
     expected: {
-      slug: '1.2.3-safari-12.0-mac-os-10.14-0aed9f1f74',
+      slug: '1.2.3-safari-12.0-mac-os-10.14-8fbee54a20',
       title: 'Results from Safari 12.0 / Mac OS 10.14 / Collector v1.2.3'
     }
   },
@@ -39,7 +39,7 @@ const REPORTS = [
       userAgent: 'Mozilla/5.0 (Macintosh; Intel Mac OS X 11_0_0) AppleWebKit/537.36 (KHTML, like Gecko) Chrome/86.0.4240.198 Safari/537.36'
     },
     expected: {
-      slug: 'dev-chrome-86.0.4240.198-mac-os-11.0.0-4c53c96588',
+      slug: 'dev-chrome-86.0.4240.198-mac-os-11.0.0-ece7bd2b1b',
       title: 'Results from Chrome 86.0.4240.198 / Mac OS 11.0.0 / Collector vDev'
     }
   }
@@ -93,7 +93,7 @@ describe('GitHub export', () => {
             .once().withArgs(sinon.match({
               owner: 'foolip',
               repo: 'mdn-bcd-results',
-              path: `${expected.slug}.json`,
+              path: `${expected.slug}.json.gz`,
               message: expected.title,
               content: sinon.match.string,
               branch: `collector/${expected.slug}`


### PR DESCRIPTION
This PR fixes #790.  To reduce file size, this uses GZip compression for the results JSON when saving them.  There are practically no performance drawbacks as a result.