### PR TITLE
Test SVGElement using a <title> element instance

### DIFF
--- a/custom-tests.json
+++ b/custom-tests.json
@@ -989,7 +989,7 @@
       "__test": "return bcd.testObjectName(instance, 'SVGDiscardElement');"
     },
     "SVGElement": {
-      "__base": "var instance = document.createElementNS('http://www.w3.org/2000/svg', 'unknown');"
+      "__base": "var instance = document.createElementNS('http://www.w3.org/2000/svg', 'title');"
     },
     "SVGEllipseElement": {
       "__base": "var instance = document.createElementNS('http://www.w3.org/2000/svg', 'ellipse');",


### PR DESCRIPTION
Using "unknown" creates an Element instance on Edge 18 and possibly
other browsers. Instead use <title>, since it's as old as SVG itself,
and SVGTitleElement has no members of its own:
https://www.w3.org/TR/SVG10/struct.html#DescriptionAndTitleElements
https://svgwg.org/svg2-draft/struct.html#DescriptionAndTitleElements

Aside: That's impressive ID stability over the decades.