### PR TITLE
Move ignore (test filtering) logic into getTests

### DIFF
--- a/app.js
+++ b/app.js
@@ -179,13 +179,14 @@ app.all('/export', (req, res, next) => {
 
 app.all('/tests/*', (req, res) => {
   const ident = req.params['0'].replace(/\//g, '.');
-  const foundTests = tests.getTests(ident, req.query.exposure);
+  const ignoreIdents = req.query.ignore ?
+      req.query.ignore.split(',').filter((s) => s) : [];
+  const foundTests = tests.getTests(ident, req.query.exposure, ignoreIdents);
   if (foundTests && foundTests.length) {
     res.render('tests', {
       title: `${ident || 'All Tests'}`,
       tests: foundTests,
-      selenium: req.query.selenium,
-      ignore: (req.query.ignore ? req.query.ignore.split(',') : [])
+      selenium: req.query.selenium
     });
   } else {
     res.status(404).render('testnotfound', {

--- a/tests.js
+++ b/tests.js
@@ -56,7 +56,7 @@ class Tests {
     return didYouMean(input, this.listEndpoints());
   }
 
-  getTests(endpoint, testExposure) {
+  getTests(endpoint, testExposure, ignoreIdents = []) {
     if (!(endpoint in this.endpoints)) {
       return [];
     }
@@ -65,6 +65,12 @@ class Tests {
 
     const tests = [];
     for (const ident of idents) {
+      const ignore = ignoreIdents.some((ignoreIdent) => {
+        return ident === ignoreIdent || ident.startsWith(`${ignoreIdent}.`);
+      });
+      if (ignore) {
+        continue;
+      }
       const test = this.tests[ident];
       for (const exposure of test.exposure) {
         if (!testExposure || exposure == testExposure) {

--- a/unittest/unit/tests.js
+++ b/unittest/unit/tests.js
@@ -115,5 +115,21 @@ describe('Tests', () => {
         {ident: 'api.AbortController.signal', tests: [{code: '"AbortController" in self && "signal" in AbortController.prototype'}], exposure: 'Window', resources: {'audio-blip': {type: 'audio', src: '/media/blip.mp3'}}}
       ]);
     });
+
+    it('filtering out ignored tests', () => {
+      // Filter out a single test.
+      assert.deepEqual(tests.getTests('api', 'Window', ['api.AbortController.signal']), [
+        {ident: 'api.AbortController', tests: [{code: '"AbortController" in self'}], exposure: 'Window', resources: {}}
+      ]);
+
+      // Filter out a tests recursively.
+      assert.deepEqual(tests.getTests('api', 'Window', ['api.AbortController']), []);
+
+      // Matching prefix does not ignore a test.
+      assert.deepEqual(tests.getTests('api', 'Window', ['api.Abort']), [
+        {ident: 'api.AbortController', tests: [{code: '"AbortController" in self'}], exposure: 'Window', resources: {}},
+        {ident: 'api.AbortController.signal', tests: [{code: '"AbortController" in self && "signal" in AbortController.prototype'}], exposure: 'Window', resources: {'audio-blip': {type: 'audio', src: '/media/blip.mp3'}}}
+      ]);
+    });
   });
 });

--- a/views/tests.ejs
+++ b/views/tests.ejs
@@ -42,12 +42,7 @@
     .filter((item) => (item[1].type === 'instance'))) { %>
     bcd.addInstance("<%- instanceId %>", "<%- instance.src %>");
   <% }; %>
-  <% tests.filter((item) => {
-    for (const i of ignore) {
-      if (item.ident.indexOf(i) > -1) return false;
-    }
-    return true;
-  }).forEach(function(test) { %>
+  <% tests.forEach(function(test) { %>
     bcd.addTest("<%- test.ident %>", <%- JSON.stringify(test.tests) %>, "<%- test.exposure %>");
   <% }); %>
   window.onload = function() {


### PR DESCRIPTION
This makes it easier to test, and it's changed to be more strict than it
was before.