### PR TITLE
Bug fixes

### DIFF
--- a/custom-tests.yaml
+++ b/custom-tests.yaml
@@ -38,7 +38,7 @@ api:
     cryptoKey:
       type: instance
       src: >-
-        if (!('crypto' in self)) {
+        if (!('crypto' in self) || !crypto) {
           return false;
         };
         var subtlecrypto = crypto.subtle || crypto.webkitSubtle;

--- a/static/resources/harness.js
+++ b/static/resources/harness.js
@@ -770,7 +770,8 @@
 
       client.open(
         'POST',
-        location.origin +
+        location.protocol +
+          location.hostname +
           '/api/results?for=' +
           encodeURIComponent(location.href)
       );

--- a/static/resources/harness.js
+++ b/static/resources/harness.js
@@ -771,7 +771,7 @@
       client.open(
         'POST',
         location.protocol +
-          location.hostname +
+          location.host +
           '/api/results?for=' +
           encodeURIComponent(location.href)
       );


### PR DESCRIPTION
This PR fixes two bugs:

- `location.origin` is undefined in early browser versions; use `protocol` and `host` instead
- Check if `crypto` is actually defined when creating cryptoKey
