### PR TITLE
Always show form buttons, but disable by default

### DIFF
--- a/static/resources/harness.js
+++ b/static/resources/harness.js
@@ -578,7 +578,8 @@
         if (client.readyState == 4) {
           if (client.status >= 200 && client.status <= 299) {
             var form = document.getElementById('form');
-            form.innerHTML = '<input type=submit name=download value="Export for download"> <input type=submit name=github value="Export to GitHub">';
+            form.children[0].disabled = false;
+            form.children[1].disabled = false;
             updateStatus('Results uploaded.', 'success-notice');
           } else {
             updateStatus('Failed to upload results: server error.', 'error-notice');

--- a/static/resources/style.css
+++ b/static/resources/style.css
@@ -68,6 +68,7 @@ select:disabled, select:disabled:hover,
 input[type=submit]:disabled, input[type=submit]:disabled:hover {
   cursor: not-allowed;
   background-color: #636363;
+  color: #ccc;
 }
 
 input::placeholder {

--- a/views/tests.ejs
+++ b/views/tests.ejs
@@ -1,6 +1,9 @@
 <%- contentFor('body') %>
 <p id="status">Running tests...</p>
-<form id="form" action=/export method=post></form>
+<form id="form" action=/export method=post>
+  <input type=submit name=download value="Export for download" disabled>
+  <input type=submit name=github value="Export to GitHub" disabled>
+</form>
 <div id="results"></div>
 
 <% let resources = {}; %>


### PR DESCRIPTION
When running the tests, we have the code configured to add the DOM for the submit buttons once we've completed the tests.  However, this causes the elements to move down on the page, which has caused me to sometimes hit one of the export buttons when trying to expand the collapsed code.  This PR is intended to fix this issue by always keeping the buttons in the DOM, disabled by default, and then enable them when the tests are done.

Tested functional in: Chrome 15 + 91, Safari 4 + 14, Opera 12.1, Firefox 4 + 89, IE 6 + 11
