### PR TITLE
Bump @webref/idl and webidl2

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -1000,9 +1000,9 @@
       "dev": true
     },
     "@webref/idl": {
-      "version": "1.0.1",
-      "resolved": "https://registry.npmjs.org/@webref/idl/-/idl-1.0.1.tgz",
-      "integrity": "sha512-UUJbYVtFmx5lLdYohQrGJGAtWgwXKYxWvz1kJeH5ClhN0Z03QRxfi/CKQnxMK0dhGgG73wUl4CL17UKnpRmedw==",
+      "version": "1.0.2",
+      "resolved": "https://registry.npmjs.org/@webref/idl/-/idl-1.0.2.tgz",
+      "integrity": "sha512-7vSiJs9+Tj+yHYN9HyjlmwN0a2VPLjHCqKuMYPfrq1mH8SxS7q6t8mJz1VDPCCHiLxwVAtSmI3Y7qc8Zou6SKg==",
       "dev": true
     },
     "abbrev": {
@@ -7190,9 +7190,9 @@
       "integrity": "sha1-IpnwLG3tMNSllhsLn3RSShj2NPw="
     },
     "webidl2": {
-      "version": "23.13.0",
-      "resolved": "https://registry.npmjs.org/webidl2/-/webidl2-23.13.0.tgz",
-      "integrity": "sha512-YfBvnpujLVLZ1zKP/aZO1XOtFhMUMFSnXjp88Q4iTMC/i1MUiv7YWq45SN8DrPHCjmnXhzjBouG0tJKg/+o0lg==",
+      "version": "23.13.1",
+      "resolved": "https://registry.npmjs.org/webidl2/-/webidl2-23.13.1.tgz",
+      "integrity": "sha512-u5njf3ZyqPr/4K8D6Cxm3B6MwSgwAdtrzxqHklwKaUdP1aQTmtKN5b65k4wlweJ/pRM6fpKUKYz8RlCJ9tka+w==",
       "dev": true
     },
     "webref": {

--- a/package.json
+++ b/package.json
@@ -55,7 +55,7 @@
     "@browser-logos/internet-explorer_9-11": "1.1.15",
     "@browser-logos/opera": "1.1.11",
     "@browser-logos/safari": "2.0.0",
-    "@webref/idl": "1.0.1",
+    "@webref/idl": "1.0.2",
     "babel-eslint": "10.1.0",
     "chai": "4.3.0",
     "chai-fs": "2.0.0",
@@ -81,7 +81,7 @@
     "puppeteer-to-istanbul": "1.4.0",
     "selenium-webdriver": "3.6.0",
     "sinon": "9.2.4",
-    "webidl2": "23.13.0",
+    "webidl2": "23.13.1",
     "webref": "github:foolip/webref#mdn-bcd-updater-fixes-4"
   }
 }


### PR DESCRIPTION
The only change in generated tests is that EncodedAudioChunk tests are
run in workers too.