### PR TITLE
Send no response for /api/results

### DIFF
--- a/app.js
+++ b/app.js
@@ -115,10 +115,8 @@ app.post('/api/results', (req, res, next) => {
     return;
   }
 
-  const response = {};
-
   storage.put(req.sessionID, forURL, req.body).then(() => {
-    res.status(201).json(response);
+    res.status(201).end();
   }).catch(next);
 });
 

--- a/unittest/app/app.js
+++ b/unittest/app/app.js
@@ -66,7 +66,7 @@ describe('/api/results', () => {
         .query({for: testURL})
         .send({x: 1});
     assert.equal(res.status, 201);
-    assert.deepEqual(res.body, {});
+    assert.equal(res.text, '');
   });
 
   it('list results after valid', async () => {


### PR DESCRIPTION
This isn't documented in DESIGN.md and isn't useful at all.