### PR TITLE
Add and improve custom tests

### DIFF
--- a/custom-tests.json
+++ b/custom-tests.json
@@ -31,19 +31,23 @@
       "webGL": {
         "type": "instance",
         "src": "var canvas = document.createElement('canvas'); if (!canvas) {return false}; return canvas.getContext('webgl2') || canvas.getContext('webgl') || canvas.getContext('experimental-webgl');"
+      },
+      "webGL1": {
+        "type": "instance",
+        "src": "var canvas = document.createElement('canvas'); if (!canvas) {return false}; return canvas.getContext('webgl') || canvas.getContext('experimental-webgl');"
+      },
+      "webGL2": {
+        "type": "instance",
+        "src": "var canvas = document.createElement('canvas'); if (!canvas) {return false}; return canvas.getContext('webgl2');"
       }
     },
     "Attr": {
       "__base": "var el = document.createElement('p'); el.setAttribute('data-foo', 'bar'); var instance = el.getAttributeNode('data-foo');"
     },
     "ANGLE_instanced_arrays": {
-      "__resources": ["webGL"],
-      "__base": "if (!reusableInstances.webGL) {return false}; var instance = reusableInstances.webGL.getExtension('ANGLE_instanced_arrays');",
-      "__test": "return !!instance || 'drawArraysInstanced' in reusableInstances.webGL;",
-      "drawArraysInstancedANGLE": "return 'drawArraysInstanced' in reusableInstances.webGL || 'drawArraysInstancedANGLE' in instance;",
-      "drawElementsInstancedANGLE": "return 'drawElementsInstanced' in reusableInstances.webGL || 'drawElementsInstancedANGLE' in instance;",
-      "VERTEX_ATTRIB_ARRAY_DIVISOR_ANGLE": "return 'VERTEX_ATTRIB_ARRAY_DIVISOR' in reusableInstances.webGL || 'VERTEX_ATTRIB_ARRAY_DIVISOR_ANGLE' in instance;",
-      "vertexAttribDivisorANGLE": "return 'vertexAttribDivisor' in reusableInstances.webGL || 'vertexAttribDivisorANGLE' in instance;"
+      "__resources": ["webGL1"],
+      "__base": "if (!reusableInstances.webGL1) {return false}; var instance = reusableInstances.webGL1.getExtension('ANGLE_instanced_arrays');",
+      "__test": "return !!instance;"
     },
     "AnalyserNode": {
       "__resources": ["audioContext"],
@@ -246,44 +250,44 @@
       "__base": "var instance = new EventSource('/eventstream');"
     },
     "EXT_blend_minmax": {
-      "__resources": ["webGL"],
-      "__base": "if (!reusableInstances.webGL) {return false}; var instance = reusableInstances.webGL.getExtension('EXT_blend_minmax');"
+      "__resources": ["webGL1"],
+      "__base": "if (!reusableInstances.webGL1) {return false}; var instance = reusableInstances.webGL1.getExtension('EXT_blend_minmax');"
     },
     "EXT_clip_cull_distance": {
       "__resources": ["webGL"],
       "__base": "if (!reusableInstances.webGL) {return false}; var instance = reusableInstances.webGL.getExtension('EXT_clip_cull_distance');"
     },
     "EXT_color_buffer_float": {
-      "__resources": ["webGL"],
-      "__base": "if (!reusableInstances.webGL) {return false}; var instance = reusableInstances.webGL.getExtension('EXT_color_buffer_float');"
+      "__resources": ["webGL2"],
+      "__base": "if (!reusableInstances.webGL2) {return false}; var instance = reusableInstances.webGL2.getExtension('EXT_color_buffer_float');"
     },
     "EXT_color_buffer_half_float": {
-      "__resources": ["webGL"],
-      "__base": "if (!reusableInstances.webGL) {return false}; var instance = reusableInstances.webGL.getExtension('EXT_color_buffer_half_float');"
+      "__resources": ["webGL1"],
+      "__base": "if (!reusableInstances.webGL1) {return false}; var instance = reusableInstances.webGL1.getExtension('EXT_color_buffer_half_float');"
     },
     "EXT_disjoint_timer_query": {
-      "__resources": ["webGL"],
-      "__base": "if (!reusableInstances.webGL) {return false}; var instance = reusableInstances.webGL.getExtension('EXT_disjoint_timer_query');"
+      "__resources": ["webGL1"],
+      "__base": "if (!reusableInstances.webGL1) {return false}; var instance = reusableInstances.webGL1.getExtension('EXT_disjoint_timer_query');"
     },
     "EXT_disjoint_timer_query_webgl2": {
-      "__resources": ["webGL"],
-      "__base": "if (!reusableInstances.webGL) {return false}; var instance = reusableInstances.webGL.getExtension('EXT_disjoint_timer_query_webgl2');"
+      "__resources": ["webGL2"],
+      "__base": "if (!reusableInstances.webGL2) {return false}; var instance = reusableInstances.webGL2.getExtension('EXT_disjoint_timer_query_webgl2');"
     },
     "EXT_float_blend": {
       "__resources": ["webGL"],
       "__base": "if (!reusableInstances.webGL) {return false}; var instance = reusableInstances.webGL.getExtension('EXT_float_blend');"
     },
     "EXT_frag_depth": {
-      "__resources": ["webGL"],
-      "__base": "if (!reusableInstances.webGL) {return false}; var instance = reusableInstances.webGL.getExtension('EXT_frag_depth');"
+      "__resources": ["webGL1"],
+      "__base": "if (!reusableInstances.webGL1) {return false}; var instance = reusableInstances.webGL1.getExtension('EXT_frag_depth');"
     },
     "EXT_shader_texture_lod": {
-      "__resources": ["webGL"],
-      "__base": "if (!reusableInstances.webGL) {return false}; var instance = reusableInstances.webGL.getExtension('EXT_shader_texture_lod');"
+      "__resources": ["webGL1"],
+      "__base": "if (!reusableInstances.webGL1) {return false}; var instance = reusableInstances.webGL1.getExtension('EXT_shader_texture_lod');"
     },
     "EXT_sRGB": {
-      "__resources": ["webGL"],
-      "__base": "if (!reusableInstances.webGL) {return false}; var instance = reusableInstances.webGL.getExtension('EXT_sRGB');"
+      "__resources": ["webGL1"],
+      "__base": "if (!reusableInstances.webGL1) {return false}; var instance = reusableInstances.webGL1.getExtension('EXT_sRGB');"
     },
     "EXT_texture_compression_bptc": {
       "__resources": ["webGL"],
@@ -298,8 +302,8 @@
       "__base": "if (!reusableInstances.webGL) {return false}; var instance = reusableInstances.webGL.getExtension('EXT_texture_filter_anisotropic');"
     },
     "EXT_texture_norm16": {
-      "__resources": ["webGL"],
-      "__base": "if (!reusableInstances.webGL) {return false}; var instance = reusableInstances.webGL.getExtension('EXT_texture_norm16');"
+      "__resources": ["webGL2"],
+      "__base": "if (!reusableInstances.webGL2) {return false}; var instance = reusableInstances.webGL2.getExtension('EXT_texture_norm16');"
     },
     "External": {
       "__base": "var instance = window.external;"
@@ -742,40 +746,40 @@
       "__base": "if (!reusableInstances.webGL) {return false}; var instance = reusableInstances.webGL.getExtension('OES_draw_buffers_indexed');"
     },
     "OES_element_index_uint": {
-      "__resources": ["webGL"],
-      "__base": "if (!reusableInstances.webGL) {return false}; var instance = reusableInstances.webGL.getExtension('OES_element_index_uint');"
+      "__resources": ["webGL1"],
+      "__base": "if (!reusableInstances.webGL1) {return false}; var instance = reusableInstances.webGL1.getExtension('OES_element_index_uint');"
     },
     "OES_fbo_render_mipmap": {
-      "__resources": ["webGL"],
-      "__base": "if (!reusableInstances.webGL) {return false}; var instance = reusableInstances.webGL.getExtension('OES_fbo_render_mipmap');"
+      "__resources": ["webGL1"],
+      "__base": "if (!reusableInstances.webGL1) {return false}; var instance = reusableInstances.webGL1.getExtension('OES_fbo_render_mipmap');"
     },
     "OES_standard_derivatives": {
-      "__resources": ["webGL"],
-      "__base": "if (!reusableInstances.webGL) {return false}; var instance = reusableInstances.webGL.getExtension('OES_standard_derivatives');"
+      "__resources": ["webGL1"],
+      "__base": "if (!reusableInstances.webGL1) {return false}; var instance = reusableInstances.webGL1.getExtension('OES_standard_derivatives');"
     },
     "OES_texture_float": {
-      "__resources": ["webGL"],
-      "__base": "if (!reusableInstances.webGL) {return false}; var instance = reusableInstances.webGL.getExtension('OES_texture_float');"
+      "__resources": ["webGL1"],
+      "__base": "if (!reusableInstances.webGL1) {return false}; var instance = reusableInstances.webGL1.getExtension('OES_texture_float');"
     },
     "OES_texture_float_linear": {
       "__resources": ["webGL"],
       "__base": "if (!reusableInstances.webGL) {return false}; var instance = reusableInstances.webGL.getExtension('OES_texture_float_linear');"
     },
     "OES_texture_half_float": {
-      "__resources": ["webGL"],
-      "__base": "if (!reusableInstances.webGL) {return false}; var instance = reusableInstances.webGL.getExtension('OES_texture_half_float');"
+      "__resources": ["webGL1"],
+      "__base": "if (!reusableInstances.webGL1) {return false}; var instance = reusableInstances.webGL1.getExtension('OES_texture_half_float');"
     },
     "OES_texture_half_float_linear": {
       "__resources": ["webGL"],
       "__base": "if (!reusableInstances.webGL) {return false}; var instance = reusableInstances.webGL.getExtension('OES_texture_half_float_linear');"
     },
     "OES_vertex_array_object": {
-      "__resources": ["webGL"],
-      "__base": "if (!reusableInstances.webGL) {return false}; var instance = reusableInstances.webGL.getExtension('OES_vertex_array_object');"
+      "__resources": ["webGL1"],
+      "__base": "if (!reusableInstances.webGL1) {return false}; var instance = reusableInstances.webGL1.getExtension('OES_vertex_array_object');"
     },
     "OVR_multiview2": {
-      "__resources": ["webGL"],
-      "__base": "if (!reusableInstances.webGL) {return false}; var instance = reusableInstances.webGL.getExtension('OVR_multiview2');"
+      "__resources": ["webGL2"],
+      "__base": "if (!reusableInstances.webGL2) {return false}; var instance = reusableInstances.webGL2.getExtension('OVR_multiview2');"
     },
     "PannerNode": {
       "__resources": ["audioContext"],
@@ -1268,8 +1272,8 @@
       "__base": "if (!reusableInstances.webGL) {return false}; var instance = reusableInstances.webGL.getExtension('WEBGL_blend_equation_advanced_coherent');"
     },
     "WEBGL_color_buffer_float": {
-      "__resources": ["webGL"],
-      "__base": "if (!reusableInstances.webGL) {return false}; var instance = reusableInstances.webGL.getExtension('WEBGL_color_buffer_float');"
+      "__resources": ["webGL1"],
+      "__base": "if (!reusableInstances.webGL1) {return false}; var instance = reusableInstances.webGL1.getExtension('WEBGL_color_buffer_float');"
     },
     "WEBGL_compressed_texture_astc": {
       "__resources": ["webGL"],
@@ -1308,12 +1312,12 @@
       "__base": "if (!reusableInstances.webGL) {return false}; var instance = reusableInstances.webGL.getExtension('WEBGL_debug_shaders');"
     },
     "WEBGL_depth_texture": {
-      "__resources": ["webGL"],
-      "__base": "if (!reusableInstances.webGL) {return false}; var instance = reusableInstances.webGL.getExtension('WEBGL_depth_texture');"
+      "__resources": ["webGL1"],
+      "__base": "if (!reusableInstances.webGL1) {return false}; var instance = reusableInstances.webGL1.getExtension('WEBGL_depth_texture');"
     },
     "WEBGL_draw_buffers": {
-      "__resources": ["webGL"],
-      "__base": "if (!reusableInstances.webGL) {return false}; var instance = reusableInstances.webGL.getExtension('WEBGL_draw_buffers');"
+      "__resources": ["webGL1"],
+      "__base": "if (!reusableInstances.webGL1) {return false}; var instance = reusableInstances.webGL1.getExtension('WEBGL_draw_buffers');"
     },
     "WEBGL_draw_instanced_base_vertex_base_instance": {
       "__resources": ["webGL"],

--- a/custom-tests.json
+++ b/custom-tests.json
@@ -1337,6 +1337,9 @@
     },
     "XPathExpression": {
       "__base": "var xpe = new XPathEvaluator(); var instance = xpe.createExpression('//div');"
+    },
+    "XPathResult": {
+      "__base": "<%api.XPathExpression:exp%> var instance = exp.evaluate(document);"
     }
   },
   "css": {

--- a/custom-tests.json
+++ b/custom-tests.json
@@ -842,6 +842,9 @@
       "__resources": ["createStyleSheet"],
       "__base": "<%api.CSSStyleSheet:instance%>"
     },
+    "StyleSheetList": {
+      "__base": "var instance = document.styleSheets;"
+    },
     "SubtleCrypto": {
       "__base": "<%api.Crypto:crypto%> var instance = crypto.subtle;"
     },

--- a/custom-tests.json
+++ b/custom-tests.json
@@ -1335,6 +1335,9 @@
       "__resources": ["webGL"],
       "__base": "<%api.EXT_disjoint_timer_query:ext%> var instance = ext.createQueryEXT();"
     },
+    "WebSocket": {
+      "__base": "var instance = new WebSocket('wss://mdn-bcd-collector.appspot.com');"
+    },
     "Window": {
       "__base": "var instance = window;"
     },

--- a/custom-tests.json
+++ b/custom-tests.json
@@ -1233,6 +1233,10 @@
       "__resources": ["video-blank"],
       "__base": "var el = document.getElementById('resource-video-blank'); var instance = el.textTracks;"
     },
+    "TimeRanges": {
+      "__resources": ["video-blank"],
+      "__base": "var el = document.getElementById('resource-video-blank'); var instance = el.buffered;"
+    },
     "TreeWalker": {
       "__base": "var instance = document.createTreeWalker(document);"
     },

--- a/custom-tests.json
+++ b/custom-tests.json
@@ -796,6 +796,13 @@
     "PerformanceTiming": {
       "__base": "<%api.Performance:performance%> var instance = performance.timing;"
     },
+    "PeriodicWave": {
+      "__resources": ["audioContext"],
+      "__base": "if (!reusableInstances.audioContext) {return false;} var instance = reusableInstances.audioContext.createPeriodicWave();"
+    },
+    "PluginArray": {
+      "__base": "var instance = navigator.plugins;"
+    },
     "ProcessingInstruction": {
       "__base": "var instance = document.createProcessingInstruction('xml', \"version='1.0' encoding='UTF-8'\");"
     },

--- a/custom-tests.json
+++ b/custom-tests.json
@@ -800,6 +800,10 @@
       "__resources": ["audioContext"],
       "__base": "if (!reusableInstances.audioContext) {return false;} var instance = reusableInstances.audioContext.createPeriodicWave();"
     },
+    "Plugin": {
+      "__todo": "XXX Doesn't work if there are no plugins",
+      "__base": "<%api.PluginArray:plugins%> var instance = plugins[0];"
+    },
     "PluginArray": {
       "__base": "var instance = navigator.plugins;"
     },

--- a/static/resources/harness.js
+++ b/static/resources/harness.js
@@ -128,7 +128,8 @@
         stringIncludes(err.message, 'argument required') ||
         stringIncludes(err.message, 'arguments required') ||
         stringIncludes(err.message, 'Argument not optional') ||
-        stringIncludes(err.message, 'Arguments can\'t be empty')
+        stringIncludes(err.message, 'Arguments can\'t be empty') ||
+        stringIncludes(err.message, 'undefined is not an object')
       ) {
         // If it failed to construct and it's not illegal or just needs
         // more arguments, the constructor's good


### PR DESCRIPTION
This PR adds and updates a number of custom tests:
- Add custom tests for PeriodicWave and PluginArray APIs
- Improve constructor test
- Add custom test for Plugin API
- Add custom test for TimeRanges API
- Add custom test for XPathResult
- Add custom test for StyleSheetList
- Add custom test for WebSocket API
- Explicitly use WebGL1 or WebGL2 for extensions that need it
