### PR TITLE
Add "max-parallel: 1" to deploy step in push

### DIFF
--- a/.github/workflows/push.yml
+++ b/.github/workflows/push.yml
@@ -20,6 +20,8 @@ jobs:
     name: Deploy
     needs: test
     runs-on: ubuntu-latest
+    strategy:
+      max-parallel: 1
     steps:
     - uses: MontyD/package-json-updated-action@1.0.1
       id: version-updated


### PR DESCRIPTION
This should prevent failing deploy steps due to multiple pushes within five minutes.