### PR TITLE
Generate tests for event interfaces

### DIFF
--- a/build.js
+++ b/build.js
@@ -589,12 +589,6 @@ const buildIDLTests = (ast) => {
 
     const adjustedIfaceName = getName(iface);
 
-    if (adjustedIfaceName.endsWith('Event') && adjustedIfaceName !== 'Event') {
-      // TODO: event interfaces are not always exposed on their own and will
-      // require the event to be fired.
-      continue;
-    }
-
     const exposureSet = getExposureSet(iface);
     const isGlobal = !!getExtAttr(iface, 'Global');
     const customIfaceTest = getCustomTestAPI(adjustedIfaceName);


### PR DESCRIPTION
This results in 812 new tests being generated for the interfaces and
their members.

The comment is true, but many event interfaces *are* exposed and it's
worth having the tests for them. Care is still needed while using the
results, but that could be added to update-bcd.js.

This reverts a change from https://github.com/foolip/mdn-bcd-collector/pull/735.