### PR TITLE
Update webref IDL

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -7143,8 +7143,8 @@
       "dev": true
     },
     "webref": {
-      "version": "github:foolip/webref#11f6436fde86d1e2be2d95e0fb901f2c82c0660d",
-      "from": "github:foolip/webref#mdn-bcd-updater-fixes-3",
+      "version": "github:foolip/webref#5efcbaf01a1cc517b4ca5d3e9747348026d7e2bb",
+      "from": "github:foolip/webref#mdn-bcd-updater-fixes-4",
       "dev": true
     },
     "which": {

--- a/package.json
+++ b/package.json
@@ -81,6 +81,6 @@
     "selenium-webdriver": "3.6.0",
     "sinon": "9.2.4",
     "webidl2": "23.13.0",
-    "webref": "github:foolip/webref#mdn-bcd-updater-fixes-3"
+    "webref": "github:foolip/webref#mdn-bcd-updater-fixes-4"
   }
 }


### PR DESCRIPTION
This results in these new tests:
api.DataCue
api.DataCue.DataCue
api.DataCue.type
api.DataCue.value
api.GPUDevice.createComputePipelineAsync
api.GPUDevice.createRenderPipelineAsync
api.GPUDevice.queue

Some api.GPUDevice.* tests are also removed.