### PR TITLE
Remove miscapitalized entries

### DIFF
--- a/custom-idl/html.idl
+++ b/custom-idl/html.idl
@@ -200,13 +200,6 @@ interface HTMLIsIndexElement : HTMLElement {
 [Exposed=Window]
 interface HTMLKeygenElement : HTMLElement {};
 
-partial interface HTMLMarqueeElement {
-  attribute DOMString bgcolor;
-  attribute unsigned long scrollamount;
-  attribute unsigned long scrolldelay;
-  attribute boolean truespeed;
-};
-
 partial interface HTMLMediaElement {
   attribute MediaController controller;
   readonly attribute DOMTokenList controlsList;


### PR DESCRIPTION
This PR removes the duplicate, miscapitalized entries for the HTMLMarqueeElement interface.﻿
