### PR TITLE
Selenium script updates

### DIFF
--- a/selenium.js
+++ b/selenium.js
@@ -153,6 +153,7 @@ const buildDriver = async (browser, version, os) => {
 
       capabilities.set(Capability.VERSION, version.split('.')[0]);
 
+      // Remap target OS for Safari x.0 vs. x.1 on SauceLabs
       if (service === 'saucelabs') {
         if (browser === 'safari') {
           capabilities.set('platform', getSafariOS(version));
@@ -178,6 +179,7 @@ const buildDriver = async (browser, version, os) => {
         }
       });
 
+      // Get console errors from browser 
       const loggingPrefs = new logging.Preferences();
       loggingPrefs.setLevel(logging.Type.BROWSER, logging.Level.SEVERE);
       capabilities.setLoggingPrefs(loggingPrefs);
@@ -186,6 +188,7 @@ const buildDriver = async (browser, version, os) => {
       }
 
       try {
+        // Build Selenium driver
         const driverBuilder = new Builder().usingServer(seleniumUrl)
             .withCapabilities(capabilities);
         const driver = await driverBuilder.build();

--- a/selenium.js
+++ b/selenium.js
@@ -147,13 +147,7 @@ const buildDriver = async (browser, version, os) => {
           Browser[browser.toUpperCase()]
       );
 
-      if (service === 'browserstack' &&
-          browser === 'safari' &&
-          version === '6.1') {
-        capabilities.set(Capability.VERSION, '6.2');
-      } else {
-        capabilities.set(Capability.VERSION, version.split('.')[0]);
-      }
+      capabilities.set(Capability.VERSION, version.split('.')[0]);
 
       if (service === 'saucelabs') {
         if (browser === 'safari') {

--- a/selenium.js
+++ b/selenium.js
@@ -301,13 +301,19 @@ const run = async (browser, version, os, ctx, task) => {
     await driver.wait(until.elementLocated(By.id('status')), 30000);
     statusEl = await driver.findElement(By.id('status'));
     try {
-      await driver.wait(until.elementTextContains(statusEl, 'uploaded'), 60000);
+      await driver.wait(until.elementTextContains(statusEl, 'upload'), 60000);
     } catch (e) {
       if (e.name == 'TimeoutError') {
         throw new Error(task.title + ' - ' + 'Timed out waiting for results to upload');
       }
 
       throw e;
+    }
+
+    const statusText = await statusEl.getText();
+
+    if (statusText.includes('Failed')) {
+      throw new Error(task.title + ' - ' + statusText);
     }
 
     log(task, 'Exporting results...');

--- a/selenium.js
+++ b/selenium.js
@@ -281,7 +281,7 @@ const run = async (browser, version, os, ctx, task) => {
 
   const driver = await buildDriver(browser, version, os);
   if (!driver) {
-    throw new Error(task.title + '-' + 'Browser/OS config unsupported');
+    throw new Error(task.title + ' - ' + 'Browser/OS config unsupported');
   }
 
   let statusEl;
@@ -304,7 +304,7 @@ const run = async (browser, version, os, ctx, task) => {
       await driver.wait(until.elementTextContains(statusEl, 'uploaded'), 60000);
     } catch (e) {
       if (e.name == 'TimeoutError') {
-        throw new Error(task.title + '-' + 'Timed out waiting for results to upload');
+        throw new Error(task.title + ' - ' + 'Timed out waiting for results to upload');
       }
 
       throw e;

--- a/selenium.js
+++ b/selenium.js
@@ -83,7 +83,9 @@ const filterVersions = (data, earliestVersion, reverse) => {
     }
   }
 
-  return versions.sort((a, b) => compareVersions(...(reverse ? [a, b] : [b, a])));
+  return versions.sort((a, b) => compareVersions(
+      ...(reverse ? [a, b] : [b, a])
+  ));
 };
 
 const getSafariOS = (version) => {
@@ -439,7 +441,9 @@ if (require.main === module) {
       }
   );
 
-  if (runAll(argv.browser, argv.os, argv.nonConcurrent, argv.reverse) === false) {
+  if (runAll(
+      argv.browser, argv.os, argv.nonConcurrent, argv.reverse
+  ) === false) {
     process.exit(1);
   }
 }

--- a/selenium.js
+++ b/selenium.js
@@ -184,6 +184,7 @@ const buildDriver = async (browser, version, os) => {
           }
         });
       } else if (browser === 'firefox') {
+        // XXX macOS Big Sur requires microphone permission via the OS...  BrowserStack bug?
         capabilities.set('moz:firefoxOptions', {
           prefs: {
             'permissions.default.microphone': 1,

--- a/selenium.js
+++ b/selenium.js
@@ -168,13 +168,13 @@ const buildDriver = async (browser, version, os) => {
 
       // Allow mic, camera, geolocation and notifications permissions
       capabilities.set('goog:chromeOptions', {
-        'args': [
-          "--use-fake-device-for-media-stream",
-          "--use-fake-ui-for-media-stream"
+        args: [
+          '--use-fake-device-for-media-stream',
+          '--use-fake-ui-for-media-stream'
         ],
-        "prefs": {
-          "profile.managed_default_content_settings.geolocation": 1,
-          "profile.managed_default_content_settings.notifications": 1,
+        prefs: {
+          'profile.managed_default_content_settings.geolocation': 1,
+          'profile.managed_default_content_settings.notifications': 1
         }
       });
 

--- a/selenium.js
+++ b/selenium.js
@@ -43,12 +43,12 @@ const gumTests = [
   'MediaStreamAudioSourceNode',
   'MediaStreamTrack',
   'MediaStreamTrackAudioSourceNode'
-].map((iface) => `api.${iface}`).join(',');
+].map((iface) => `api.${iface}`);
 
 const ignore = {
   chrome: {
-    25: 'api.MediaStreamAudioDestinationNode',
-    26: 'api.MediaStreamAudioDestinationNode'
+    25: ['api.MediaStreamAudioDestinationNode'],
+    26: ['api.MediaStreamAudioDestinationNode']
   },
   edge: {
     12: gumTests,
@@ -256,7 +256,7 @@ const run = async (browser, version, os, ctx, task) => {
   let statusEl;
 
   const ignorelist = ignore[browser] && ignore[browser][version];
-  const getvars = `?selenium=true${ignorelist ? `&ignore=${ignorelist}` : ''}`;
+  const getvars = `?selenium=true${ignorelist ? `&ignore=${ignorelist.join(',')}` : ''}`;
 
   try {
     log(task, 'Loading homepage...');

--- a/selenium.js
+++ b/selenium.js
@@ -83,7 +83,7 @@ const filterVersions = (data, earliestVersion) => {
     }
   }
 
-  return versions.sort((a, b) => compareVersions(b, a));
+  return versions;// .sort((a, b) => compareVersions(b, a));
 };
 
 const getSafariOS = (version) => {
@@ -192,10 +192,10 @@ const buildDriver = async (browser, version, os) => {
             'permissions.default.geo': 1,
             'permissions.default.desktop-notification': 1
           }
-        })
+        });
       }
 
-      // Get console errors from browser 
+      // Get console errors from browser
       const loggingPrefs = new logging.Preferences();
       loggingPrefs.setLevel(logging.Type.BROWSER, logging.Level.SEVERE);
       capabilities.setLoggingPrefs(loggingPrefs);

--- a/selenium.js
+++ b/selenium.js
@@ -269,7 +269,7 @@ const run = async (browser, version, os, ctx, task) => {
     await driver.wait(until.elementLocated(By.id('status')), 30000);
     statusEl = await driver.findElement(By.id('status'));
     try {
-      await driver.wait(until.elementTextContains(statusEl, 'uploaded'), 45000);
+      await driver.wait(until.elementTextContains(statusEl, 'uploaded'), 60000);
     } catch (e) {
       if (e.name == 'TimeoutError') {
         throw new Error('Timed out waiting for results to upload');

--- a/selenium.js
+++ b/selenium.js
@@ -185,9 +185,6 @@ const buildDriver = async (browser, version, os) => {
         });
       } else if (browser === 'firefox') {
         capabilities.set('moz:firefoxOptions', {
-          args: [
-            'use-fake-ui-for-media-stream'
-          ],
           prefs: {
             'permissions.default.microphone': 1,
             'permissions.default.camera': 1,

--- a/selenium.js
+++ b/selenium.js
@@ -184,7 +184,8 @@ const buildDriver = async (browser, version, os) => {
           }
         });
       } else if (browser === 'firefox') {
-        // XXX macOS Big Sur requires microphone permission via the OS...  BrowserStack bug?
+        // XXX macOS Big Sur requires microphone permission via the OS...
+        // BrowserStack bug?
         capabilities.set('moz:firefoxOptions', {
           prefs: {
             'permissions.default.microphone': 1,

--- a/selenium.js
+++ b/selenium.js
@@ -183,6 +183,18 @@ const buildDriver = async (browser, version, os) => {
             'profile.managed_default_content_settings.notifications': 1
           }
         });
+      } else if (browser === 'firefox') {
+        capabilities.set('moz:firefoxOptions', {
+          args: [
+            'use-fake-ui-for-media-stream'
+          ],
+          prefs: {
+            'permissions.default.microphone': 1,
+            'permissions.default.camera': 1,
+            'permissions.default.geo': 1,
+            'permissions.default.desktop-notification': 1
+          }
+        })
       }
 
       // Get console errors from browser 

--- a/selenium.js
+++ b/selenium.js
@@ -112,7 +112,11 @@ const buildDriver = async (browser, version, os) => {
         continue;
       }
 
-      if (browser === 'safari' && ['10', '11', '12', '13', '14'].includes(version)) {
+      if (
+        browser === 'safari' &&
+        version >= 10 &&
+        Math.round(version) == version
+      ) {
         // BrowserStack doesn't support the Safari x.0 versions
         continue;
       }

--- a/selenium.js
+++ b/selenium.js
@@ -188,6 +188,7 @@ const buildDriver = async (browser, version, os) => {
         // BrowserStack bug?
         capabilities.set('moz:firefoxOptions', {
           prefs: {
+            'media.navigator.permission.disabled': 1,
             'permissions.default.microphone': 1,
             'permissions.default.camera': 1,
             'permissions.default.geo': 1,

--- a/selenium.js
+++ b/selenium.js
@@ -83,7 +83,7 @@ const filterVersions = (data, earliestVersion) => {
     }
   }
 
-  return versions;// .sort((a, b) => compareVersions(b, a));
+  return versions.sort((a, b) => compareVersions(b, a));
 };
 
 const getSafariOS = (version) => {

--- a/selenium.js
+++ b/selenium.js
@@ -73,7 +73,7 @@ const log = (task, message) => {
   // task.output = new Date(Date.now()).toLocaleTimeString(undefined, {hour12: false}) + ': ' + message;
 };
 
-const filterVersions = (data, earliestVersion) => {
+const filterVersions = (data, earliestVersion, reverse) => {
   const versions = [];
 
   for (const [version, versionData] of Object.entries(data)) {
@@ -83,7 +83,7 @@ const filterVersions = (data, earliestVersion) => {
     }
   }
 
-  return versions.sort((a, b) => compareVersions(b, a));
+  return versions.sort((a, b) => compareVersions(...(reverse ? [a, b] : [b, a])));
 };
 
 const getSafariOS = (version) => {
@@ -332,7 +332,7 @@ const run = async (browser, version, os, ctx, task) => {
   }
 };
 
-const runAll = async (limitBrowsers, oses, nonConcurrent) => {
+const runAll = async (limitBrowsers, oses, nonConcurrent, reverse) => {
   if (!Object.keys(secrets.selenium).length) {
     console.error(chalk`{red.bold A Selenium remote WebDriver URL is not defined in secrets.json.  Please define your Selenium remote(s).}`);
     return false;
@@ -343,11 +343,11 @@ const runAll = async (limitBrowsers, oses, nonConcurrent) => {
   }
 
   let browsersToTest = {
-    chrome: filterVersions(bcdBrowsers.chrome.releases, '15'),
-    edge: filterVersions(bcdBrowsers.edge.releases, '12'),
-    firefox: filterVersions(bcdBrowsers.firefox.releases, '4'),
-    ie: filterVersions(bcdBrowsers.ie.releases, '6'),
-    safari: filterVersions(bcdBrowsers.safari.releases, '5.1')
+    chrome: filterVersions(bcdBrowsers.chrome.releases, '15', reverse),
+    edge: filterVersions(bcdBrowsers.edge.releases, '12', reverse),
+    firefox: filterVersions(bcdBrowsers.firefox.releases, '4', reverse),
+    ie: filterVersions(bcdBrowsers.ie.releases, '6', reverse),
+    safari: filterVersions(bcdBrowsers.safari.releases, '5.1', reverse)
   };
 
   if (limitBrowsers) {
@@ -429,11 +429,17 @@ if (require.main === module) {
               alias: 's',
               type: 'boolean',
               nargs: 0
+            })
+            .option('reverse', {
+              describe: 'Run browser versions oldest-to-newest',
+              alias: 'r',
+              type: 'boolean',
+              nargs: 0
             });
       }
   );
 
-  if (runAll(argv.browser, argv.os, argv.nonConcurrent) === false) {
+  if (runAll(argv.browser, argv.os, argv.nonConcurrent, argv.reverse) === false) {
     process.exit(1);
   }
 }

--- a/selenium.js
+++ b/selenium.js
@@ -281,7 +281,7 @@ const run = async (browser, version, os, ctx, task) => {
 
   const driver = await buildDriver(browser, version, os);
   if (!driver) {
-    throw new Error('Browser/OS config unsupported');
+    throw new Error(task.title + '-' + 'Browser/OS config unsupported');
   }
 
   let statusEl;
@@ -304,7 +304,7 @@ const run = async (browser, version, os, ctx, task) => {
       await driver.wait(until.elementTextContains(statusEl, 'uploaded'), 60000);
     } catch (e) {
       if (e.name == 'TimeoutError') {
-        throw new Error('Timed out waiting for results to upload');
+        throw new Error(task.title + '-' + 'Timed out waiting for results to upload');
       }
 
       throw e;

--- a/selenium.js
+++ b/selenium.js
@@ -245,6 +245,10 @@ const changeProtocol = (browser, version, page) => {
       break;
   }
 
+  if (browser === 'edge' && version <= 18) {
+    page = page.replace(/,/g, '%2C');
+  }
+
   if (useHttp) {
     return page.replace('https://', 'http://');
   }

--- a/selenium.js
+++ b/selenium.js
@@ -168,16 +168,18 @@ const buildDriver = async (browser, version, os) => {
       }
 
       // Allow mic, camera, geolocation and notifications permissions
-      capabilities.set('goog:chromeOptions', {
-        args: [
-          '--use-fake-device-for-media-stream',
-          '--use-fake-ui-for-media-stream'
-        ],
-        prefs: {
-          'profile.managed_default_content_settings.geolocation': 1,
-          'profile.managed_default_content_settings.notifications': 1
-        }
-      });
+      if (['chrome', 'edge'].includes(browser)) {
+        capabilities.set('goog:chromeOptions', {
+          args: [
+            '--use-fake-device-for-media-stream',
+            '--use-fake-ui-for-media-stream'
+          ],
+          prefs: {
+            'profile.managed_default_content_settings.geolocation': 1,
+            'profile.managed_default_content_settings.notifications': 1
+          }
+        });
+      }
 
       // Get console errors from browser 
       const loggingPrefs = new logging.Preferences();

--- a/selenium.js
+++ b/selenium.js
@@ -147,6 +147,10 @@ const buildDriver = async (browser, version, os) => {
           Browser[browser.toUpperCase()]
       );
 
+      capabilities.set(
+          'name', `mdn-bcd-collector: ${prettyName(browser, version, os)}`
+      );
+
       capabilities.set(Capability.VERSION, version.split('.')[0]);
 
       if (service === 'saucelabs') {
@@ -168,10 +172,6 @@ const buildDriver = async (browser, version, os) => {
       if (service === 'browserstack') {
         capabilities.set('browserstack.console', 'errors');
       }
-
-      capabilities.set(
-          'name', `mdn-bcd-collector: ${prettyName(browser, version, os)}`
-      );
 
       try {
         const driverBuilder = new Builder().usingServer(seleniumUrl)

--- a/selenium.js
+++ b/selenium.js
@@ -166,9 +166,21 @@ const buildDriver = async (browser, version, os) => {
         }
       }
 
-      const prefs = new logging.Preferences();
-      prefs.setLevel(logging.Type.BROWSER, logging.Level.SEVERE);
-      capabilities.setLoggingPrefs(prefs);
+      // Allow mic, camera, geolocation and notifications permissions
+      capabilities.set('goog:chromeOptions', {
+        'args': [
+          "--use-fake-device-for-media-stream",
+          "--use-fake-ui-for-media-stream"
+        ],
+        "prefs": {
+          "profile.managed_default_content_settings.geolocation": 1,
+          "profile.managed_default_content_settings.notifications": 1,
+        }
+      });
+
+      const loggingPrefs = new logging.Preferences();
+      loggingPrefs.setLevel(logging.Type.BROWSER, logging.Level.SEVERE);
+      capabilities.setLoggingPrefs(loggingPrefs);
       if (service === 'browserstack') {
         capabilities.set('browserstack.console', 'errors');
       }

--- a/selenium.js
+++ b/selenium.js
@@ -172,7 +172,7 @@ const buildDriver = async (browser, version, os) => {
       }
 
       // Allow mic, camera, geolocation and notifications permissions
-      if (['chrome', 'edge'].includes(browser)) {
+      if (browser === 'chrome' || (browser === 'edge' && version >= 79)) {
         capabilities.set('goog:chromeOptions', {
           args: [
             '--use-fake-device-for-media-stream',

--- a/selenium.js
+++ b/selenium.js
@@ -288,9 +288,10 @@ const run = async (browser, version, os, ctx, task) => {
     await goToPage(driver, browser, version, `${host}/${getvars}`);
     await click(driver, browser, 'start');
 
-    log(task, 'Running tests...');
+    log(task, 'Loading test page...');
     await awaitPage(driver, browser, version, `${host}/tests/${getvars}`);
 
+    log(task, 'Running tests...');
     await driver.wait(until.elementLocated(By.id('status')), 30000);
     statusEl = await driver.findElement(By.id('status'));
     try {

--- a/static/resources/harness.js
+++ b/static/resources/harness.js
@@ -583,6 +583,7 @@
             updateStatus('Results uploaded.', 'success-notice');
           } else {
             updateStatus('Failed to upload results: server error.', 'error-notice');
+            console.log('Server response: ' + client.response);
           }
         }
       };


### PR DESCRIPTION
This PR performs a number of updates to the Selenium script to resolve some issues caused by some new custom tests, along with existing tests, due to permissions requirements.  This PR also performs a few other little updates to make the script a little nicer, including the following:

- Increase test timeout
- Turn the browser-specific ignores into arrays rather than strings
- Remove logic to remap Safari 6.1
- Allow mic, camera, geolocation, and notifications for Chrome, Edge and Firefox
- Simplify code to ignore the Safari x.0 versions on BrowserStack
- Increase verbosity of tests and add more comments
- Encode the commas in URLs for EdgeHTML versions of Edge (due to some odd issues)
- Add a command line argument to reverse the browser's version order in testing (oldest-to-newest)
- Catch results upload failures

This should fix #1230 with both the timeout increase and the permissions, since the holes are caused by timeouts (sometimes due to an on-screen prompt).