### PR TITLE
Check for all duplicates (not just operations) in mergeMembers

### DIFF
--- a/build.js
+++ b/build.js
@@ -186,16 +186,11 @@ const compileTest = (test) => {
 };
 
 const mergeMembers = (target, source) => {
-  // Check for operation overloads across partials/mixins.
-  const targetOperations = new Set();
-  for (const {type, name} of target.members) {
-    if (type === 'operation' && name) {
-      targetOperations.add(name);
-    }
-  }
-  for (const {type, name} of source.members) {
-    if (type === 'operation' && targetOperations.has(name)) {
-      throw new Error(`Operation overloading across partials/mixins for ${target.name}.${name}`);
+  // Check for duplicate members across partials/mixins.
+  const targetMembers = new Set(target.members.map((m) => m.name));
+  for (const member of source.members) {
+    if (targetMembers.has(member.name)) {
+      throw new Error(`Duplicate definition of ${target.name}.${member.name}`);
     }
   }
   // Now merge members.

--- a/custom-idl/dom.idl
+++ b/custom-idl/dom.idl
@@ -237,11 +237,7 @@ partial interface Range {
   short compareNode(Node node);
 };
 
-enum SlotAssignmentMode { "manual", "name" };
-
 partial interface ShadowRoot {
+  // https://github.com/whatwg/dom/issues/931
   readonly attribute boolean delegatesFocus;
-
-  // https://github.com/whatwg/dom/pull/860
-  readonly attribute SlotAssignmentMode slotAssignment;
 };

--- a/custom-idl/html.idl
+++ b/custom-idl/html.idl
@@ -690,8 +690,6 @@ partial interface Window {
   undefined minimize();
   attribute EventHandler onappinstalled;
   attribute EventHandler onbeforeinstallprompt;
-  attribute EventHandler ongamepadconnected;
-  attribute EventHandler ongamepaddisconnected;
   attribute EventHandler onpaint;
   undefined openDialog();
   attribute object pkcs11;

--- a/unittest/unit/build.js
+++ b/unittest/unit/build.js
@@ -704,7 +704,7 @@ describe('build', () => {
       };
       expect(() => {
         flattenIDL(specIDLs, customIDLs);
-      }).to.throw('Operation overloading across partials/mixins for CSS.supports');
+      }).to.throw('Duplicate definition of CSS.supports');
     });
 
     it('Partial missing main', () => {


### PR DESCRIPTION
A custom validation rule for this was removed in
https://github.com/foolip/mdn-bcd-collector/pull/959, but what remains
is insufficient to catch accidentally duplicated custom IDL.

Fix the duplicates that had crept in since then.