### PR TITLE
Compact report JSON

### DIFF
--- a/github.js
+++ b/github.js
@@ -24,7 +24,7 @@ const github = (options) => {
   const octokit = new Octokit(options);
 
   const getReportMeta = (report) => {
-    const json = stringify(report, {space: 2}) + '\n';
+    const json = stringify(report);
     const buffer = Buffer.from(json);
     /* eslint-disable-next-line max-len */
     // like https://github.com/web-platform-tests/wpt.fyi/blob/26805a0122ea01076ac22c0a96313c1cf5cc30d6/results-processor/wptreport.py#L79

--- a/selenium.js
+++ b/selenium.js
@@ -26,6 +26,7 @@ const fs = require('fs-extra');
 const path = require('path');
 const chalk = require('chalk');
 const Listr = require('listr');
+const stringify = require('json-stable-stringify');
 
 // TODO temporary until https://github.com/SamVerschueren/listr/issues/150 fixed
 const ListrRenderer = require('listr-verbose-renderer');
@@ -286,9 +287,7 @@ const run = async (browser, version, os, ctx, task) => {
       if (!ctx.testenv) {
         const report = JSON.parse(reportString);
         const {filename} = github.getReportMeta(report);
-        await fs.writeJson(
-            path.join(resultsDir, filename), report, {spaces: 2}
-        );
+        await fs.writeFile(path.join(resultsDir, filename), stringify(report));
       }
     } catch (e) {
       // If we can't download the results, fallback to GitHub

--- a/unittest/unit/github.js
+++ b/unittest/unit/github.js
@@ -28,7 +28,7 @@ const REPORTS = [
       userAgent: 'Mozilla/5.0 (Macintosh; Intel Mac OS X 10_14) AppleWebKit/605.1.15 (KHTML, like Gecko) Version/12.0 Safari/605.1.15'
     },
     expected: {
-      slug: '1.2.3-safari-12.0-mac-os-10.14-0aed9f1f74',
+      slug: '1.2.3-safari-12.0-mac-os-10.14-cadc34e83f',
       title: 'Results from Safari 12.0 / Mac OS 10.14 / Collector v1.2.3'
     }
   },
@@ -39,7 +39,7 @@ const REPORTS = [
       userAgent: 'Mozilla/5.0 (Macintosh; Intel Mac OS X 11_0_0) AppleWebKit/537.36 (KHTML, like Gecko) Chrome/86.0.4240.198 Safari/537.36'
     },
     expected: {
-      slug: 'dev-chrome-86.0.4240.198-mac-os-11.0.0-4c53c96588',
+      slug: 'dev-chrome-86.0.4240.198-mac-os-11.0.0-31072b9b56',
       title: 'Results from Chrome 86.0.4240.198 / Mac OS 11.0.0 / Collector vDev'
     }
   }


### PR DESCRIPTION
This PR shrinks the JSON reports into compact versions without whitespace.  Since the files are meant to be read by machine, there's not really much reason to beautify the JSON.  (We can beautify as needed.)﻿
