### PR TITLE
Fix odd bug with older browsers trying to post results to example.org

### DIFF
--- a/static/resources/harness.js
+++ b/static/resources/harness.js
@@ -751,7 +751,9 @@
 
       client.open(
         'POST',
-        '/api/results?for=' + encodeURIComponent(location.href)
+        location.origin +
+          '/api/results?for=' +
+          encodeURIComponent(location.href)
       );
       client.setRequestHeader('Content-Type', 'application/json;charset=UTF-8');
       client.send(body);


### PR DESCRIPTION
This PR fixes a bug where older versions of Chrome and Safari (and possibly Firefox too) try to send the results to `example.org` instead of our own website.﻿
