### PR TITLE
Avoid generating extra tests for readonly setlike/maplike

### DIFF
--- a/build.js
+++ b/build.js
@@ -334,23 +334,24 @@ const flattenMembers = (iface) => {
         break;
       case 'maplike':
         members.push(
-            {name: 'clear', type: 'operation'},
-            {name: 'delete', type: 'operation'},
             {name: 'entries', type: 'operation'},
             {name: 'forEach', type: 'operation'},
             {name: 'get', type: 'operation'},
             {name: 'has', type: 'operation'},
             {name: 'keys', type: 'operation'},
-            {name: 'set', type: 'operation'},
             {name: 'size', type: 'attribute'},
             {name: 'values', type: 'operation'}
         );
+        if (!member.readonly) {
+          members.push(
+              {name: 'clear', type: 'operation'},
+              {name: 'delete', type: 'operation'},
+              {name: 'set', type: 'operation'}
+          );
+        }
         break;
       case 'setlike':
         members.push(
-            {name: 'add', type: 'operation'},
-            {name: 'clear', type: 'operation'},
-            {name: 'delete', type: 'operation'},
             {name: 'entries', type: 'operation'},
             {name: 'forEach', type: 'operation'},
             {name: 'has', type: 'operation'},
@@ -358,6 +359,13 @@ const flattenMembers = (iface) => {
             {name: 'size', type: 'attribute'},
             {name: 'values', type: 'operation'}
         );
+        if (!member.readonly) {
+          members.push(
+              {name: 'add', type: 'operation'},
+              {name: 'clear', type: 'operation'},
+              {name: 'delete', type: 'operation'}
+          );
+        }
         break;
       case 'operation':
         switch (member.special) {


### PR DESCRIPTION
This removes the following incorrecly generated tests:
api.AudioParamMap.clear
api.AudioParamMap.delete
api.AudioParamMap.set
api.BluetoothManufacturerDataMap.clear
api.BluetoothManufacturerDataMap.delete
api.BluetoothManufacturerDataMap.set
api.BluetoothServiceDataMap.clear
api.BluetoothServiceDataMap.delete
api.BluetoothServiceDataMap.set
api.EventCounts.clear
api.EventCounts.delete
api.EventCounts.set
api.GPUAdapterFeatures.add
api.GPUAdapterFeatures.clear
api.GPUAdapterFeatures.delete
api.KeyboardLayoutMap.clear
api.KeyboardLayoutMap.delete
api.KeyboardLayoutMap.set
api.MIDIInputMap.clear
api.MIDIInputMap.delete
api.MIDIInputMap.set
api.MIDIOutputMap.clear
api.MIDIOutputMap.delete
api.MIDIOutputMap.set
api.RTCStatsReport.clear
api.RTCStatsReport.delete
api.RTCStatsReport.set
api.XRAnchorSet.add
api.XRAnchorSet.clear
api.XRAnchorSet.delete