### PR TITLE
Release 3.2.7

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -1,6 +1,6 @@
 {
   "name": "mdn-bcd-collector",
-  "version": "3.2.6",
+  "version": "3.2.7",
   "lockfileVersion": 1,
   "requires": true,
   "dependencies": {

--- a/package.json
+++ b/package.json
@@ -1,7 +1,7 @@
 {
   "name": "mdn-bcd-collector",
   "description": "Data collection service for @mdn/browser-compat-data",
-  "version": "3.2.6",
+  "version": "3.2.7",
   "private": true,
   "license": "Apache-2.0",
   "repository": {


### PR DESCRIPTION
This release properly fixes the bug in Chrome ≤20 / Safari ≤6 attempting to post results and navigate to `https://example.org`.﻿
