### PR TITLE
Make update-bcd more conservative about updating existing data

### DIFF
--- a/package.json
+++ b/package.json
@@ -67,7 +67,6 @@
     "eslint": "7.23.0",
     "eslint-config-google": "0.14.0",
     "eslint-plugin-prefer-arrow": "1.2.3",
-    "fast-deep-equal": "3.1.3",
     "fs-extra": "9.1.0",
     "json3": "3.3.3",
     "klaw": "3.0.0",

--- a/unittest/unit/update-bcd.js
+++ b/unittest/unit/update-bcd.js
@@ -634,7 +634,7 @@ describe('BCD updater', () => {
           AudioContext: {
             __compat: {support: {chrome: {version_added: '85'}}},
             close: {
-              __compat: {support: {}}
+              __compat: {support: {chrome: {version_added: '85'}}}
             }
           },
           DeprecatedInterface: {


### PR DESCRIPTION
The previous logic for finding a `simpleStatement` considered anything
with a `version_removed` to be non-simple, going down the code path of
adding entries unless an identical one already existed.

Instead, limit this case to when there were no existing statements, in
which case there's no merging of entries to worry about.

Defer dealing with multiple existing statements or multiple inferred
statements beyond the simple case of no existing statements.

The resulting edits suggest differ by quite a lot from the previous
state, overall updating fewer files.

Fixes https://github.com/foolip/mdn-bcd-collector/issues/1068.

https://github.com/foolip/mdn-bcd-collector/issues/875 is the plan for
catching differences in the data which cannot yet be fixed
automatically.