### PR TITLE
Selenium: don't try to test Safari 14.0 in BrowserStack

### DIFF
--- a/selenium.js
+++ b/selenium.js
@@ -112,7 +112,7 @@ const buildDriver = async (browser, version, os) => {
         continue;
       }
 
-      if (browser === 'safari' && ['10', '11', '12', '13'].includes(version)) {
+      if (browser === 'safari' && ['10', '11', '12', '13', '14'].includes(version)) {
         // BrowserStack doesn't support the Safari x.0 versions
         continue;
       }


### PR DESCRIPTION
BrowserStack doesn't support Safari x.0 versions since Safari 10.  This PR updates the Selenium script to ensure that Safari 14.0 is run on SauceLabs instead.﻿
