### PR TITLE
Fix custom test for Notification API

### DIFF
--- a/custom-tests.json
+++ b/custom-tests.json
@@ -779,7 +779,7 @@
       "__base": "var instance = document.createNodeIterator(document);"
     },
     "Notification": {
-      "__base": "var instance = new Notification('');"
+      "__base": "if (!('Notification' in self)) {return false;} var instance = new Notification('');"
     },
     "OfflineAudioContext": {
       "__resources": ["offlineAudioContext"],


### PR DESCRIPTION
This PR fixes the Notification API custom test, by checking to see if the Notification API is defined first before attempting to construct a Notification instance.﻿
