### PR TITLE
Avoid external URL in FontFace source

### DIFF
--- a/custom-tests.json
+++ b/custom-tests.json
@@ -332,7 +332,7 @@
       "__base": "var instance = window.external;"
     },
     "FontFace": {
-      "__base": "var instance = new FontFace('Roboto', 'https://fonts.googleapis.com/css2?family=Roboto&display=swap');"
+      "__base": "var instance = new FontFace('Material Design Icons', 'url(/fonts/materialdesignicons-webfont.woff)');"
     },
     "GainNode": {
       "__resources": ["audioContext"],


### PR DESCRIPTION
No fetch happens since load() isn't called, but this comes up when
looking for external URLs, so just replace it with a relative URL that
would work if actually fetched.