### PR TITLE
Get a DOMException instance from a thrown exception

### DIFF
--- a/custom-tests.json
+++ b/custom-tests.json
@@ -245,7 +245,7 @@
       "__base": "var instance = new DOMError('DOMError');"
     },
     "DOMException": {
-      "__base": "var instance = new DOMException('DOMException');"
+      "__base": "var instance = null; try { document.createElement('1'); } catch (e) { instance = e; }"
     },
     "DOMImplementation": {
       "__base": "var instance = document.implementation;"


### PR DESCRIPTION
The exception type was supported long before its constructor in some
browsers, so this is necessary to get the right data.