### PR TITLE
Fix tests for ANGLE_instanced_arrays

### DIFF
--- a/custom-tests.json
+++ b/custom-tests.json
@@ -31,7 +31,12 @@
     },
     "ANGLE_instanced_arrays": {
       "__resources": ["webGL"],
-      "__base": "if (!reusableInstances.webGL) {return false}; var instance = reusableInstances.webGL.getExtension('ANGLE_instanced_arrays');"
+      "__base": "if (!reusableInstances.webGL) {return false}; var instance = reusableInstances.webGL.getExtension('ANGLE_instanced_arrays');",
+      "__test": "return !!instance || 'drawArraysInstanced' in reusableInstances.webGL;",
+      "drawArraysInstancedANGLE": "return 'drawArraysInstanced' in reusableInstances.webGL || 'drawArraysInstancedANGLE' in instance;",
+      "drawElementsInstancedANGLE": "return 'drawElementsInstanced' in reusableInstances.webGL || 'drawElementsInstancedANGLE' in instance;",
+      "VERTEX_ATTRIB_ARRAY_DIVISOR_ANGLE": "return 'VERTEX_ATTRIB_ARRAY_DIVISOR' in reusableInstances.webGL || 'VERTEX_ATTRIB_ARRAY_DIVISOR_ANGLE' in instance;",
+      "vertexAttribDivisorANGLE": "return 'vertexAttribDivisor' in reusableInstances.webGL || 'vertexAttribDivisorANGLE' in instance;"
     },
     "AnalyserNode": {
       "__resources": ["audioContext"],


### PR DESCRIPTION
Reading more on the [`ANGLE_instanced_arrays` documentation](https://developer.mozilla.org/en-US/docs/Web/API/ANGLE_instanced_arrays), it appears that it is available as an "extension" only in WebGL1.  "In WebGL2, the functionality of this extension is available on the WebGL2 context by default and the constants and methods are available without the "ANGLE" suffix."

This PR updates the custom tests to test the non-suffixed versions directly from the WebGL2 contexts.