### PR TITLE
IE 5.5 no longer supported

### DIFF
--- a/views/index.ejs
+++ b/views/index.ejs
@@ -46,7 +46,7 @@
     </div>
     <div class="compat-table-separator"></div>
     <div class="compat-table-entry">
-      <img src="/browser-logos/ie.png" /><p>Internet Explorer 5.5+</p>
+      <img src="/browser-logos/ie.png" /><p>Internet Explorer 6+</p>
     </div>
     <div class="compat-table-entry">
       <img src="/browser-logos/opera.png" /><p>Opera 9.5+</p>


### PR DESCRIPTION
Apparently IE 5.5 is no longer supported...ah well!  This is a quickie to update the compat table on the front.﻿
