### PR TITLE
Increase Selenium timeouts to 30s

### DIFF
--- a/selenium.js
+++ b/selenium.js
@@ -256,7 +256,7 @@ const run = async (browser, version, os, ctx, task) => {
     await driver.wait(until.elementLocated(By.id('status')), 30000);
     statusEl = await driver.findElement(By.id('status'));
     try {
-      await driver.wait(until.elementTextContains(statusEl, 'uploaded'), 30000);
+      await driver.wait(until.elementTextContains(statusEl, 'uploaded'), 45000);
     } catch (e) {
       if (e.name == 'TimeoutError') {
         throw new Error('Timed out waiting for results to upload');

--- a/selenium.js
+++ b/selenium.js
@@ -192,7 +192,7 @@ const awaitPageReady = async (driver) => {
   await driver.wait(() => {
     return driver.executeScript('return document.readyState')
         .then((readyState) => (readyState === 'complete'));
-  }, 15000);
+  }, 30000);
   await driver.executeScript('return document.readyState');
 };
 
@@ -253,10 +253,10 @@ const run = async (browser, version, os, ctx, task) => {
     log(task, 'Running tests...');
     await awaitPage(driver, browser, version, `${host}/tests/${getvars}`);
 
-    await driver.wait(until.elementLocated(By.id('status')), 5000);
+    await driver.wait(until.elementLocated(By.id('status')), 30000);
     statusEl = await driver.findElement(By.id('status'));
     try {
-      await driver.wait(until.elementTextContains(statusEl, 'uploaded'), 45000);
+      await driver.wait(until.elementTextContains(statusEl, 'uploaded'), 30000);
     } catch (e) {
       if (e.name == 'TimeoutError') {
         throw new Error('Timed out waiting for results to upload');


### PR DESCRIPTION
When running this script timeouts are pretty common. Especially the 5s
timeout seems problematic, since the main thread might be blocked
running the tests at that point.