### PR TITLE
Remove Function.prototype.displayName test

### DIFF
--- a/custom-js.json
+++ b/custom-js.json
@@ -196,7 +196,6 @@
     "Function.prototype.bind": {},
     "Function.prototype.call": {},
     "Function.prototype.caller": {},
-    "Function.prototype.displayName": {},
     "Function.prototype.length": {},
     "Function.prototype.name": {},
     "Function.prototype.toSource": {},


### PR DESCRIPTION
This is a Firefox-only feature, but this feature detection doesn't work.
Going by the description on MDN, it's probably a property that code can
only set, and FireFox DevTools might look for that property:
https://developer.mozilla.org/en-US/docs/Web/JavaScript/Reference/Global_Objects/Function/displayName

Just don't test it for now.