### PR TITLE
Fix cryptoKey instance

### DIFF
--- a/custom-tests.yaml
+++ b/custom-tests.yaml
@@ -42,6 +42,9 @@ api:
           return false;
         };
         var subtlecrypto = crypto.subtle || crypto.webkitSubtle;
+        if (!subtlecrypto) {
+          return false;
+        };
         return subtlecrypto.generateKey({
           name: 'RSA-OAEP',
           modulusLength: 4096,


### PR DESCRIPTION
This PR fixes the `cryptoKey` instance to ensure `subtleCrypto` exists before attempting to generate a key.﻿
