### PR TITLE
Remap Safari 4.1 -> 5 and 6.1/6.2 -> 7

### DIFF
--- a/ua-parser.js
+++ b/ua-parser.js
@@ -68,6 +68,33 @@ const parseUA = (userAgent, browsers) => {
   data.browser.name = browsers[data.browser.id].name;
   data.inBcd = false;
 
+  if (data.browser.id === 'safari') {
+    // Handle Safari backport versions
+    if (
+      compareVersions.compare(data.version, '4.1', '>=') &&
+      compareVersions.compare(data.version, '5', '<')
+    ) {
+      // Safari 4.1 is a backported version of Safari 5
+      // https://github.com/mdn/browser-compat-data/issues/4679
+
+      data.inBcd = true;
+      data.version = '5';
+      return data;
+    }
+
+    if (
+      compareVersions.compare(data.version, '6.1', '>=') &&
+      compareVersions.compare(data.version, '7', '<')
+    ) {
+      // Safari 6.1/6.2 are backported versions of Safari 7
+      // https://github.com/mdn/browser-compat-data/issues/9423
+
+      data.inBcd = true;
+      data.version = '7';
+      return data;
+    }
+  };
+
   const versions = Object.keys(browsers[data.browser.id].releases);
   versions.sort(compareVersions);
 


### PR DESCRIPTION
This PR adds some logic into the UA parser to remap Safari 4.1 to 5, as well as 6.1/6.2 to 7.  This is based upon determining that these releases are backported versions of the new major releases for older macOS systems.

More details for each in the following issues on BCD:
https://github.com/mdn/browser-compat-data/issues/4679 (Safari 4.1)
https://github.com/mdn/browser-compat-data/issues/9423 (Safari 6.1/6.2)
