### PR TITLE
Validate the payloads sent to /api/results

### DIFF
--- a/DESIGN.md
+++ b/DESIGN.md
@@ -218,7 +218,26 @@ POST /api/results
 ```
 
 The `Content-Type` should be `application/json` and the post body should be
-the JSON results with a test-defined structure.
+an array of test results:
+
+```json
+[
+  {
+    "name": "api.Attr",
+    "exposure": "Window",
+    "result": true
+  },
+  {
+    "name": "api.Blob",
+    "exposure": "Worker",
+    "result": null,
+    "message": "[exception message]"
+  }
+]
+```
+
+Status `400 Bad Request` is returned if the results do not match the expected
+format.
 
 #### Parameters
 

--- a/app.js
+++ b/app.js
@@ -24,6 +24,7 @@ const uniqueString = require('unique-string');
 const expressLayouts = require('express-ejs-layouts');
 
 const logger = require('./logger');
+const {parseResults} = require('./results');
 const storage = require('./storage').getStorage();
 const {parseUA} = require('./ua-parser');
 
@@ -103,19 +104,20 @@ app.post('/api/get', (req, res) => {
 
 app.post('/api/results', (req, res, next) => {
   if (!req.is('json')) {
-    res.status(400).end();
+    res.status(400).send('body should be JSON');
     return;
   }
 
-  let forURL;
+  let url;
+  let results;
   try {
-    forURL = new URL(req.query.for).toString();
-  } catch (err) {
-    res.status(400).end();
+    [url, results] = parseResults(req.query.for, req.body);
+  } catch (e) {
+    res.status(400).send(e.message);
     return;
   }
 
-  storage.put(req.sessionID, forURL, req.body).then(() => {
+  storage.put(req.sessionID, url, results).then(() => {
     res.status(201).end();
   }).catch(next);
 });

--- a/results.js
+++ b/results.js
@@ -1,0 +1,63 @@
+// Copyright 2021 Google LLC
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//     https://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+'use strict';
+
+const parseShortString = (value, desc) => {
+  if (typeof value !== 'string' || value.length > 1000) {
+    throw new Error(`${desc} should be a short string`);
+  }
+  return value;
+};
+
+// Parse a results payload from the client into a structure that only contains
+// the expected data and does not contain any long strings.
+const parseResults = (url, results) => {
+  try {
+    url = new URL(url).toString();
+  } catch (e) {
+    throw new Error('invalid URL');
+  }
+
+  if (!Array.isArray(results)) {
+    throw new Error('results should be an array');
+  }
+
+  results = results.map((v, i) => {
+    if (!v || typeof v !== 'object') {
+      throw new Error(`results[${i}] should be an object`);
+    }
+    const copy = {};
+    copy.name = parseShortString(v.name, `results[${i}].name`);
+    if (![true, false, null].includes(v.result)) {
+      throw new Error(`results[${i}].result should be true/false/null`);
+    }
+    copy.result = v.result;
+    if (v.result === null) {
+      copy.message = parseShortString(v.message, `results[${i}].message`);
+    }
+    // Copy exposure either from |v.exposure| or |v.info.exposure|.
+    if (v.info) {
+      copy.exposure = parseShortString(v.info.exposure, `results[${i}].info.exposure`);
+      // Don't copy |v.info.code|.
+    } else {
+      copy.exposure = parseShortString(v.exposure, `results[${i}].exposure`);
+    }
+    return copy;
+  });
+
+  return [url, results];
+};
+
+module.exports = {parseResults};

--- a/unittest/app/app.js
+++ b/unittest/app/app.js
@@ -56,15 +56,32 @@ describe('/api/results', () => {
   const testURL = `http://localhost:8080/tests/api`;
   const testURL2 = `https://host.test/tests/css`;
 
+  const testResults = [
+    {
+      exposure: 'Worker',
+      name: 'api.Blob',
+      result: false
+    }
+  ];
+
+  const modifiedResults = [
+    {
+      exposure: 'Worker',
+      name: 'api.Blob',
+      result: true
+    }
+  ];
+
   it('GitHub export, no results', async () => {
     const res = await agent.post('/api/results/export/github').send();
     assert.equal(res.status, 412);
   });
 
+
   it('submit valid results', async () => {
     const res = await agent.post('/api/results')
         .query({for: testURL})
-        .send({x: 1});
+        .send(testResults);
     assert.equal(res.status, 201);
     assert.equal(res.text, '');
   });
@@ -74,15 +91,15 @@ describe('/api/results', () => {
     assert.equal(res.status, 200);
     assert.deepEqual(res.body, {
       __version: version,
-      results: {[testURL]: {x: 1}},
+      results: {[testURL]: testResults},
       userAgent: userAgent
     });
   });
 
-  it('submit duplicate results', async () => {
+  it('submit modified results', async () => {
     const res = await agent.post('/api/results')
         .query({for: testURL})
-        .send({x: 2});
+        .send(modifiedResults);
     assert.equal(res.status, 201);
   });
 
@@ -91,7 +108,7 @@ describe('/api/results', () => {
     assert.equal(res.status, 200);
     assert.deepEqual(res.body, {
       __version: version,
-      results: {[testURL]: {x: 2}},
+      results: {[testURL]: modifiedResults},
       userAgent: userAgent
     });
   });
@@ -99,9 +116,9 @@ describe('/api/results', () => {
   it('submit valid results for new URL', async () => {
     const res = await agent.post('/api/results')
         .query({for: testURL2})
-        .send({y: 3});
+        .send(testResults);
     assert.equal(res.status, 201);
-    assert.deepEqual(res.body, {});
+    assert.deepEqual(res.text, '');
   });
 
   it('list results after new valid', async () => {
@@ -109,7 +126,7 @@ describe('/api/results', () => {
     assert.equal(res.status, 200);
     assert.deepEqual(res.body, {
       __version: version,
-      results: {[testURL]: {x: 2}, [testURL2]: {y: 3}},
+      results: {[testURL]: modifiedResults, [testURL2]: testResults},
       userAgent: userAgent
     });
   });

--- a/unittest/unit/results.js
+++ b/unittest/unit/results.js
@@ -1,0 +1,138 @@
+// Copyright 2021 Google LLC
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//     https://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+'use strict';
+
+const assert = require('chai').assert;
+
+const {parseResults} = require('../../results');
+
+describe('results', () => {
+  describe('parseResults', () => {
+    it('happy path', () => {
+      const [url, results] = parseResults('http://localhost', [
+        {
+          exposure: 'Window',
+          name: 'api.Attr.name',
+          result: true,
+          message: 'ignored',
+          extra_stuff: 'ignored'
+        }
+      ]);
+      assert.equal(url, 'http://localhost/'); // normalized
+      assert.deepEqual(results, [
+        {
+          exposure: 'Window',
+          name: 'api.Attr.name',
+          result: true
+        }
+      ]);
+    });
+
+    it('flattening of exposure', () => {
+      const [_, results] = parseResults('http://localhost', [
+        {
+          info: {
+            code: 'ignored',
+            exposure: 'Window'
+          },
+          name: 'api.Attr.localName',
+          result: false,
+          message: 'ignored'
+        }
+      ]);
+      assert.deepEqual(results, [
+        {
+          exposure: 'Window',
+          name: 'api.Attr.localName',
+          result: false
+        }
+      ]);
+    });
+
+    it('with message', () => {
+      const [_, results] = parseResults('http://localhost', [
+        {
+          exposure: 'Window',
+          name: 'api.Attr.name',
+          result: null,
+          message: 'bad thing happened'
+        }
+      ]);
+      assert.deepEqual(results, [
+        {
+          exposure: 'Window',
+          name: 'api.Attr.name',
+          result: null,
+          message: 'bad thing happened'
+        }
+      ]);
+    });
+
+    it('invalid URL', () => {
+      assert.throws(() => {
+        parseResults('not a URL', []);
+      }, Error, 'invalid URL');
+    });
+
+    it('invalid results', () => {
+      assert.throws(() => {
+        parseResults('http://localhost', null);
+      }, Error, 'results should be an array');
+    });
+
+    it('invalid results entry', () => {
+      assert.throws(() => {
+        parseResults('http://localhost', [null]);
+      }, Error, 'results[0] should be an object');
+    });
+
+
+    it('invalid name', () => {
+      assert.throws(() => {
+        parseResults('http://localhost', [
+          {
+            exposure: 'Window',
+            name: 42,
+            result: true
+          }
+        ]);
+      }, Error, 'results[0].name should be a short string');
+    });
+
+    it('invalid result', () => {
+      assert.throws(() => {
+        parseResults('http://localhost', [
+          {
+            exposure: 'Window',
+            name: 'api.Attr.name',
+            result: 42
+          }
+        ]);
+      }, Error, 'results[0].result should be true/false/null');
+    });
+
+    it('invalid exposure', () => {
+      assert.throws(() => {
+        parseResults('http://localhost', [
+          {
+            exposure: 42,
+            name: 'api.Attr.name',
+            result: true
+          }
+        ]);
+      }, Error, 'results[0].exposure should be a short string');
+    });
+  });
+});


### PR DESCRIPTION
This is in preparation for exposing the results as a URL available to
another client (Selenium). It should be difficult to store arbitrary
data in the service to make it unattractive for abuse.

This also modifies the results format, notably dropping the code.