### PR TITLE
Release 3.2.6

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -1,6 +1,6 @@
 {
   "name": "mdn-bcd-collector",
-  "version": "3.2.5",
+  "version": "3.2.6",
   "lockfileVersion": 1,
   "requires": true,
   "dependencies": {

--- a/package.json
+++ b/package.json
@@ -1,7 +1,7 @@
 {
   "name": "mdn-bcd-collector",
   "description": "Data collection service for @mdn/browser-compat-data",
-  "version": "3.2.5",
+  "version": "3.2.6",
   "private": true,
   "license": "Apache-2.0",
   "repository": {


### PR DESCRIPTION
This release includes a critical bug fix that causes issues with submitting results in Chrome ≤20 and Safari ≤6.  Additionally, this includes some improvements to the debug mode logs, and a fix for the `cryptoKey` instance.﻿
