### PR TITLE
Update BCD: improve ranges

### DIFF
--- a/unittest/unit/update-bcd.js
+++ b/unittest/unit/update-bcd.js
@@ -562,10 +562,10 @@ describe('BCD updater', () => {
   describe('inferSupportStatements', () => {
     const expectedResults = {
       'api.AbortController': [
-        {version_added: '≤83'}
+        {version_added: '0> ≤83'}
       ],
       'api.AbortController.abort': [
-        {version_added: '≤84'}
+        {version_added: '0> ≤84'}
       ],
       'api.AbortController.AbortController': [
         {version_added: '85'}
@@ -577,24 +577,24 @@ describe('BCD updater', () => {
         {version_added: '85'}
       ],
       'api.DeprecatedInterface': [
-        {version_added: '≤83', version_removed: '85'}
+        {version_added: '0> ≤83', version_removed: '85'}
       ],
       'api.ExperimentalInterface': [
-        {version_added: '≤83'}
+        {version_added: '0> ≤83'}
       ],
       'api.NewInterfaceNotInBCD': [
         {version_added: '85'}
       ],
       'api.NullAPI': [],
       'api.PrefixedInterface1': [
-        {version_added: '≤83'}
+        {version_added: '0> ≤83'}
       ],
       'api.PrefixedInterface2': [
-        {prefix: 'WebKit', version_added: '≤83'},
+        {prefix: 'WebKit', version_added: '0> ≤83'},
         {version_added: '85'}
       ],
       'api.RemovedInterface': [
-        {version_added: '≤83', version_removed: '84'},
+        {version_added: '0> ≤83', version_removed: '84'},
         {version_added: '85'}
       ],
       'css.properties.font-family': [

--- a/update-bcd.js
+++ b/update-bcd.js
@@ -240,7 +240,10 @@ const update = (bcd, supportMatrix) => {
         // alternative name, but in any case implies that the main feature
         // is not supported. So only update in case new data contradicts that.
         if (inferredStatements.some((statement) => statement.version_added)) {
-          supportStatement.unshift(...inferredStatements);
+          supportStatement.unshift(...inferredStatements.map((item) => {
+            item.version_added = typeof(item.version_added) === 'string' ? item.version_added.replace('0> ', '') : item.version_added;
+            return item;
+          }));
           supportStatement = supportStatement.filter((item, pos, self) => {
             return pos === self.findIndex((el) => deepEqual(el, item));
           });


### PR DESCRIPTION
This PR improves our generated ranges.  A while back, we introduced generating ranges for when we don't know the exact version, however we were only generating one half of a range.  This led to the issue of not updating some inaccurate data, as well as checking the versions in the collector when mirroring.  For example: we generate the range of "≤19" based upon data from Chrome 17 (false), 18 (null), and 19 (true) -- if Chrome is set to "2" in BCD, however, the updater will ignore it even though we can confirm the data is inaccurate.  Now, this generates ranges such as "17> ≤19" (whilst still generating ranges like "≤4" if we don't have results for all the prior versions since the first browser release), so that we can catch additional invalid data.