### PR TITLE
Create add-new-bcd script

### DIFF
--- a/add-new-bcd.js
+++ b/add-new-bcd.js
@@ -91,7 +91,7 @@ const main = async () => {
   if (!await fs.pathExists(filepath)) {
     console.log('Generating new cache file...');
 
-    await collectMissing();
+    await collectMissing(filepath);
     await updateBcd(['../mdn-bcd-results/'], ['__missing'], []);
   }
 

--- a/add-new-bcd.js
+++ b/add-new-bcd.js
@@ -1,0 +1,97 @@
+'use strict';
+
+const fs = require('fs-extra');
+const path = require('path');
+
+const {getMissing} = require('./find-missing');
+const {main: updateBcd} = require('./update-bcd');
+
+const BCD_DIR = process.env.BCD_DIR || `../browser-compat-data`;
+const filepath = path.resolve(path.join(BCD_DIR, '__missing', '__missing.json'));
+
+const template = {
+  __compat: {
+    support: {
+      chrome: { version_added: null },
+      chrome_android: { version_added: null },
+      edge: { version_added: null },
+      firefox: { version_added: null },
+      firefox_android: { version_added: null },
+      ie: { version_added: null },
+      opera: { version_added: null },
+      opera_android: { version_added: null },
+      safari: { version_added: null },
+      safari_ios: { version_added: null },
+      samsunginternet_android: { version_added: null },
+      webview_android: { version_added: null },
+    },
+    status: { experimental: false, standard_track: true, deprecated: false },
+  },
+};
+
+const traverseFeatures = (obj, identifier) => {
+  const features = [];
+
+  for (const i in obj) {
+    if (
+      !!obj[i] &&
+      typeof obj[i] == 'object' &&
+      i !== '__compat'
+    ) {
+      if (obj[i].__compat) {
+        for (const support of Object.values(obj[i].__compat.support)) {
+          if (!([false, null].includes(support.version_added))) {
+            features.push(`${identifier}${i}`);
+            break;
+          }
+        }
+      }
+
+      features.push(...traverseFeatures(obj[i], identifier + i + '.'));
+    }
+  }
+
+  return features;
+};
+
+const recursiveAdd = (ident, i, data) => {
+  const part = ident[i];
+  const more = i + 1 < ident.length;
+
+  if (!(part in data)) {
+    data[part] = more ? {} : Object.assign({}, template);
+  }
+
+  if (more) {
+    recursiveAdd(ident, i + 1, data[part]);
+  }
+}
+
+const collectMissing = async () => {
+  const missing = {api: {}};
+
+  for (const entry of getMissing('bcd-from-collector', ['api']).missingEntries) {
+    recursiveAdd(entry.split('.'), 0, missing);
+  };
+
+  const json = JSON.stringify(missing, null, '  ') + '\n';
+  await fs.ensureDir(path.dirname(filepath));
+  await fs.writeFile(filepath, json);
+};
+
+const main = async () => {
+  if (!await fs.pathExists(filepath)) {
+    console.log('Generating new file...');
+
+    await collectMissing();
+    await updateBcd(['../mdn-bcd-results/'], ['__missing'], []);
+
+    console.log('');
+  }
+
+  const data = await fs.readJSON(filepath);
+
+  console.log(traverseFeatures(data.api, 'api.').join('\n'));
+}
+
+main();

--- a/add-new-bcd.js
+++ b/add-new-bcd.js
@@ -39,14 +39,14 @@ const recursiveAdd = (ident, i, data, obj) => {
   return data;
 };
 
-function orderFeatures(key, value) {
+const orderFeatures = (key, value) => {
   if (value instanceof Object && '__compat' in value) {
     value = Object.keys(value)
-      .sort(compareFeatures)
-      .reduce((result, key) => {
-        result[key] = value[key];
-        return result;
-      }, {});
+        .sort(compareFeatures)
+        .reduce((result, key) => {
+          result[key] = value[key];
+          return result;
+        }, {});
   }
   return value;
 }

--- a/add-new-bcd.js
+++ b/add-new-bcd.js
@@ -11,21 +11,21 @@ const BCD_DIR = process.env.BCD_DIR || `../browser-compat-data`;
 const template = {
   __compat: {
     support: {
-      chrome: { version_added: null },
-      chrome_android: { version_added: null },
-      edge: { version_added: null },
-      firefox: { version_added: null },
-      firefox_android: { version_added: null },
-      ie: { version_added: null },
-      opera: { version_added: null },
-      opera_android: { version_added: null },
-      safari: { version_added: null },
-      safari_ios: { version_added: null },
-      samsunginternet_android: { version_added: null },
-      webview_android: { version_added: null },
+      chrome: {version_added: null},
+      chrome_android: {version_added: null},
+      edge: {version_added: null},
+      firefox: {version_added: null},
+      firefox_android: {version_added: null},
+      ie: {version_added: null},
+      opera: {version_added: null},
+      opera_android: {version_added: null},
+      safari: {version_added: null},
+      safari_ios: {version_added: null},
+      samsunginternet_android: {version_added: null},
+      webview_android: {version_added: null}
     },
-    status: { experimental: false, standard_track: true, deprecated: false },
-  },
+    status: {experimental: false, standard_track: true, deprecated: false}
+  }
 };
 
 const recursiveAdd = (ident, i, data, obj) => {
@@ -36,18 +36,18 @@ const recursiveAdd = (ident, i, data, obj) => {
               Object.assign({}, obj);
 
   return data;
-}
+};
 
 const writeFile = async (ident, obj) => {
   const filepath = path.resolve(path.join(BCD_DIR, ident[0], `${ident[1]}.json`));
-  
+
   let data = {api: {}};
   if (await fs.pathExists(filepath)) {
     data = await fs.readJSON(filepath);
   }
 
   await fs.writeJSON(filepath, recursiveAdd(
-    ident.concat(['__compat']), 0, data, obj.__compat
+      ident.concat(['__compat']), 0, data, obj.__compat
   ), {spaces: 2});
 };
 
@@ -78,7 +78,7 @@ const collectMissing = async (filepath) => {
 
   for (const entry of getMissing('bcd-from-collector', ['api']).missingEntries) {
     recursiveAdd(entry.split('.'), 0, missing, template);
-  };
+  }
 
   const json = JSON.stringify(missing, null, '  ') + '\n';
   await fs.ensureDir(path.dirname(filepath));
@@ -100,6 +100,6 @@ const main = async () => {
   await fs.remove(filepath);
 
   console.log('Done!');
-}
+};
 
 main();

--- a/add-new-bcd.js
+++ b/add-new-bcd.js
@@ -49,7 +49,7 @@ const orderFeatures = (key, value) => {
         }, {});
   }
   return value;
-}
+};
 
 const writeFile = async (ident, obj) => {
   const filepath = path.resolve(path.join(BCD_DIR, ident[0], `${ident[1]}.json`));

--- a/add-new-bcd.js
+++ b/add-new-bcd.js
@@ -88,17 +88,16 @@ const collectMissing = async (filepath) => {
 const main = async () => {
   const filepath = path.resolve(path.join(BCD_DIR, '__missing', '__missing.json'));
 
-  if (!await fs.pathExists(filepath)) {
-    console.log('Generating new cache file...');
+  console.log('Generating new cache file...');
 
-    await collectMissing(filepath);
-    await updateBcd(['../mdn-bcd-results/'], ['__missing'], []);
-  }
+  await collectMissing(filepath);
+  await updateBcd(['../mdn-bcd-results/'], ['__missing'], []);
 
   console.log('Adding data...');
-
   const data = await fs.readJSON(filepath);
   await traverseFeatures(data.api, ['api']);
+
+  fs.rm(filepath);
 
   console.log('Done!');
 }

--- a/add-new-bcd.js
+++ b/add-new-bcd.js
@@ -88,16 +88,16 @@ const collectMissing = async (filepath) => {
 const main = async () => {
   const filepath = path.resolve(path.join(BCD_DIR, '__missing', '__missing.json'));
 
-  console.log('Generating new cache file...');
-
+  console.log('Generating missing BCD...');
   await collectMissing(filepath);
   await updateBcd(['../mdn-bcd-results/'], ['__missing'], []);
 
-  console.log('Adding data...');
+  console.log('Injecting BCD...');
   const data = await fs.readJSON(filepath);
   await traverseFeatures(data.api, ['api']);
 
-  fs.rm(filepath);
+  console.log('Cleaning up...');
+  await fs.remove(filepath);
 
   console.log('Done!');
 }

--- a/nodemon.json
+++ b/nodemon.json
@@ -8,6 +8,7 @@
     "find-missing.js",
     "scripts.js",
     "selenium.js",
-    "update-bcd.js"
+    "update-bcd.js",
+    "add-new-bcd.js"
   ]
 }

--- a/package.json
+++ b/package.json
@@ -26,7 +26,8 @@
     "test": "npm run lint && npm run unittest",
     "selenium": "node selenium.js",
     "update-bcd": "node update-bcd.js",
-    "find-missing": "node find-missing.js"
+    "find-missing": "node find-missing.js",
+    "add-new-bcd": "node add-new-bcd.js"
   },
   "dependencies": {
     "@google-cloud/logging-winston": "4.0.1",

--- a/update-bcd.js
+++ b/update-bcd.js
@@ -357,7 +357,8 @@ module.exports = {
   getSupportMap,
   getSupportMatrix,
   inferSupportStatements,
-  update
+  update,
+  main
 };
 
 /* istanbul ignore if */


### PR DESCRIPTION
This PR introduces a new script that adds new BCD entries based upon what is currently missing but is in spec, and has support in at least one browser as per the collector results.
