### PR TITLE
Fix tests for WritableStreamDefaultController/Writer

### DIFF
--- a/custom-tests.json
+++ b/custom-tests.json
@@ -1504,10 +1504,10 @@
       "__base": "var instance = navigator;"
     },
     "WritableStreamDefaultController": {
-      "__base": "var promise = new Promise(function(resolve, reject) {new WritableStream({start(controller) {resolve(controller)}})});"
+      "__base": "if (!('WritableStream' in self)) {return false}; var promise = new Promise(function(resolve, reject) {new WritableStream({start(controller) {resolve(controller)}})});"
     },
     "WritableStreamDefaultWriter": {
-      "__base": "var instance = new WritableStream({}).getWriter();"
+      "__base": "if (!('WritableStream' in self)) {return false}; var instance = new WritableStream({}).getWriter();"
     },
     "XMLHttpRequest": {
       "__base": "var instance = new XMLHttpRequest();"


### PR DESCRIPTION
This PR fixes the tests for the WritableStreamDefaultController and WritableStreamDefaultWriter interfaces, so that they check for support of WritableStream first.﻿
