### PR TITLE
Add IDs for export buttons

### DIFF
--- a/static/resources/harness.js
+++ b/static/resources/harness.js
@@ -580,9 +580,8 @@
       client.onreadystatechange = function() {
         if (client.readyState == 4) {
           if (client.status >= 200 && client.status <= 299) {
-            var form = document.getElementById('form');
-            form.children[0].disabled = false;
-            form.children[1].disabled = false;
+            document.getElementById('export-download').disabled = false;
+            document.getElementById('export-github').disabled = false;
             updateStatus('Results uploaded.', 'success-notice');
           } else {
             updateStatus('Failed to upload results: server error.', 'error-notice');

--- a/views/tests.ejs
+++ b/views/tests.ejs
@@ -1,8 +1,8 @@
 <%- contentFor('body') %>
 <p id="status">Running tests...</p>
 <form id="form" action=/export method=post>
-  <input type=submit name=download value="Export for download" disabled>
-  <input type=submit name=github value="Export to GitHub" disabled>
+  <input id="export-download" type=submit name=download value="Export for download" disabled>
+  <input id="export-github" type=submit name=github value="Export to GitHub" disabled>
 </form>
 <div id="results"></div>
 


### PR DESCRIPTION
This PR adds IDs for the export buttons.  This fixes a compatibility issue with early Firefox versions, as well as allows for forcing a click of the buttons.
