### PR TITLE
Revert documentURI after testing api.Document.documentURI.readonly

### DIFF
--- a/custom-tests.yaml
+++ b/custom-tests.yaml
@@ -483,7 +483,9 @@ api:
         var orig = d.documentURI;
         try {
           d.documentURI = 'http://example.org/';
-          return d.documentURI === orig;
+          var result = d.documentURI === orig;
+          d.documentURI = orig; // Reset just in case
+          return result;
         } catch(e) {
           return e instanceof TypeError;
         }


### PR DESCRIPTION
This is a continuation from #1392 which fixes further issues I've found with the page links, including the export buttons.  The changes in #1392 fix an issue in some older Firefox releases as well, so there's no need to revert those changes.﻿
