### PR TITLE
Release 3.1.5

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -1,6 +1,6 @@
 {
   "name": "mdn-bcd-collector",
-  "version": "3.1.4",
+  "version": "3.1.5",
   "lockfileVersion": 1,
   "requires": true,
   "dependencies": {

--- a/package.json
+++ b/package.json
@@ -1,7 +1,7 @@
 {
   "name": "mdn-bcd-collector",
   "description": "Data collection service for @mdn/browser-compat-data",
-  "version": "3.1.4",
+  "version": "3.1.5",
   "private": true,
   "license": "Apache-2.0",
   "repository": {


### PR DESCRIPTION
Notable changes:

https://github.com/foolip/mdn-bcd-collector/pull/1194
https://github.com/foolip/mdn-bcd-collector/pull/1195
https://github.com/foolip/mdn-bcd-collector/pull/1198
https://github.com/foolip/mdn-bcd-collector/pull/1203

Added tests:

api.GPUSupportedLimits
api.GPUSupportedLimits.maxBindGroups
api.GPUSupportedLimits.maxDynamicStorageBuffersPerPipelineLayout
api.GPUSupportedLimits.maxDynamicUniformBuffersPerPipelineLayout
api.GPUSupportedLimits.maxSampledTexturesPerShaderStage
api.GPUSupportedLimits.maxSamplersPerShaderStage
api.GPUSupportedLimits.maxStorageBufferBindingSize
api.GPUSupportedLimits.maxStorageBuffersPerShaderStage
api.GPUSupportedLimits.maxStorageTexturesPerShaderStage
api.GPUSupportedLimits.maxTextureArrayLayers
api.GPUSupportedLimits.maxTextureDimension1D
api.GPUSupportedLimits.maxTextureDimension2D
api.GPUSupportedLimits.maxTextureDimension3D
api.GPUSupportedLimits.maxUniformBufferBindingSize
api.GPUSupportedLimits.maxUniformBuffersPerShaderStage
api.GPUSupportedLimits.maxVertexAttributes
api.GPUSupportedLimits.maxVertexBufferArrayStride
api.GPUSupportedLimits.maxVertexBuffers

Removed tests:

api.GPUAdapterLimits
api.GPUAdapterLimits.maxBindGroups
api.GPUAdapterLimits.maxDynamicStorageBuffersPerPipelineLayout
api.GPUAdapterLimits.maxDynamicUniformBuffersPerPipelineLayout
api.GPUAdapterLimits.maxSampledTexturesPerShaderStage
api.GPUAdapterLimits.maxSamplersPerShaderStage
api.GPUAdapterLimits.maxStorageBufferBindingSize
api.GPUAdapterLimits.maxStorageBuffersPerShaderStage
api.GPUAdapterLimits.maxStorageTexturesPerShaderStage
api.GPUAdapterLimits.maxTextureArrayLayers
api.GPUAdapterLimits.maxTextureDimension1D
api.GPUAdapterLimits.maxTextureDimension2D
api.GPUAdapterLimits.maxTextureDimension3D
api.GPUAdapterLimits.maxUniformBufferBindingSize
api.GPUAdapterLimits.maxUniformBuffersPerShaderStage
api.GPUAdapterLimits.maxVertexAttributes
api.GPUAdapterLimits.maxVertexBufferArrayStride
api.GPUAdapterLimits.maxVertexBuffers