### PR TITLE
Update styling for results display

### DIFF
--- a/static/resources/harness.js
+++ b/static/resources/harness.js
@@ -581,37 +581,45 @@
       for (var i=0; i<results.length; i++) {
         var result = results[i];
 
-        var thisResultEl = document.createElement('div');
-        thisResultEl.className = 'result';
+        var resultEl = document.createElement('details');
+        resultEl.className = 'result';
 
-        var resultNameEl = document.createElement('p');
-
-        resultNameEl.innerHTML = result.name;
+        var resultSummaryEl = document.createElement('summary');
+        resultSummaryEl.innerHTML = result.name;
         if (result.name.indexOf('css.') != 0) {
-          resultNameEl.innerHTML += ' (' + result.info.exposure + ' exposure)';
+          resultSummaryEl.innerHTML += ' (' + result.info.exposure + ' exposure)';
         }
-        resultNameEl.innerHTML += ':&nbsp;';
+        resultSummaryEl.innerHTML += ':&nbsp;';
 
-        var resultValueEl = document.createElement('strong');
-        resultValueEl.innerHTML = stringify(result.result);
+        var resultValue = stringify(result.result);
+        var resultValueEl = document.createElement('span');
+        resultValueEl.className = 'result-value result-value-' + resultValue;
+        resultValueEl.innerHTML = resultValue;
         if (result.prefix) {
           resultValueEl.innerHTML += ' (' + result.prefix + ' prefix)';
         }
+        resultSummaryEl.appendChild(resultValueEl);
+        resultEl.appendChild(resultSummaryEl);
+
+        var resultInfoEl = document.createElement('div');
+        resultInfoEl.className = 'result-info';
+
         if (result.message) {
-          resultValueEl.innerHTML += ' (' + result.message + ')';
+          var resultMessageEl = document.createElement('p');
+          resultMessageEl.className = 'result-message';
+          resultMessageEl.innerHTML = result.message;
+          resultInfoEl.appendChild(resultMessageEl);
         }
-        resultNameEl.appendChild(resultValueEl);
-        thisResultEl.appendChild(resultNameEl);
 
         if (result.info.code) {
-          var codeEl = document.createElement('code');
-          codeEl.innerHTML = result.info.code.replace(/ /g, '&nbsp;').replace(/\n/g, '<br />');
-          thisResultEl.appendChild(codeEl);
-          thisResultEl.appendChild(document.createElement('br'));
-          thisResultEl.appendChild(document.createElement('br'));
+          var resultCodeEl = document.createElement('code');
+          resultCodeEl.className = 'result-code';
+          resultCodeEl.innerHTML = result.info.code.replace(/ /g, '&nbsp;').replace(/\n/g, '<br />');
+          resultInfoEl.appendChild(resultCodeEl);
         }
 
-        resultsEl.appendChild(thisResultEl);
+        resultEl.appendChild(resultInfoEl);
+        resultsEl.appendChild(resultEl);
       }
     }
   }

--- a/static/resources/style.css
+++ b/static/resources/style.css
@@ -1,4 +1,4 @@
-@import url('https://fonts.googleapis.com/css2?family=Roboto+Mono:wght@400;700&family=Roboto:wght@400;700&family=Montserrat:wght@500&display=swap');
+@import url('https://fonts.googleapis.com/css2?family=Roboto+Mono:wght@400;700&family=Roboto:ital,wght@0,400;0,700;1,400&family=Montserrat:wght@500&display=swap');
 
 html {
   background: #111;
@@ -229,8 +229,31 @@ hr {
 
 /* End: Homepage */
 
-.result p {
-  margin-bottom: 0;
+.result {
+  margin-bottom: 0.5em;
+}
+
+.result .result-value {
+  font-weight: bold;
+}
+
+.result-value-true {
+  color: #afa;
+}
+
+.result-value-false {
+  color: #faa;
+}
+
+.result .result-info {
+  display: block;
+  margin-left: 1.5em;
+  margin-bottom: 1em;
+}
+
+.result .result-message {
+  font-style: italic;
+  margin-top: 0;
 }
 
 @media (prefers-color-scheme: light) {
@@ -263,7 +286,7 @@ hr {
     background-color: #eee;
   }
 
-  .error-notice {
+  .error-notice, .result-value-false {
     color: #700;
   }
 
@@ -271,7 +294,7 @@ hr {
     color: #770;
   }
 
-  .success-notice {
+  .success-notice, .result-value-true {
     color: #070;
   }
 


### PR DESCRIPTION
This PR updates the styling for the results upon test completion to consolidate screen space using the `<details>` element to make the code display a dropdown, along with a few other enhancements (such as coloring the result green/red based upon the value).

Before:
<img width="1028" alt="Screen Shot 2020-11-29 at 05 46 15" src="https://user-images.githubusercontent.com/5179191/100543699-7d669700-3206-11eb-938a-aeb908c8ac4c.png">

After:
<img width="1072" alt="Screen Shot 2020-11-29 at 05 46 17" src="https://user-images.githubusercontent.com/5179191/100543718-9bcc9280-3206-11eb-93b9-ce629cce9d89.png">
