### PR TITLE
Fix some custom Web Audio API tests

### DIFF
--- a/custom-tests.json
+++ b/custom-tests.json
@@ -86,10 +86,8 @@
       "__base": "if (!reusableInstances.audioContext) {return false;} var instance = reusableInstances.audioContext.createAnalyser();"
     },
     "AudioParam": {
+      "__resources": ["audioContext"],
       "__base": "<%api.GainNode:gainNode%> var instance = gainNode.gain;"
-    },
-    "AudioParamMap": {
-      "__base": "<%api.AudioWorkletNode:worklet%> promise.then(function(worklet) {return worklet.parameters});"
     },
     "AudioTrack": {
       "__resources": ["audio-blip"],
@@ -849,7 +847,8 @@
       "__base": "var instance = window.screen;"
     },
     "ScriptProcessorNode": {
-      "__base": "if (!reusableInstances.audioContext) {return false;} var instance = reusableInstances.audioContext.createProcessor();"
+      "__resources": ["audioContext"],
+      "__base": "if (!reusableInstances.audioContext) {return false;} var instance = reusableInstances.audioContext.createScriptProcessor();"
     },
     "Selection": {
       "__base": "var instance = window.getSelection();"


### PR DESCRIPTION
The tests for AudioParam/AudioParamMap/ScriptProcessorNode return all
false because reusableInstances.audioContext isn't created.

Add the missing dependency and fix the .createScriptProcessor() call.

The AudioParamMap test would be work to fix, so remove it to get
prototype tests for now.