### PR TITLE
Expand on custom prefixed interface tests

### DIFF
--- a/custom-idl/IndexedDB.idl
+++ b/custom-idl/IndexedDB.idl
@@ -29,5 +29,5 @@ partial interface IDBVersionChangeEvent {
 };
 
 partial interface Window {
-  attribute object webkitIndexedDB;
+  readonly attribute IDBFactory webkitIndexedDB;
 };

--- a/custom-idl/css-animations.idl
+++ b/custom-idl/css-animations.idl
@@ -25,6 +25,7 @@ interface Point {
   attribute float y;
 };
 
-partial interface Window {
-  attribute object WebKitAnimationEvent;
+[Exposed=Window]
+interface WebKitAnimationEvent : Event {
+  constructor(DOMString type);
 };

--- a/custom-idl/css-transitions.idl
+++ b/custom-idl/css-transitions.idl
@@ -1,0 +1,4 @@
+[Exposed=Window]
+interface WebKitTransitionEvent : Event {
+  constructor(DOMString type);
+};

--- a/custom-idl/cssom.idl
+++ b/custom-idl/cssom.idl
@@ -128,8 +128,6 @@ partial interface Element {
   readonly attribute MSStyleCSSProperties? runtimeStyle;
 };
 
-interface WebKitCSSMatrix : DOMMatrix {};
-
 partial interface Window {
   // https://github.com/WebKit/WebKit/blob/bc44d2f960d35b47803c79ffbdc9cf57c0a01778/Source/WebCore/page/DOMWindow.idl#L124
   // https://chromium.googlesource.com/chromium/src.git/+/9b52888ec6e049583e3765eb6ed2f7c58c1d50a0

--- a/custom-idl/encrypted-media.idl
+++ b/custom-idl/encrypted-media.idl
@@ -1,13 +1,28 @@
 partial interface HTMLMediaElement {
   // https://github.com/WebKit/WebKit/blob/c397d717fcd82a8daff69dccb1354a5f94ca6f9a/Source/WebCore/html/HTMLMediaElement.idl#L106
-  readonly attribute object webkitKeys;
-  undefined webkitSetMediaKeys(object? mediaKeys);
+  readonly attribute WebKitMediaKeys? webkitKeys;
+  undefined webkitSetMediaKeys(WebKitMediaKeys? mediaKeys);
 };
 
-partial interface Window {
-  attribute object WebKitMediaKeyError;
-  attribute object WebKitMediaKeyMessageEvent;
-  attribute object WebKitMediaKeyNeededEvent;
-  attribute object WebKitMediaKeys;
-  attribute object WebKitMediaKeySession;
+[Exposed=Window]
+interface WebKitMediaKeyError {
+};
+
+[Exposed=Window]
+interface WebKitMediaKeyMessageEvent : Event {
+  constructor(DOMString type);
+};
+
+[Exposed=Window]
+interface WebKitMediaKeyNeededEvent : Event {
+  constructor(DOMString type);
+};
+
+[Exposed=Window]
+interface WebKitMediaKeys {
+  constructor(DOMString keySystem);
+};
+
+[Exposed=Window]
+interface WebKitMediaKeySession : EventTarget {
 };

--- a/custom-idl/geometry.idl
+++ b/custom-idl/geometry.idl
@@ -3,16 +3,20 @@ partial interface DOMMatrixReadOnly {
   undefined transform();
 };
 
+[Exposed=Window]
+interface WebKitCSSMatrix {
+  constructor();
+};
+
 // https://github.com/WebKit/webkit/blob/master/Source/WebCore/page/WebKitPoint.idl
-[Exposed=Window] interface WebKitPoint {
+[Exposed=Window]
+interface WebKitPoint {
   constructor(optional unrestricted double x = 0, optional unrestricted double y = 0);
   attribute unrestricted double x;
   attribute unrestricted double y;
 };
 
 partial interface Window {
-  attribute object WebKitCSSMatrix;
-
   // https://www.w3.org/TR/2009/WD-css3-2d-transforms-20090320/#window-interface
   Point convertPointFromPageToNode(Node node, Point point);
   Point convertPointFromNodeToPage(Node node, Point point);

--- a/custom-idl/mediacapture-streams.idl
+++ b/custom-idl/mediacapture-streams.idl
@@ -13,6 +13,7 @@ interface LocalMediaStream : MediaStream {
   undefined stop();
 };
 
-partial interface Window {
-  attribute object webkitMediaStream;
+[Exposed=Window]
+interface webkitMediaStream {
+  constructor();
 };

--- a/custom-idl/speech-api.idl
+++ b/custom-idl/speech-api.idl
@@ -1,7 +1,24 @@
-partial interface Window {
-  attribute object webkitSpeechGrammar;
-  attribute object webkitSpeechGrammarList;
-  attribute object webkitSpeechRecognition;
-  attribute object webkitSpeechRecognitionError;
-  attribute object webkitSpeechRecognitionEvent;
+[Exposed=Window]
+interface webkitSpeechGrammar {
+  constructor();
+};
+
+[Exposed=Window]
+interface webkitSpeechGrammarList {
+  constructor();
+};
+
+[Exposed=Window]
+interface webkitSpeechRecognition : EventTarget {
+  constructor();
+};
+
+[Exposed=Window]
+interface webkitSpeechRecognitionError : Event {
+  constructor(DOMString type);
+};
+
+[Exposed=Window]
+interface webkitSpeechRecognitionEvent : Event {
+  constructor(DOMString type);
 };

--- a/custom-idl/uievents.idl
+++ b/custom-idl/uievents.idl
@@ -34,6 +34,7 @@ partial interface WheelEvent {
   readonly attribute long wheelDelta;
 };
 
-partial interface Window {
-  attribute object WebKitMutationObserver;
+[Exposed=Window]
+interface WebKitMutationObserver {
+  constructor(MutationCallback callback);
 };

--- a/custom-idl/webaudio.idl
+++ b/custom-idl/webaudio.idl
@@ -74,8 +74,16 @@ partial interface PannerNode {
   undefined setVelocity(float x, float y, float z);
 };
 
-partial interface Window {
-  attribute object webkitAudioContext;
-  attribute object webkitAudioPannerNode;
-  attribute object webkitOfflineAudioContext;
+[Exposed=Window]
+interface webkitAudioContext : EventTarget {
+  constructor();
+};
+
+[Exposed=Window]
+interface webkitOfflineAudioContext : webkitAudioContext {
+  constructor(unsigned long numberOfChannels, unsigned long length, float sampleRate);
+};
+
+[Exposed=Window]
+interface webkitAudioPannerNode : AudioNode {
 };

--- a/custom-idl/webrtc.idl
+++ b/custom-idl/webrtc.idl
@@ -12,6 +12,7 @@ partial interface RTCPeerConnection {
   attribute EventHandler onremovestream;
 };
 
-partial interface Window {
-  attribute object webkitRTCPeerConnection;
+[Exposed=Window]
+interface webkitRTCPeerConnection {
+  constructor();
 };


### PR DESCRIPTION
This was a bit inconsistent, with some things using partial interface
Window and others using interfaces. Use interfaces consistently where
it's a matter of an alias, more like what we've been doing for members.
This also makes it possible to test the constructors separately.