### PR TITLE
Fix Firefox collection regarding new WebKitAnimationEvent test

### DIFF
--- a/static/resources/harness.js
+++ b/static/resources/harness.js
@@ -194,7 +194,10 @@
       result.result = null;
       result.message = 'threw ' + stringify(value);
     } else if (value && typeof value === 'object') {
-      if ('name' in value && stringIncludes(value.name, 'NS_ERROR')) {
+      if ('name' in value && (
+        stringIncludes(value.name, 'NS_ERROR') ||
+        stringIncludes(value.name, 'NotSupported'))
+      ) {
         result.result = null;
         result.message = 'threw ' + stringify(value.message);
       } else if ('result' in value) {


### PR DESCRIPTION
This PR fixes a small bug with the error processing of the error thrown by old Firefox versions when attempting to create a WebKitAnimationEvent.
