### PR TITLE
Increase the verbosity of errors in results parsing

### DIFF
--- a/results.js
+++ b/results.js
@@ -16,7 +16,7 @@
 
 const parseShortString = (value, desc) => {
   if (typeof value !== 'string') {
-    throw new Error(`${desc} should be string; got ${typeof value}`);
+    throw new Error(`${desc} should be a string; got ${typeof value}`);
   }
   if (value.length > 1000) {
     throw new Error(`${desc} should be a short string; string is too long`);

--- a/results.js
+++ b/results.js
@@ -15,8 +15,11 @@
 'use strict';
 
 const parseShortString = (value, desc) => {
-  if (typeof value !== 'string' || value.length > 1000) {
-    throw new Error(`${desc} should be a short string`);
+  if (typeof value !== 'string') {
+    throw new Error(`${desc} should be string; got ${typeof value}`);
+  }
+  if (value.length > 1000) {
+    throw new Error(`${desc} should be a short string; string is too long`);
   }
   return value;
 };
@@ -36,23 +39,23 @@ const parseResults = (url, results) => {
 
   results = results.map((v, i) => {
     if (!v || typeof v !== 'object') {
-      throw new Error(`results[${i}] should be an object`);
+      throw new Error(`results[${i}] should be an object; got ${v}`);
     }
     const copy = {};
     copy.name = parseShortString(v.name, `results[${i}].name`);
     if (![true, false, null].includes(v.result)) {
-      throw new Error(`results[${i}].result should be true/false/null`);
+      throw new Error(`results[${i}].result (${v.name}) should be true/false/null; got ${v.result}`);
     }
     copy.result = v.result;
     if (v.result === null) {
-      copy.message = parseShortString(v.message, `results[${i}].message`);
+      copy.message = parseShortString(v.message, `results[${i}].message (${v.name})`);
     }
     // Copy exposure either from |v.exposure| or |v.info.exposure|.
     if (v.info) {
-      copy.exposure = parseShortString(v.info.exposure, `results[${i}].info.exposure`);
+      copy.exposure = parseShortString(v.info.exposure, `results[${i}].info.exposure (${v.name})`);
       // Don't copy |v.info.code|.
     } else {
-      copy.exposure = parseShortString(v.exposure, `results[${i}].exposure`);
+      copy.exposure = parseShortString(v.exposure, `results[${i}].exposure (${v.name})`);
     }
     return copy;
   });

--- a/unittest/unit/results.js
+++ b/unittest/unit/results.js
@@ -108,7 +108,7 @@ describe('results', () => {
             result: true
           }
         ]);
-      }, Error, 'results[0].name should be a short string');
+      }, Error, 'results[0].name should be a string; got number');
     });
 
     it('invalid result', () => {
@@ -120,7 +120,7 @@ describe('results', () => {
             result: 42
           }
         ]);
-      }, Error, 'results[0].result should be true/false/null');
+      }, Error, 'results[0].result (api.Attr.name) should be true/false/null; got 42');
     });
 
     it('invalid exposure', () => {
@@ -132,7 +132,7 @@ describe('results', () => {
             result: true
           }
         ]);
-      }, Error, 'results[0].exposure should be a short string');
+      }, Error, 'results[0].exposure (api.Attr.name) should be a string; got number');
     });
   });
 });


### PR DESCRIPTION
This PR increases the verbosity of the errors thrown by the results parser (`results.js`).  This will help us get to the bottom of any issues we're experiencing a little easier.
