### PR TITLE
Add custom tests for WritableStreamDefaultController/Writer

### DIFF
--- a/custom-tests.json
+++ b/custom-tests.json
@@ -1500,6 +1500,12 @@
     "WorkerNavigator": {
       "__base": "var instance = navigator;"
     },
+    "WritableStreamDefaultController": {
+      "__base": "var promise = new Promise(function(resolve, reject) {new WritableStream({start(controller) {resolve(controller)}})});"
+    },
+    "WritableStreamDefaultWriter": {
+      "__base": "var instance = new WritableStream({}).getWriter();"
+    },
     "XMLHttpRequest": {
       "__base": "var instance = new XMLHttpRequest();"
     },


### PR DESCRIPTION
This PR adds custom tests for the `WritableStreamDefaultController` and `WritableStreamDefaultWriter` APIs.  Since neither seem to be exposed as their own interfaces, this will let us collect results properly.﻿
