### PR TITLE
Improve test for WebSocket API

### DIFF
--- a/custom-tests.json
+++ b/custom-tests.json
@@ -1483,7 +1483,7 @@
       "__base": "var instance; try {instance = new WebKitTransitionEvent('webkitTransitionEnd');} catch(e) {instance = document.createEvent('WebKitTransitionEvent');}"
     },
     "WebSocket": {
-      "__base": "var instance = new WebSocket('wss://' + location.hostname);"
+      "__base": "var constructor = self.WebSocket || self.MozWebSocket; if (!constructor) {return false;} var instance = new constructor('wss://' + location.hostname);"
     },
     "WheelEvent": {
       "__base": "var instance; try {instance = new WheelEvent('wheel');} catch(e) {instance = document.createEvent('WheelEvent');}"


### PR DESCRIPTION
This PR improves the WebSocket API custom test in two ways:
1) Checks for WebSocket support before attempting to construct one
2) Checks for support under the `Moz` prefix as well﻿
