### PR TITLE
Fix custom test for ProcessingInstruction API

### DIFF
--- a/custom-tests.json
+++ b/custom-tests.json
@@ -838,7 +838,7 @@
       "__base": "var instance = navigator.plugins;"
     },
     "ProcessingInstruction": {
-      "__base": "var instance = document.createProcessingInstruction('bcd', \"version='1.0' encoding='UTF-8'\");"
+      "__base": "var instance = document.createProcessingInstruction('xml-stylesheet', 'type=\"text/xsl\" href=\"transform.xsl\"');"
     },
     "Range": {
       "__base": "var instance = document.createRange();"

--- a/custom-tests.json
+++ b/custom-tests.json
@@ -838,7 +838,7 @@
       "__base": "var instance = navigator.plugins;"
     },
     "ProcessingInstruction": {
-      "__base": "var instance = document.createProcessingInstruction('xml', \"version='1.0' encoding='UTF-8'\");"
+      "__base": "var instance = document.createProcessingInstruction('bcd', \"version='1.0' encoding='UTF-8'\");"
     },
     "Range": {
       "__base": "var instance = document.createRange();"


### PR DESCRIPTION
This PR fixes an issue with the custom test for the `ProcessingInstruction` API.  When I initially wrote the custom test, I thought that it had to say `xml`, when in fact, it was the exact opposite.
