### PR TITLE
Update arguments to find-missing script

### DIFF
--- a/find-missing.js
+++ b/find-missing.js
@@ -38,7 +38,7 @@ const findMissing = (entries, allEntries) => {
 const getMissing = (direction = 'collector-from-bcd', category = []) => {
   const filterCategory = (item) => {
     return !category.length || category.some((cat) => item.startsWith(`${cat}.`));
-  }
+  };
 
   const bcdEntries = [
     ...traverseFeatures(bcd.api, 'api.'),

--- a/find-missing.js
+++ b/find-missing.js
@@ -35,12 +35,16 @@ const findMissing = (entries, allEntries) => {
   return {missingEntries, total: allEntries.length};
 };
 
-const getMissing = (direction = 'collector-from-bcd') => {
+const getMissing = (direction = 'collector-from-bcd', category = []) => {
+  const filterCategory = (item) => {
+    return !category.length || category.some((cat) => item.startsWith(`${cat}.`));
+  }
+
   const bcdEntries = [
     ...traverseFeatures(bcd.api, 'api.'),
     ...traverseFeatures(bcd.css.properties, 'css.properties.')
-  ];
-  const collectorEntries = Object.keys(tests);
+  ].filter(filterCategory);
+  const collectorEntries = Object.keys(tests).filter(filterCategory);
 
   switch (direction) {
     case 'bcd-from-collector':
@@ -67,11 +71,18 @@ const main = () => {
               nargs: 1,
               type: 'string',
               default: 'collector-from-bcd'
+            })
+            .option('category', {
+              alias: 'c',
+              describe: 'The BCD categories to filter',
+              type: 'array',
+              choices: ['api', 'css.properties'],
+              default: ['api', 'css.properties']
             });
       }
   );
 
-  const {missingEntries, total} = getMissing(argv.direction);
+  const {missingEntries, total} = getMissing(argv.direction, argv.category);
   console.log(missingEntries.join('\n'));
   console.log(`\n${missingEntries.length}/${total} (${(missingEntries.length/total*100.0).toFixed(2)}%) missing`);
 };

--- a/find-missing.js
+++ b/find-missing.js
@@ -23,19 +23,19 @@ const traverseFeatures = (obj, identifier) => {
   return features;
 };
 
-const findMissing = (entries1, entries2) => {
+const findMissing = (entries, allEntries) => {
   const missingEntries = [];
 
-  for (const entry of entries1) {
-    if (!entries2.includes(entry)) {
+  for (const entry of allEntries) {
+    if (!entries.includes(entry)) {
       missingEntries.push(entry);
     }
   }
 
-  return {missingEntries, total: entries2.length};
+  return {missingEntries, total: allEntries.length};
 };
 
-const getMissing = (direction = 'collector-to-bcd') => {
+const getMissing = (direction = 'collector-from-bcd') => {
   const bcdEntries = [
     ...traverseFeatures(bcd.api, 'api.'),
     ...traverseFeatures(bcd.css.properties, 'css.properties.')
@@ -43,13 +43,13 @@ const getMissing = (direction = 'collector-to-bcd') => {
   const collectorEntries = Object.keys(tests);
 
   switch (direction) {
-    case 'bcd-to-collector':
-      return findMissing(collectorEntries, bcdEntries);
-    default:
-      console.log(`Direction '${direction}' is unknown; defaulting to collector -> bcd`);
-      // eslint-disable-next-line no-fallthrough
-    case 'collector-to-bcd':
+    case 'bcd-from-collector':
       return findMissing(bcdEntries, collectorEntries);
+    default:
+      console.log(`Direction '${direction}' is unknown; defaulting to collector <- bcd`);
+      // eslint-disable-next-line no-fallthrough
+    case 'collector-from-bcd':
+      return findMissing(collectorEntries, bcdEntries);
   }
 };
 
@@ -62,11 +62,11 @@ const main = () => {
         yargs
             .option('direction', {
               alias: 'd',
-              describe: 'Which direction to find missing entries from ("a-to-b" will check what is in a that is missing from b)',
-              choices: ['bcd-to-collector', 'collector-to-bcd'],
+              describe: 'Which direction to find missing entries from ("a-from-b" will check what is in a that is missing from b)',
+              choices: ['bcd-from-collector', 'collector-from-bcd'],
               nargs: 1,
               type: 'string',
-              default: 'collector-to-bcd'
+              default: 'collector-from-bcd'
             });
       }
   );

--- a/unittest/unit/find-missing.js
+++ b/unittest/unit/find-missing.js
@@ -78,30 +78,38 @@ describe('find-missing', () => {
       sinon.stub(console, 'log');
     });
 
-    it('collector -> bcd', () => {
+    it('collector <- bcd', () => {
       assert.deepEqual(getMissing(), {missingEntries: [
         'api.AbortController.dummy',
         'api.DummyAPI',
         'api.DummyAPI.dummy',
         'css.properties.font-face'
-      ], total: 4});
-    });
-
-    it('bcd -> collector', () => {
-      assert.deepEqual(getMissing('bcd-to-collector'), {missingEntries: [
-        'javascript.builtins.array'
       ], total: 7});
     });
 
+    it('bcd <- collector', () => {
+      assert.deepEqual(getMissing('bcd-from-collector'), {missingEntries: [
+        'javascript.builtins.array'
+      ], total: 4});
+    });
+
+    it('filter category', () => {
+      assert.deepEqual(getMissing('collector-from-bcd', ['api']), {missingEntries: [
+        'api.AbortController.dummy',
+        'api.DummyAPI',
+        'api.DummyAPI.dummy'
+      ], total: 5});
+    });
+
     it('unknown direction', () => {
-      assert.deepEqual(getMissing('foo-to-bar'), {missingEntries: [
+      assert.deepEqual(getMissing('foo-from-bar'), {missingEntries: [
         'api.AbortController.dummy',
         'api.DummyAPI',
         'api.DummyAPI.dummy',
         'css.properties.font-face'
-      ], total: 4});
+      ], total: 7});
 
-      assert.isTrue(console.log.calledWith('Direction \'foo-to-bar\' is unknown; defaulting to collector -> bcd'));
+      assert.isTrue(console.log.calledWith('Direction \'foo-from-bar\' is unknown; defaulting to collector <- bcd'));
     });
 
     afterEach(() => {


### PR DESCRIPTION
This PR updates the arguments to the find-missing script in two ways:
- Fixes the direction argument and its results for clarity
- Adds a category argument to filter results by category
