### PR TITLE
Custom tests: replace variable assignments as well

### DIFF
--- a/build.js
+++ b/build.js
@@ -38,7 +38,8 @@ const compileCustomTest = (code, format = true) => {
 
       importcode = importcode
           .replace(/var (instance|promise)/g, `var ${instancevar}`)
-          .replace(/promise\.then/g, `${instancevar}.then`);
+          .replace(/promise\.then/g, `${instancevar}.then`)
+          .replace(/(instance|promise) = /g, `${instancevar} = `);
       if (instancevar !== 'instance' && instancevar !== 'promise') {
         importcode += ` if (!${instancevar}) {return false;}`;
       }

--- a/unittest/unit/build.js
+++ b/unittest/unit/build.js
@@ -230,7 +230,7 @@ describe('build', () => {
               __base: 'var promise = somePromise();'
             },
             foobar: {
-              __base: '<%api.foo:foopromise%> var promise = foopromise.then(function() {});'
+              __base: '<%api.foo:foo%> var promise = foo.then(function() {});'
             }
           }
         }
@@ -251,7 +251,7 @@ describe('build', () => {
       it('interface with import', () => {
         assert.equal(
             getCustomTestAPI('foobar'),
-            '(function () {\n  var foopromise = somePromise();\n  if (!foopromise) {\n    return false;\n  }\n  var promise = foopromise.then(function () {});\n  return promise.then(function (instance) {\n    return !!instance;\n  });\n})();');
+            '(function () {\n  var foo = somePromise();\n  if (!foo) {\n    return false;\n  }\n  var promise = foo.then(function () {});\n  return promise.then(function (instance) {\n    return !!instance;\n  });\n})();');
       });
     });
 


### PR DESCRIPTION
This PR updates the custom tests' importing mechanic to rename the variables in assignments without the `var` keyword present, such as in the case of the `Element` API.  This fixes custom tests like the `DOMRectList` API.﻿
