### PR TITLE
Add custom test for WebGLVertexArrayObjectOES API

### DIFF
--- a/custom-tests.json
+++ b/custom-tests.json
@@ -1451,6 +1451,10 @@
       "__resources": ["webGL"],
       "__base": "<%api.EXT_disjoint_timer_query:ext%> var instance = ext.createQueryEXT();"
     },
+    "WebGLVertexArrayObjectOES": {
+      "__resources": ["webGL1"],
+      "__base": "<%api.OES_vertex_array_object:ext%> var instance = ext.createVertexArrayOES();"
+    },
     "WebSocket": {
       "__base": "var instance = new WebSocket('wss://' + location.hostname);"
     },


### PR DESCRIPTION
This PR adds a custom test for the WebGLVertexArrayObjectOES API.  This was created in response to https://github.com/mdn/browser-compat-data/pull/10715.