### PR TITLE
Update UA parser to handle old Android WebView versions

### DIFF
--- a/ua-parser.js
+++ b/ua-parser.js
@@ -36,6 +36,7 @@ const parseUA = (userAgent, browsers) => {
     case 'samsung_browser':
       data.browser.id = 'samsunginternet';
       break;
+    case 'android_browser':
     case 'chrome_webview':
       data.browser.id = 'webview';
       break;
@@ -48,7 +49,7 @@ const parseUA = (userAgent, browsers) => {
   }
 
   // https://github.com/mdn/browser-compat-data/blob/master/docs/data-guidelines.md#safari-for-ios-versioning
-  data.fullVersion = data.browser.id === 'safari_ios' ? ua.os.version : ua.browser.version;
+  data.fullVersion = (data.browser.id === 'safari_ios' || ua.browser.name === 'Android Browser') ? ua.os.version : ua.browser.version;
   data.version = getMajorMinorVersion(data.fullVersion);
 
   if (!(data.browser.id in browsers)) {


### PR DESCRIPTION
This PR updates the UA parser script to handle pre-Chromium Android WebView versions.  Whilst setting up my virtual machines, I noticed that the built-in browser has its own separate version from the Android OS version (which BCD uses), somewhat like Safari iOS/iPadOS.  With this PR, the UA parser will use the Android OS version for pre-Chromium WebView versions.﻿
