### PR TITLE
Allow for filtering browsers in update-bcd

### DIFF
--- a/unittest/unit/update-bcd.js
+++ b/unittest/unit/update-bcd.js
@@ -20,20 +20,6 @@ const proxyquire = require('proxyquire').noCallThru();
 const sinon = require('sinon');
 
 const logger = require('../../logger');
-const {
-  findEntry,
-  getSupportMap,
-  getSupportMatrix,
-  inferSupportStatements,
-  update
-} = proxyquire('../../update-bcd', {
-  './overrides': [
-    'Test overrides',
-    ['css.properties.font-family', 'safari', '5.1', false, ''],
-    ['css.properties.font-family', 'chrome', '83', false, ''],
-    ['css.properties.font-face', 'chrome', '*', null, '']
-  ]
-});
 
 const bcd = {
   api: {
@@ -113,6 +99,22 @@ const bcd = {
     }
   }
 };
+
+const {
+  findEntry,
+  getSupportMap,
+  getSupportMatrix,
+  inferSupportStatements,
+  update
+} = proxyquire('../../update-bcd', {
+  './overrides': [
+    'Test overrides',
+    ['css.properties.font-family', 'safari', '5.1', false, ''],
+    ['css.properties.font-family', 'chrome', '83', false, ''],
+    ['css.properties.font-face', 'chrome', '*', null, '']
+  ],
+  '../browser-compat-data': bcd
+});
 
 const reports = [
   {
@@ -462,7 +464,7 @@ describe('BCD updater', () => {
     });
 
     it('normal', () => {
-      assert.deepEqual(getSupportMatrix(bcd.browsers, reports), new Map([
+      assert.deepEqual(getSupportMatrix(reports), new Map([
         ['api.AbortController', new Map([['chrome', new Map([
           ['82', {result: null, prefix: ''}],
           ['83', {result: true, prefix: ''}],
@@ -603,7 +605,7 @@ describe('BCD updater', () => {
       'css.properties.font-face': []
     };
 
-    const supportMatrix = getSupportMatrix(bcd.browsers, reports);
+    const supportMatrix = getSupportMatrix(reports);
     for (const [path, browserMap] of supportMatrix.entries()) {
       for (const [_, versionMap] of browserMap.entries()) {
         it(path, () => {
@@ -629,7 +631,7 @@ describe('BCD updater', () => {
           },
           userAgent: 'Mozilla/5.0 (Windows NT 6.1; WOW64) AppleWebKit/537.36 (KHTML, like Gecko) Chrome/83.0.4103.61 Safari/537.36'
         };
-        const versionMap = getSupportMatrix(bcd.browsers, [report])
+        const versionMap = getSupportMatrix([report])
             .entries().next().value[1].entries().next().value[1];
 
         inferSupportStatements(versionMap);
@@ -638,7 +640,7 @@ describe('BCD updater', () => {
   });
 
   describe('update', () => {
-    const supportMatrix = getSupportMatrix(bcd.browsers, reports);
+    const supportMatrix = getSupportMatrix(reports);
     let bcdCopy;
 
     beforeEach(() => {

--- a/update-bcd.js
+++ b/update-bcd.js
@@ -11,7 +11,6 @@ const overrides = require('./overrides').filter(Array.isArray);
 const {parseUA} = require('./ua-parser');
 
 const BCD_DIR = process.env.BCD_DIR || `../browser-compat-data`;
-// This will load and parse parts of BCD twice, but it's simple.
 const {browsers} = require(BCD_DIR);
 
 const findEntry = (bcd, path) => {
@@ -79,7 +78,7 @@ const getSupportMap = (report) => {
 
 // Load all reports and build a map from BCD path to browser + version
 // and test result (null/true/false) for that version.
-const getSupportMatrix = (browsers, reports) => {
+const getSupportMatrix = (reports) => {
   const supportMatrix = new Map;
 
   for (const report of reports) {
@@ -338,7 +337,7 @@ const main = async (reportPaths, categories, limitBrowsers) => {
   );
 
   const reports = Object.values(await loadJsonFiles(reportPaths));
-  const supportMatrix = getSupportMatrix(browsers, reports);
+  const supportMatrix = getSupportMatrix(reports);
 
   // Should match https://github.com/mdn/browser-compat-data/blob/f10bf2cc7d1b001a390e70b7854cab9435ffb443/test/linter/test-style.js#L63
   // TODO: https://github.com/mdn/browser-compat-data/issues/3617


### PR DESCRIPTION
This PR introduces a command line argument that allows for filtering the browsers to modify.