### PR TITLE
Use a AudioBufferSourceNode instance to test AudioScheduledSourceNode

### DIFF
--- a/custom-tests.json
+++ b/custom-tests.json
@@ -89,6 +89,11 @@
       "__resources": ["audioContext"],
       "__base": "<%api.GainNode:gainNode%> var instance = gainNode.gain;"
     },
+    "AudioScheduledSourceNode": {
+      "__resources": ["audioContext"],
+      "__base": "if (!reusableInstances.audioContext) {return false;} var instance = reusableInstances.audioContext.createBufferSource();",
+      "__test": "return 'AudioScheduledSourceNode' in self"
+    },
     "AudioTrack": {
       "__resources": ["audio-blip"],
       "__base": "<%api.AudioTrackList:audioTracks%> var instance = audioTracks[0];"


### PR DESCRIPTION
AudioBufferSourceNode is as of as the Web Audio API itself, and will
do for testing if AudioScheduledSourceNode members were supported.