### PR TITLE
Update UA parser to better handle iOS browsers

### DIFF
--- a/ua-parser.js
+++ b/ua-parser.js
@@ -31,7 +31,7 @@ const parseUA = (userAgent, browsers) => {
 
   switch (data.browser.id) {
     case 'mobile_safari':
-      data.browser.id = 'safari_ios';
+      data.browser.id = 'safari';
       break;
     case 'samsung_browser':
       data.browser.id = 'samsunginternet';
@@ -46,19 +46,22 @@ const parseUA = (userAgent, browsers) => {
   if (os === 'android') {
     data.browser.id += '_android';
     data.browser.name += ' Android';
-  }
 
-  data.fullVersion = ua.browser.version;
+    if (ua.browser.name === 'Android Browser') {
+      // For early WebView Android, use the OS version
+      data.fullVersion = compareVersions.compare(ua.os.version, '5.0', '<') ?
+        ua.os.version :
+        ua.engine.version;
+    }
+  } else if (os === 'ios') {
+    data.browser.id += '_ios';
+    data.browser.name += ' iOS';
 
-  if (data.browser.id === 'safari_ios') {
     // https://github.com/mdn/browser-compat-data/blob/main/docs/data-guidelines.md#safari-for-ios-versioning
     data.fullVersion = ua.os.version;
-  } else if (ua.browser.name === 'Android Browser') {
-    data.fullVersion = compareVersions.compare(ua.os.version, '5.0', '<') ?
-      ua.os.version :
-      ua.engine.version;
   }
 
+  data.fullVersion = data.fullVersion || ua.browser.version;
   data.version = getMajorMinorVersion(data.fullVersion);
 
   if (!(data.browser.id in browsers)) {

--- a/unittest/unit/ua-parser.js
+++ b/unittest/unit/ua-parser.js
@@ -133,6 +133,10 @@ describe('parseUA', () => {
     assert.deepEqual(parseUA('Mozilla/5.0 (Linux; Android 11; Pixel 2 Build/RP1A.200720.009; wv) AppleWebKit/537.36 (KHTML, like Gecko) Version/4.0 Chrome/86.0.4240.198 Mobile Safari/537.36 WEBVIEW TEST/1.2.1.80 (Phone; anonymous)', browsers), {browser: {id: 'webview_android', name: 'WebView Android'}, version: '86', fullVersion: '86.0.4240.198', os: {name: 'Android', version: '11'}, inBcd: true});
   });
 
+  it('Chrome on iOS (not in BCD)', () => {
+    assert.deepEqual(parseUA('Mozilla/5.0 (iPad; CPU OS 14_6 like Mac OS X) AppleWebKit/605.1.15 (KHTML, like Gecko) CriOS/91.0.4472.80 Mobile/15E148 Safari/604.1', browsers), {browser: {id: 'chrome_ios', name: 'Chrome iOS'}, version: '14.6', fullVersion: '14.6', os: {name: 'iOS', version: '14.6'}, inBcd: undefined});
+  });
+
   it('Yandex Browser (not in BCD)', () => {
     assert.deepEqual(parseUA('Mozilla/5.0 (Windows NT 6.3) AppleWebKit/537.36 (KHTML, like Gecko) Chrome/58.0.3029.110 YaBrowser/17.6.1.749 Yowser/2.5 Safari/537.36', browsers), {browser: {id: 'yandex', name: 'Yandex'}, version: '17.6', fullVersion: '17.6.1.749', os: {name: 'Windows', version: '8.1'}, inBcd: undefined});
   });


### PR DESCRIPTION
A while back, I accidentally merged a PR where I ran the collector on Chrome iOS.  At first, I didn't notice the odd results surrounding Chrome 91, but then when I looked closely, I realized it was due to the merge of a Chrome iOS result.

This PR updates the UA parser to treat iOS similar to Android, adding a suffix to the browser ID and name to indicate it's an iOS browser.  This will make Chrome iOS (and any other browsers on iOS that aren't Safari itself) register as not a part of BCD, instead of treating it as Chrome Desktop (as it is now) or merging the results into Safari iOS (since some browsers have varying API support).﻿
