### PR TITLE
Use <b> as a HTMLElement instance (not HTMLUnknownElement)

### DIFF
--- a/custom-tests.json
+++ b/custom-tests.json
@@ -423,7 +423,7 @@
       "__base": "var instance = document;"
     },
     "HTMLElement": {
-      "__base": "var instance = document.createElement('element');"
+      "__base": "var instance = document.createElement('b');"
     },
     "HTMLEmbedElement": {
       "__base": "var instance = document.createElement('embed');",


### PR DESCRIPTION
It doesn't matter, but it's just as well to use a direct instance of the
interface under test when it's possible.