### PR TITLE
Add missing "audioContext" dependency for custom Web Audio tests

### DIFF
--- a/custom-tests.json
+++ b/custom-tests.json
@@ -86,9 +86,11 @@
       "__base": "if (!reusableInstances.audioContext) {return false;} var instance = reusableInstances.audioContext.createAnalyser();"
     },
     "AudioParam": {
+      "__resources": ["audioContext"],
       "__base": "<%api.GainNode:gainNode%> var instance = gainNode.gain;"
     },
     "AudioParamMap": {
+      "__resources": ["audioContext"],
       "__base": "<%api.AudioWorkletNode:worklet%> promise.then(function(worklet) {return worklet.parameters});"
     },
     "AudioTrack": {
@@ -849,6 +851,7 @@
       "__base": "var instance = window.screen;"
     },
     "ScriptProcessorNode": {
+      "__resources": ["audioContext"],
       "__base": "if (!reusableInstances.audioContext) {return false;} var instance = reusableInstances.audioContext.createProcessor();"
     },
     "Selection": {


### PR DESCRIPTION
The tests for AudioParam/AudioParamMap/ScriptProcessorNode return all
false because reusableInstances.audioContext isn't created.