### PR TITLE
Get spec IDL from the new @webref/idl package

### DIFF
--- a/custom-idl/file-system-api.idl
+++ b/custom-idl/file-system-api.idl
@@ -47,7 +47,7 @@ partial interface FileSystemEntry {
   undefined moveTo(FileSystemDirectoryEntry parent, optional DOMString name, optional FileSystemEntryCallback successCallback, optional ErrorCallback errorCallback);
   undefined copyTo(FileSystemDirectoryEntry parent, optional DOMString name, optional FileSystemEntryCallback successCallback, optional ErrorCallback errorCallback);
   DOMString toURL();
-  undefined remove(undefinedFunction successCallback, optional ErrorCallback errorCallback);
+  undefined remove(VoidFunction successCallback, optional ErrorCallback errorCallback);
 };
 
 partial interface FileSystemFileEntry {
@@ -68,7 +68,7 @@ interface DirectoryEntry {
   DirectoryReader createReader();
   undefined getFile(DOMString path, optional FileSystemFlags options, optional FileSystemEntryCallback successCallback, optional ErrorCallback errorCallback);
   undefined getDirectory(DOMString path, optional FileSystemFlags options, optional FileSystemEntryCallback successCallback, optional ErrorCallback errorCallback);
-  undefined removeRecursively(undefinedFunction successCallback, optional ErrorCallback errorCallback);
+  undefined removeRecursively(VoidFunction successCallback, optional ErrorCallback errorCallback);
 };
 
 [Exposed=Window,Worker]

--- a/custom-idl/html.idl
+++ b/custom-idl/html.idl
@@ -312,7 +312,7 @@ partial interface HTMLButtonElement {
 
 partial interface HTMLCanvasElement {
   // https://developer.mozilla.org/en-US/docs/Web/API/HTMLCanvasElement/mozFetchAsStream
-  undefined mozFetchAsStream(undefinedFunction callback, optional DOMString type = "image/png");
+  undefined mozFetchAsStream(VoidFunction callback, optional DOMString type = "image/png");
   // https://developer.mozilla.org/en-US/docs/Web/API/HTMLCanvasElement/mozGetAsFile
   File mozGetAsFile(DOMString name, optional DOMString type = "image/png");
   // https://developer.mozilla.org/en-US/docs/Web/API/HTMLCanvasElement/mozOpaque

--- a/package-lock.json
+++ b/package-lock.json
@@ -1000,6 +1000,12 @@
       "integrity": "sha512-sL/cEvJWAnClXw0wHk85/2L0G6Sj8UB0Ctc1TEMbKSsmpRosqhwj9gWgFRZSrBr2f9tiXISwNhCPmlfqUqyb9Q==",
       "dev": true
     },
+    "@webref/idl": {
+      "version": "1.0.1",
+      "resolved": "https://registry.npmjs.org/@webref/idl/-/idl-1.0.1.tgz",
+      "integrity": "sha512-UUJbYVtFmx5lLdYohQrGJGAtWgwXKYxWvz1kJeH5ClhN0Z03QRxfi/CKQnxMK0dhGgG73wUl4CL17UKnpRmedw==",
+      "dev": true
+    },
     "abbrev": {
       "version": "1.1.1",
       "resolved": "https://registry.npmjs.org/abbrev/-/abbrev-1.1.1.tgz",

--- a/package.json
+++ b/package.json
@@ -55,6 +55,7 @@
     "@browser-logos/internet-explorer_9-11": "1.1.15",
     "@browser-logos/opera": "1.1.11",
     "@browser-logos/safari": "2.0.0",
+    "@webref/idl": "1.0.1",
     "babel-eslint": "10.1.0",
     "chai": "4.3.0",
     "chai-fs": "2.0.0",

--- a/unittest/unit/build.js
+++ b/unittest/unit/build.js
@@ -818,9 +818,18 @@ describe('build', () => {
   });
 
   it('buildIDL', () => {
-    const specData = require('../../spec-data');
-    assert.typeOf(buildIDL(specData.webref.idl, specData.custom.idl), 'object');
-  }).timeout(5000);
+    const specIDLs = {
+      first: WebIDL2.parse(`interface DOMError {};`),
+      second: WebIDL2.parse(`interface XSLTProcessor {};`)
+    };
+
+    const customIDLs = {
+      second: WebIDL2.parse(`partial interface XSLTProcessor { undefined reset(); };`)
+    };
+
+    const tests = buildIDL(specIDLs, customIDLs);
+    assert.containsAllKeys(tests, ['api.XSLTProcessor.reset']);
+  });
 
   describe('flattenIDL', () => {
     const customIDLs = {
@@ -1881,63 +1890,6 @@ describe('build', () => {
       expect(() => {
         validateIDL(ast);
       }).to.not.throw();
-    });
-
-    it('no members', () => {
-      const ast = WebIDL2.parse(`interface Node {};`);
-      expect(() => {
-        validateIDL(ast);
-      }).to.not.throw();
-    });
-
-    it('overloaded operator', () => {
-      const ast = WebIDL2.parse(`interface Node {
-        boolean contains(Node otherNode);
-        boolean contains(Node otherNode, boolean deepEqual);
-      };`);
-      expect(() => {
-        validateIDL(ast);
-      }).to.not.throw();
-    });
-
-    it('nameless member', () => {
-      const ast = WebIDL2.parse(`interface Node {
-        iterable<Node>;
-      };`);
-      expect(() => {
-        validateIDL(ast);
-      }).to.not.throw();
-    });
-
-    /* Remove when issues are resolved spec-side */
-    it('allowed duplicates', () => {
-      const ast = WebIDL2.parse(`interface SVGAElement {
-        attribute DOMString href;
-        attribute DOMString href;
-      };
-
-      interface WebGLRenderingContext {
-        attribute object canvas;
-        attribute object canvas;
-      };
-
-      interface WebGL2RenderingContext {
-        attribute object canvas;
-        attribute object canvas;
-      };`);
-      expect(() => {
-        validateIDL(ast);
-      }).to.not.throw();
-    });
-
-    it('disallowed duplicates', () => {
-      const ast = WebIDL2.parse(`interface Node {
-        attribute DOMString type;
-        attribute DOMString type;
-      };`);
-      expect(() => {
-        validateIDL(ast);
-      }).to.throw();
     });
 
     it('unknown types', () => {


### PR DESCRIPTION
- Drop validation now done by webref tests
- Simplify the buildIDL test to a very basic smoke test.
- webref is still needed for CSS definitions, so is left in for now.

This also reverts the accidental `undefinedFunction` from #675.