### PR TITLE
More Selenium script updates

### DIFF
--- a/README.md
+++ b/README.md
@@ -88,13 +88,47 @@ This step is performed automatically when the `main` branch is updated:
 
 ## Running tests via Selenium WebDriver
 
+A script has been provided which will collect all of the results for nearly all of the browsers, using the Selenium WebDriver to control your CTs, and download them to your computer (which can then be submitted as a PR).  To run this script, you'll need a few prerequisites:
+
+- A clone of [mdn-bcd-results](https://github.com/foolip/mdn-bcd-results) adjacent to this folder's repository (or at least a folder at `../mdn-bcd-results`)
+- At least one Selenium remote (ex. BrowserStack, SauceLabs, etc.)
+
+### Define Selenium Hosts
+
+In `secrets.json`, you'll need to add your Selenium remote(s).  In the `selenium` object, define your remote(s) by setting the key as the service name (ex. "browserstack", "saucelabs", "lambdatest", "custom", etc.) and the value as either an object containing the username and key for known remotes, or simply a string of the remote URL.  Your `secrets.json` should look something like this:
+
+```json
+{
+  "github": {...},
+  "selenium": {
+    "browserstack": {
+      "username": "example",
+      "key": "some-API-key-goes-here"
+    },
+    "saucelabs": {
+      "username": "example",
+      "key": "some-API-key-goes-here",
+      "region": "us-west-1"
+    },
+    "custom": "https://my.example.page.org/selenium/wd"
+  }
+}
+```
+
+Currently, the Selenium hosts known to the script are:
+
+- BrowserStack - requires `username` and `key`
+- SauceLabs - requires `username`, `key`, and `region`
+
+You may use other Selenium hosts, but please be aware that they have not been tested and you may experience unexpected results.
+
+### Run the script
+
 To test using the latest deployed version, run:
 
 ```sh
 npm run selenium
 ```
-
-In `secrets.json`, configure your Selenium remote(s) by the service name as the key, and the URL as the value (ex. `"browserstack": "https://USERNAME:KEY@hub-cloud.browserstack.com/wd/hub"`). Please check with your CT on how to configure your WebDriver URL.
 
 You can also limit the browsers to test by defining browsers as arguments:
 

--- a/README.md
+++ b/README.md
@@ -88,14 +88,14 @@ This step is performed automatically when the `main` branch is updated:
 
 ## Running tests via Selenium WebDriver
 
-A script has been provided which will collect all of the results for nearly all of the browsers, using the Selenium WebDriver to control your CTs, and download them to your computer (which can then be submitted as a PR).  To run this script, you'll need a few prerequisites:
+A script has been provided which will collect all of the results for nearly all of the browsers, using the Selenium WebDriver to control your CTs, and download them to your computer (which can then be submitted as a PR). To run this script, you'll need a few prerequisites:
 
 - A clone of [mdn-bcd-results](https://github.com/foolip/mdn-bcd-results) adjacent to this folder's repository (or at least a folder at `../mdn-bcd-results`)
 - At least one Selenium remote (ex. BrowserStack, SauceLabs, etc.)
 
 ### Define Selenium Hosts
 
-In `secrets.json`, you'll need to add your Selenium remote(s).  In the `selenium` object, define your remote(s) by setting the key as the service name (ex. "browserstack", "saucelabs", "lambdatest", "custom", etc.) and the value as either an object containing the username and key for known remotes, or simply a string of the remote URL.  Your `secrets.json` should look something like this:
+In `secrets.json`, you'll need to add your Selenium remote(s). In the `selenium` object, define your remote(s) by setting the key as the service name (ex. "browserstack", "saucelabs", "lambdatest", "custom", etc.) and the value as either an object containing the username and key for known remotes, or simply a string of the remote URL. Your `secrets.json` should look something like this:
 
 ```json
 {

--- a/secrets.sample.json
+++ b/secrets.sample.json
@@ -1,9 +1,16 @@
 {
   "github": {
-    "token": "0123456789abcdef"
+    "token": ""
   },
   "selenium": {
-    "browserstack": "https://USERNAME:ACCESSKEY@hub-cloud.browserstack.com/wd/hub",
-    "saucelabs": "https://USERNAME:ACCESSKEY@ondemand.us-west-1.saucelabs.com/wd/hub"
+    "browserstack": {
+      "username": "",
+      "key": ""
+    },
+    "saucelabs": {
+      "username": "",
+      "key": "",
+      "region": ""
+    }
   }
 }

--- a/selenium.js
+++ b/selenium.js
@@ -132,6 +132,14 @@ const getSeleniumUrl = (service, credentials) => {
   // If credentials object is just a string, treat it as the URL
   if (typeof credentials === 'string') return credentials;
 
+  if (!(service in seleniumUrls)) {
+    if ('url' in credentials) {
+      seleniumUrls[service] = url;
+    } else {
+      throw new Error(`Couldn't compile Selenium URL for ${service}: service is unknown and URL not specified`);
+    }
+  }
+
   const re = /\${([^}]+)?}/g;
   let missingVars = [];
 
@@ -146,7 +154,7 @@ const getSeleniumUrl = (service, credentials) => {
 
   // Check for any unfilled variables
   if (missingVars.length) {
-    throw new Error(`Couldn't compile Selenium URL for ${service}, missing required variables: ${missingVars.join(', ')}`)
+    throw new Error(`Couldn't compile Selenium URL for ${service}: missing required variables: ${missingVars.join(', ')}`)
   }
 
   return seleniumUrl;

--- a/selenium.js
+++ b/selenium.js
@@ -247,14 +247,6 @@ const buildDriver = async (browser, version, os) => {
   return undefined;
 };
 
-const awaitPageReady = async (driver) => {
-  await driver.wait(() => {
-    return driver.executeScript('return document.readyState')
-        .then((readyState) => (readyState === 'complete'));
-  }, 30000);
-  await driver.executeScript('return document.readyState');
-};
-
 const changeProtocol = (browser, version, page) => {
   let useHttp = false;
   switch (browser) {
@@ -275,6 +267,14 @@ const changeProtocol = (browser, version, page) => {
   }
 
   return page;
+};
+
+const awaitPageReady = async (driver) => {
+  await driver.wait(() => {
+    return driver.executeScript('return document.readyState')
+        .then((readyState) => (readyState === 'complete'));
+  }, 30000);
+  await driver.executeScript('return document.readyState');
 };
 
 const awaitPage = async (driver, browser, version, page) => {

--- a/selenium.js
+++ b/selenium.js
@@ -128,6 +128,31 @@ const getSafariOS = (version) => {
   }
 };
 
+const getOsesToTest = (os) => {
+  let osesToTest = [];
+
+  switch (os) {
+    case 'Windows':
+      osesToTest = [
+        ['Windows', '10'],
+        ['Windows', '8.1'],
+        ['Windows', '8'],
+        ['Windows', '7'],
+        ['Windows', 'XP']
+      ];
+      break;
+    case 'macOS':
+      osesToTest = service === 'saucelabs' ?
+                   [['macOS', '10.14']] :
+                   [['OS X', 'Big Sur'], ['OS X', 'Mojave'], ['OS X', 'El Capitan']];
+      break;
+    default:
+      throw new Error(`Unknown/unsupported OS: ${os}`);
+  }
+
+  return osesToTest;
+}
+
 const getSeleniumUrl = (service, credentials) => {
   // If credentials object is just a string, treat it as the URL
   if (typeof credentials === 'string') return credentials;
@@ -178,29 +203,8 @@ const buildDriver = async (browser, version, os) => {
       }
     }
 
-    let osesToTest = [];
-
-    switch (os) {
-      case 'Windows':
-        osesToTest = [
-          ['Windows', '10'],
-          ['Windows', '8.1'],
-          ['Windows', '8'],
-          ['Windows', '7'],
-          ['Windows', 'XP']
-        ];
-        break;
-      case 'macOS':
-        osesToTest = service === 'saucelabs' ?
-                     [['macOS', '10.14']] :
-                     [['OS X', 'Big Sur'], ['OS X', 'Mojave'], ['OS X', 'El Capitan']];
-        break;
-      default:
-        throw new Error(`Unknown/unsupported OS: ${os}`);
-    }
-
     // eslint-disable-next-line guard-for-in
-    for (const [osName, osVersion] of osesToTest) {
+    for (const [osName, osVersion] of getOsesToTest(os)) {
       const capabilities = new Capabilities();
       capabilities.set(
           Capability.BROWSER_NAME,

--- a/selenium.js
+++ b/selenium.js
@@ -162,8 +162,6 @@ const getSeleniumUrl = (service, credentials) => {
 
 const buildDriver = async (browser, version, os) => {
   for (const [service, seleniumCredentials] of Object.entries(secrets.selenium)) {
-    const seleniumUrl = getSeleniumUrl(service, seleniumCredentials);
-
     if (service === 'browserstack') {
       if (browser === 'edge' && ['12', '13', '14'].includes(version)) {
         // BrowserStack remaps Edge 12-14 as Edge 15
@@ -264,6 +262,8 @@ const buildDriver = async (browser, version, os) => {
       }
 
       try {
+        const seleniumUrl = getSeleniumUrl(service, seleniumCredentials);
+
         // Build Selenium driver
         const driverBuilder = new Builder().usingServer(seleniumUrl)
             .withCapabilities(capabilities);
@@ -273,7 +273,8 @@ const buildDriver = async (browser, version, os) => {
       } catch (e) {
         if (e.message.startsWith('Misconfigured -- Unsupported OS/browser/version/device combo') ||
             e.message.startsWith('OS/Browser combination invalid') ||
-            e.message.startsWith('Browser/Browser_Version not supported')) {
+            e.message.startsWith('Browser/Browser_Version not supported') ||
+            e.message.startsWith("Couldn't compile Selenium URL")) {
           // If unsupported config, continue to the next grid configuration
           continue;
         } else {

--- a/selenium.js
+++ b/selenium.js
@@ -88,6 +88,23 @@ const filterVersions = (data, earliestVersion, reverse) => {
   ));
 };
 
+const getBrowsersToTest = (limitBrowsers, reverse) => {
+  let browsersToTest = {
+    chrome: filterVersions(bcdBrowsers.chrome.releases, '15', reverse),
+    edge: filterVersions(bcdBrowsers.edge.releases, '12', reverse),
+    firefox: filterVersions(bcdBrowsers.firefox.releases, '4', reverse),
+    ie: filterVersions(bcdBrowsers.ie.releases, '6', reverse),
+    safari: filterVersions(bcdBrowsers.safari.releases, '5.1', reverse)
+  };
+
+  if (limitBrowsers) {
+    return Object.fromEntries(Object.entries(browsersToTest)
+        .filter(([k]) => (limitBrowsers.includes(k))));
+  };
+
+  return browsersToTest;
+}
+
 const getSafariOS = (version) => {
   // Sauce Labs differentiates 10.0 vs. 10.1 in the OS version. This
   // function sets the appropriate OS version accordingly.
@@ -344,19 +361,7 @@ const runAll = async (limitBrowsers, oses, nonConcurrent, reverse) => {
     console.warn(chalk`{yellow.bold Test mode: results are not saved.}`);
   }
 
-  let browsersToTest = {
-    chrome: filterVersions(bcdBrowsers.chrome.releases, '15', reverse),
-    edge: filterVersions(bcdBrowsers.edge.releases, '12', reverse),
-    firefox: filterVersions(bcdBrowsers.firefox.releases, '4', reverse),
-    ie: filterVersions(bcdBrowsers.ie.releases, '6', reverse),
-    safari: filterVersions(bcdBrowsers.safari.releases, '5.1', reverse)
-  };
-
-  if (limitBrowsers) {
-    browsersToTest = Object.fromEntries(Object.entries(browsersToTest)
-        .filter(([k]) => (limitBrowsers.includes(k))));
-  }
-
+  const browsersToTest = getBrowsersToTest(limitBrowsers, reverse);
   const tasks = [];
 
   // eslint-disable-next-line guard-for-in


### PR DESCRIPTION
This PR provides even more Selenium script updates for legibility, convenience, and simplicity.  Some legibility/simplicity updates include the following:

- Create getBrowsersToTest()
- Create getOsesToTest()
- Move functions
- Update documentation regarding Selenium script

A big update involves the handling of the Selenium URLs as well.  This refactors the Selenium URLs to take an object containing the user's credentials, which then fills a pre-programmed URL for the service.  This allows a user to simply define the username and API key for BrowserStack or SauceLabs and let the script handle the rest.  This will also make it easier for #1222 to tap into the API keys right from `secrets.json`.

This refactoring will not conflict with the existing method of defining Selenium remotes.  Both as a way not to confuse existing `secrets.json` files, and to continue allowing for custom services, the remote may also be defined as a simple string, rather than username-key objects.