### PR TITLE
Use window.toolbar as a BarProp instance

### DIFF
--- a/custom-tests.json
+++ b/custom-tests.json
@@ -113,6 +113,9 @@
       "__resources": ["audioContext"],
       "__base": "if (!reusableInstances.audioContext) {return false;} if (!reusableInstances.audioContext.audioWorklet) {return false;} var promise = reusableInstances.audioContext.audioWorklet.addModule('/resources/custom-tests/api/AudioWorkletNode/WhiteNoiseProcessor.js').then(function() {return new AudioWorkletNode(reusableInstances.audioContext, 'white-noise-processor')}); promise.then(function() {});"
     },
+    "BarProp": {
+      "__base": "var instance = window.toolbar;"
+    },
     "BaseAudioContext": {
       "__resources": ["audioContext"],
       "__base": "var instance = reusableInstances.audioContext;",


### PR DESCRIPTION
All of window.*bar are very old, but this one gets the most hits on
Google and appears in old documentation like this:
https://www.oreilly.com/library/view/pure-javascript/0672315475/0672315475_ch07lev2sec592.html