### PR TITLE
Enable fake media stream for Firefox in Selenium script

### DIFF
--- a/selenium.js
+++ b/selenium.js
@@ -253,6 +253,7 @@ const buildDriver = async (browser, version, os) => {
         capabilities.set('moz:firefoxOptions', {
           prefs: {
             'media.navigator.permission.disabled': 1,
+            'media.navigator.streams.fake': 1,
             'permissions.default.microphone': 1,
             'permissions.default.camera': 1,
             'permissions.default.geo': 1,


### PR DESCRIPTION
This PR should help bypass some of the OS-level permissions issues﻿we've been dealing with, so that we can get all the results for Firefox easily.
