### PR TITLE
Fix variable names in custom tests to avoid "interface"

### DIFF
--- a/custom-tests.json
+++ b/custom-tests.json
@@ -169,7 +169,7 @@
     },
     "CSSConditionRule": {
       "__resources": ["createStyleSheet"],
-      "__base": "<%api.CSSMediaRule:interface%>"
+      "__base": "<%api.CSSMediaRule:instance%>"
     },
     "CSSCounterStyleRule": {
       "__resources": ["createStyleSheet"],
@@ -185,7 +185,7 @@
     },
     "CSSGroupingRule": {
       "__resources": ["createStyleSheet"],
-      "__base": "<%api.CSSMediaRule:interface%>"
+      "__base": "<%api.CSSMediaRule:instance%>"
     },
     "CSSImportRule": {
       "__resources": ["createStyleSheet"],

--- a/package-lock.json
+++ b/package-lock.json
@@ -1,6 +1,6 @@
 {
   "name": "mdn-bcd-collector",
-  "version": "3.2.1",
+  "version": "3.2.2",
   "lockfileVersion": 1,
   "requires": true,
   "dependencies": {


### PR DESCRIPTION
This is apparently a reserved keyword in strict mode and is breaking
these tests.