### PR TITLE
Fix constructor test function

### DIFF
--- a/static/resources/harness.js
+++ b/static/resources/harness.js
@@ -119,7 +119,7 @@
     } catch (err) {
       if (
         stringIncludes(err.message, 'Illegal constructor') ||
-        stringIncludes(err.message, 'function is not a constructor') ||
+        stringIncludes(err.message, 'is not a constructor') ||
         stringIncludes(err.message, 'Function expected')
       ) {
         result.result = false;


### PR DESCRIPTION
In some versions of Safari stringifies the object rather than using the word "function".  This PR fixes it to catch for such cases.
