### PR TITLE
Fix test for XPathResult

### DIFF
--- a/custom-tests.json
+++ b/custom-tests.json
@@ -1524,7 +1524,7 @@
       "__base": "var instance = new XMLHttpRequest();"
     },
     "XPathExpression": {
-      "__base": "var xpe = new XPathEvaluator(); var instance = xpe.createExpression('//div');"
+      "__base": "var xpe = new XPathEvaluator(); var instance = xpe.createExpression('//div', xpe.createNSResolver(document));"
     },
     "XPathResult": {
       "__base": "<%api.XPathExpression:exp%> var instance = exp.evaluate(document);"


### PR DESCRIPTION
Apparently, the resolver argument was required in earlier versions of Firefox (57 and below).  This PR corrects the test to work with these older Firefox versions.