### PR TITLE
Restore getUserMedia() for custom tests and skip them in Edge 12-18

### DIFF
--- a/custom-tests.json
+++ b/custom-tests.json
@@ -661,6 +661,9 @@
       "__resources": ["image-black"],
       "__base": "var instance = createImageBitmap(document.getElementById('resource-image-black'));"
     },
+    "ImageCapture": {
+      "__base": "<%api.MediaStreamTrack:track%> var promise = track.then(function(t) {return new ImageCapture(t);});"
+    },
     "ImageData": {
       "__base": "<%api.CanvasRenderingContext2D:ctx%> var instance = ctx.createImageData(16, 16);"
     },
@@ -698,9 +701,23 @@
       "__base": "var instance = new MediaSource();",
       "isTypeSupported": "return 'isTypeSupported' in MediaSource;"
     },
+    "MediaStream": {
+      "__base": "<%api.MediaDevices:mediaDevices%> var promise = mediaDevices.getUserMedia({audio: true, video: true}); promise.then(function() {});"
+    },
     "MediaStreamAudioDestinationNode": {
       "__resources": ["audioContext"],
       "__base": "if (!reusableInstances.audioContext) {return false;} var instance = reusableInstances.audioContext.createMediaStreamDestination();"
+    },
+    "MediaStreamAudioSourceNode": {
+      "__resources": ["audioContext"],
+      "__base": "<%api.MediaStream:mediaStream%> if (!reusableInstances.audioContext) {return false;} var promise = mediaStream.then(function(ms) {return reusableInstances.audioContext.createMediaStreamSource(ms)});"
+    },
+    "MediaStreamTrack": {
+      "__base": "<%api.MediaStream:mediaStream%> var promise = mediaStream.then(function(ms) {return ms.getVideoTracks()[0]});"
+    },
+    "MediaStreamTrackAudioSourceNode": {
+      "__resources": ["audioContext"],
+      "__base": "<%api.MediaStream:mediaStream%> if (!reusableInstances.audioContext) {return false;} var promise = mediaStream.then(function(ms) {return reusableInstances.audioContext.createMediaStreamTrackSource(ms)});"
     },
     "MessageChannel": {
       "__base": "if (!('MessageChannel' in self)) {return false;} var instance = new MessageChannel();"

--- a/selenium.js
+++ b/selenium.js
@@ -36,10 +36,28 @@ const resultsDir = path.join(__dirname, '..', 'mdn-bcd-results');
 const testenv = process.env.NODE_ENV === 'test';
 const host = `https://${testenv ? 'staging-dot-' : ''}mdn-bcd-collector.appspot.com`;
 
+// Custom tests that use getUserMedia() make Edge 12-18 block.
+const gumTests = [
+  'ImageCapture',
+  'MediaStream',
+  'MediaStreamAudioSourceNode',
+  'MediaStreamTrack',
+  'MediaStreamTrackAudioSourceNode'
+].map((iface) => `api.${iface}`).join(',');
+
 const ignore = {
   chrome: {
     25: 'api.MediaStreamAudioDestinationNode',
     26: 'api.MediaStreamAudioDestinationNode'
+  },
+  edge: {
+    12: gumTests,
+    13: gumTests,
+    14: gumTests,
+    15: gumTests,
+    16: gumTests,
+    17: gumTests,
+    18: gumTests
   }
 };
 


### PR DESCRIPTION
This reverts https://github.com/foolip/mdn-bcd-collector/pull/1008.