### PR TITLE
Avoid calling getUserMedia() in custom tests

### DIFF
--- a/custom-tests.json
+++ b/custom-tests.json
@@ -661,9 +661,6 @@
       "__resources": ["image-black"],
       "__base": "var instance = createImageBitmap(document.getElementById('resource-image-black'));"
     },
-    "ImageCapture": {
-      "__base": "<%api.MediaStreamTrack:track%> var promise = track.then(function(t) {return new ImageCapture(t);});"
-    },
     "ImageData": {
       "__base": "<%api.CanvasRenderingContext2D:ctx%> var instance = ctx.createImageData(16, 16);"
     },
@@ -701,23 +698,9 @@
       "__base": "var instance = new MediaSource();",
       "isTypeSupported": "return 'isTypeSupported' in MediaSource;"
     },
-    "MediaStream": {
-      "__base": "<%api.MediaDevices:mediaDevices%> var promise = mediaDevices.getUserMedia({audio: true, video: true}); promise.then(function() {});"
-    },
     "MediaStreamAudioDestinationNode": {
       "__resources": ["audioContext"],
       "__base": "if (!reusableInstances.audioContext) {return false;} var instance = reusableInstances.audioContext.createMediaStreamDestination();"
-    },
-    "MediaStreamAudioSourceNode": {
-      "__resources": ["audioContext"],
-      "__base": "<%api.MediaStream:mediaStream%> if (!reusableInstances.audioContext) {return false;} var promise = mediaStream.then(function(ms) {return reusableInstances.audioContext.createMediaStreamSource(ms)});"
-    },
-    "MediaStreamTrack": {
-      "__base": "<%api.MediaStream:mediaStream%> var promise = mediaStream.then(function(ms) {return ms.getVideoTracks()[0]});"
-    },
-    "MediaStreamTrackAudioSourceNode": {
-      "__resources": ["audioContext"],
-      "__base": "<%api.MediaStream:mediaStream%> if (!reusableInstances.audioContext) {return false;} var promise = mediaStream.then(function(ms) {return reusableInstances.audioContext.createMediaStreamTrackSource(ms)});"
     },
     "MessageChannel": {
       "__base": "if (!('MessageChannel' in self)) {return false;} var instance = new MessageChannel();"


### PR DESCRIPTION
This appears to be the cause of Edge 12-18 not working. This
unfortunately loses some good coverage, which perhaps should be brought
back when running tests manually but skipped in automation.