### PR TITLE
Simplify getSupportMap to use bare values, not {result: ...}

### DIFF
--- a/unittest/unit/update-bcd.js
+++ b/unittest/unit/update-bcd.js
@@ -393,34 +393,34 @@ describe('BCD updater', () => {
   describe('getSupportMap', () => {
     it('normal', () => {
       assert.deepEqual(getSupportMap(reports[0]), new Map([
-        ['api.AbortController', {result: true}],
-        ['api.AbortController.abort', {result: null}],
-        ['api.AbortController.AbortController', {result: false}],
-        ['api.AudioContext', {result: false}],
-        ['api.AudioContext.close', {result: false}],
-        ['api.DeprecatedInterface', {result: true}],
-        ['api.ExperimentalInterface', {result: true}],
-        ['api.NullAPI', {result: null}],
-        ['api.RemovedInterface', {result: true}],
-        ['css.properties.font-family', {result: true}],
-        ['css.properties.font-face', {result: true}]
+        ['api.AbortController', true],
+        ['api.AbortController.abort', null],
+        ['api.AbortController.AbortController', false],
+        ['api.AudioContext', false],
+        ['api.AudioContext.close', false],
+        ['api.DeprecatedInterface', true],
+        ['api.ExperimentalInterface', true],
+        ['api.NullAPI', null],
+        ['api.RemovedInterface', true],
+        ['css.properties.font-family', true],
+        ['css.properties.font-face', true]
       ]));
     });
 
     it('support in only one exposure', () => {
       assert.deepEqual(getSupportMap(reports[1]), new Map([
-        ['api.AbortController', {result: true}],
-        ['api.AbortController.abort', {result: true}],
-        ['api.AbortController.AbortController', {result: false}],
-        ['api.AudioContext', {result: false}],
-        ['api.AudioContext.close', {result: false}],
-        ['api.DeprecatedInterface', {result: true}],
-        ['api.ExperimentalInterface', {result: true}],
-        ['api.NewInterfaceNotInBCD', {result: false}],
-        ['api.NullAPI', {result: null}],
-        ['api.RemovedInterface', {result: false}],
-        ['css.properties.font-family', {result: true}],
-        ['css.properties.font-face', {result: true}]
+        ['api.AbortController', true],
+        ['api.AbortController.abort', true],
+        ['api.AbortController.AbortController', false],
+        ['api.AudioContext', false],
+        ['api.AudioContext.close', false],
+        ['api.DeprecatedInterface', true],
+        ['api.ExperimentalInterface', true],
+        ['api.NewInterfaceNotInBCD', false],
+        ['api.NullAPI', null],
+        ['api.RemovedInterface', false],
+        ['css.properties.font-family', true],
+        ['css.properties.font-face', true]
       ]));
     });
 
@@ -440,82 +440,82 @@ describe('BCD updater', () => {
       assert.deepEqual(getSupportMatrix(reports), new Map([
         ['api.AbortController', new Map([
           ['chrome', new Map([
-            ['82', {result: null}],
-            ['83', {result: true}],
-            ['84', {result: true}],
-            ['85', {result: true}]
+            ['82', null],
+            ['83', true],
+            ['84', true],
+            ['85', true]
           ])],
           ['safari', new Map([
-            ['13', {result: null}],
-            ['13.1', {result: true}],
-            ['14', {result: null}]
+            ['13', null],
+            ['13.1', true],
+            ['14', null]
           ])]
         ])],
         ['api.AbortController.abort', new Map([['chrome', new Map([
-          ['82', {result: null}],
-          ['83', {result: null}],
-          ['84', {result: true}],
-          ['85', {result: true}]
+          ['82', null],
+          ['83', null],
+          ['84', true],
+          ['85', true]
         ])]])],
         ['api.AbortController.AbortController', new Map([['chrome', new Map([
-          ['82', {result: null}],
-          ['83', {result: false}],
-          ['84', {result: false}],
-          ['85', {result: true}]
+          ['82', null],
+          ['83', false],
+          ['84', false],
+          ['85', true]
         ])]])],
         ['api.AudioContext', new Map([['chrome', new Map([
-          ['82', {result: null}],
-          ['83', {result: false}],
-          ['84', {result: false}],
-          ['85', {result: true}]
+          ['82', null],
+          ['83', false],
+          ['84', false],
+          ['85', true]
         ])]])],
         ['api.AudioContext.close', new Map([['chrome', new Map([
-          ['82', {result: null}],
-          ['83', {result: false}],
-          ['84', {result: false}],
-          ['85', {result: true}]
+          ['82', null],
+          ['83', false],
+          ['84', false],
+          ['85', true]
         ])]])],
         ['api.DeprecatedInterface', new Map([['chrome', new Map([
-          ['82', {result: null}],
-          ['83', {result: true}],
-          ['84', {result: true}],
-          ['85', {result: false}]
+          ['82', null],
+          ['83', true],
+          ['84', true],
+          ['85', false]
         ])]])],
         ['api.ExperimentalInterface', new Map([['chrome', new Map([
-          ['82', {result: null}],
-          ['83', {result: true}],
-          ['84', {result: true}],
-          ['85', {result: true}]
+          ['82', null],
+          ['83', true],
+          ['84', true],
+          ['85', true]
         ])]])],
         ['api.NewInterfaceNotInBCD', new Map([['chrome', new Map([
-          ['82', {result: null}],
-          ['83', {result: null}],
-          ['84', {result: false}],
-          ['85', {result: true}]
+          ['82', null],
+          ['83', null],
+          ['84', false],
+          ['85', true]
         ])]])],
         ['api.NullAPI', new Map([['chrome', new Map([
-          ['82', {result: null}],
-          ['83', {result: null}],
-          ['84', {result: null}],
-          ['85', {result: null}]
+          ['82', null],
+          ['83', null],
+          ['84', null],
+          ['85', null]
         ])]])],
         ['api.RemovedInterface', new Map([['chrome', new Map([
-          ['82', {result: null}],
-          ['83', {result: true}],
-          ['84', {result: false}],
-          ['85', {result: true}]
+          ['82', null],
+          ['83', true],
+          ['84', false],
+          ['85', true]
         ])]])],
         ['css.properties.font-family', new Map([['chrome', new Map([
-          ['82', {result: null}],
-          ['83', {result: false}],
-          ['84', {result: true}],
-          ['85', {result: true}]
+          ['82', null],
+          ['83', false],
+          ['84', true],
+          ['85', true]
         ])]])],
         ['css.properties.font-face', new Map([['chrome', new Map([
-          ['82', {result: null}],
-          ['83', {result: null}],
-          ['84', {result: null}],
-          ['85', {result: null}]
+          ['82', null],
+          ['83', null],
+          ['84', null],
+          ['85', null]
         ])]])]
       ]));
 

--- a/update-bcd.js
+++ b/update-bcd.js
@@ -60,7 +60,7 @@ const getSupportMap = (report) => {
       } else if (result === false) {
         // This may yet be overruled by a later result (above).
         supported = false;
-      } else if (result == null) {
+      } else if (result === null) {
         // Leave supported as it is.
       } else {
         throw new Error(`result not true/false/null; got ${result}`);

--- a/update-bcd.js
+++ b/update-bcd.js
@@ -28,7 +28,7 @@ const findEntry = (bcd, ident) => {
   return entry;
 };
 
-// Get support map from BCD path to test result(null/true/false) for a single
+// Get support map from BCD path to test result (null/true/false) for a single
 // report.
 const getSupportMap = (report) => {
   // Transform `report` to map from test name (BCD path) to array of results.
@@ -48,29 +48,31 @@ const getSupportMap = (report) => {
   // Transform `testMap` to map from test name (BCD path) to flattened support.
   const supportMap = new Map;
   for (const [name, results] of testMap.entries()) {
-    let supported = {result: null};
+    let supported = null;
     // eslint-disable-next-line no-unused-vars
-    for (const {url, result} of results) {
-      if (result === null) {
-        const parentName = name.split('.').slice(0, -1).join('.');
-        const parentSupport = supportMap.get(parentName);
-        if (parentSupport && parentSupport.result === false) {
-          supported.result = false;
-        }
-        continue;
-      }
-      if (supported.result === null) {
-        supported = {result};
-        continue;
-      }
-      if (supported.result !== result) {
-        // This will happen for [SecureContext] APIs and APIs under multiple
-        // exposure scopes.
-        // logger.warn(`Contradictory results for ${name}: ${JSON.stringify(
-        //     results, null, '  '
-        // )}`);
-        supported.result = true;
+    for (const {result} of results) {
+      if (result === true) {
+        // If any result is true, the flattened support should be true. There
+        // can be contradictory results with multiple exposure scopes, but here
+        // we treat support in any scope as support of the feature.
+        supported = true;
         break;
+      } else if (result === false) {
+        // This may yet be overruled by a later result (above).
+        supported = false;
+      } else if (result == null) {
+        // Leave supported as it is.
+      } else {
+        throw new Error(`result not true/false/null; got ${result}`);
+      }
+    }
+
+    if (supported === null) {
+      // If the parent feature support is false, copy that.
+      const parentName = name.split('.').slice(0, -1).join('.');
+      const parentSupport = supportMap.get(parentName);
+      if (parentSupport === false) {
+        supported = false;
       }
     }
 
@@ -112,7 +114,7 @@ const getSupportMatrix = (reports) => {
         versionMap = new Map;
         for (const browserVersion of
           Object.keys(browsers[browser.id].releases)) {
-          versionMap.set(browserVersion, {result: null});
+          versionMap.set(browserVersion, null);
         }
         browserMap.set(browser.id, versionMap);
       }
@@ -132,10 +134,10 @@ const getSupportMatrix = (reports) => {
     }
     if (version === '*') {
       for (const v of versionMap.keys()) {
-        versionMap.set(v, {result: supported});
+        versionMap.set(v, supported);
       }
     } else {
-      versionMap.set(version, {result: supported});
+      versionMap.set(version, supported);
     }
   }
 
@@ -150,7 +152,7 @@ const inferSupportStatements = (versionMap) => {
   let lastWasNull = false;
 
   for (const [_, version] of versions.entries()) {
-    const {result: supported} = versionMap.get(version);
+    const supported = versionMap.get(version);
     const lastStatement = statements[statements.length - 1];
 
     if (supported === true) {


### PR DESCRIPTION
These objects only had a single property, making the code around it more
convoluted for no good, and harder to debug.