### PR TITLE
Add instances for XMLHttpRequestEventTarget and XMLHttpRequestUpload

### DIFF
--- a/custom-tests.yaml
+++ b/custom-tests.yaml
@@ -2130,6 +2130,12 @@ api:
       var instance = new WritableStream({}).getWriter();
   XMLHttpRequest:
     __base: var instance = new XMLHttpRequest();
+  XMLHttpRequestEventTarget:
+    __base: <%api.XMLHttpRequest:instance%>
+  XMLHttpRequestUpload:
+    __base: >-
+      <%api.XMLHttpRequest:xhr%>
+      var instance = xhr.upload;
   XPathExpression:
     __base: >-
       var xpe = new XPathEvaluator();


### PR DESCRIPTION
For XMLHttpRequestEventTarget we could use either XMLHttpRequest or
XMLHttpRequestUpload and it's possible some event was first supported
for upload, but checking for support in both would be more involved.