### PR TITLE
Remove tests for columnNumber/fileName/lineNumber

### DIFF
--- a/custom-js.json
+++ b/custom-js.json
@@ -170,9 +170,6 @@
       "ctor_args": "'message'"
     },
     "Error.prototype.cause": {},
-    "Error.prototype.columnNumber": {},
-    "Error.prototype.fileName": {},
-    "Error.prototype.lineNumber": {},
     "Error.prototype.message": {},
     "Error.prototype.name": {},
     "Error.prototype.toSource": {},


### PR DESCRIPTION
As it turns out, these appear on Error instances and not on the
prototype, just like the stack property.

These will need custom tests, drop generated tests.