### PR TITLE
Remove copyright notices from HTML files

### DIFF
--- a/static/unittest/index.html
+++ b/static/unittest/index.html
@@ -1,13 +1,6 @@
 <!DOCTYPE html>
 <html>
 <head>
-<!--Copyright 2020 Google LLC
-
-Licensed under the Apache License, Version 2.0 (the "License"); you may not use this file except in compliance with the License. You may obtain a copy of the License at
-
-     https://www.apache.org/licenses/LICENSE-2.0
-
-Unless required by applicable law or agreed to in writing, software distributed under the License is distributed on an "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied. See the License for the specific language governing permissions and limitations under the License.-->
 <meta charset="utf-8">
 <meta name="viewport" content="width=device-width">
 <script src="/resources/json3.min.js"></script>

--- a/views/layout.ejs
+++ b/views/layout.ejs
@@ -1,13 +1,6 @@
 <!DOCTYPE html>
 <html>
   <head>
-    <!--Copyright 2020 Google LLC
-
-    Licensed under the Apache License, Version 2.0 (the "License"); you may not use this file except in compliance with the License. You may obtain a copy of the License at
-
-         https://www.apache.org/licenses/LICENSE-2.0
-
-    Unless required by applicable law or agreed to in writing, software distributed under the License is distributed on an "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied. See the License for the specific language governing permissions and limitations under the License.-->
     <meta charset="utf-8">
     <meta http-equiv="Content-Type" content="text/html; charset=utf-8">
     <meta http-equiv="X-UA-Compatible" content="IE=edge,chrome=1">


### PR DESCRIPTION
Large comments before <meta charset="utf-8"> risks breaking it:
https://hsivonen.fi/label-utf-8/