### PR TITLE
Correct preference for fake Firefox media stream

### DIFF
--- a/selenium.js
+++ b/selenium.js
@@ -269,8 +269,6 @@ const buildDriver = async (browser, version, os) => {
           }
         });
       } else if (browser === 'firefox') {
-        // XXX macOS Big Sur requires microphone permission via the OS...
-        // BrowserStack bug?
         capabilities.set('moz:firefoxOptions', {
           prefs: {
             'media.navigator.permission.disabled': 1,

--- a/selenium.js
+++ b/selenium.js
@@ -274,7 +274,7 @@ const buildDriver = async (browser, version, os) => {
         capabilities.set('moz:firefoxOptions', {
           prefs: {
             'media.navigator.permission.disabled': 1,
-            'media.navigator.streams.fake': 1,
+            'media.navigator.streams.fake': true,
             'permissions.default.microphone': 1,
             'permissions.default.camera': 1,
             'permissions.default.geo': 1,


### PR DESCRIPTION
This PR fixes the preferences for Firefox so that we can properly collect results on macOS.﻿
