### PR TITLE
Release 3.2.8

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -1,6 +1,6 @@
 {
   "name": "mdn-bcd-collector",
-  "version": "3.2.7",
+  "version": "3.2.8",
   "lockfileVersion": 1,
   "requires": true,
   "dependencies": {

--- a/package.json
+++ b/package.json
@@ -1,7 +1,7 @@
 {
   "name": "mdn-bcd-collector",
   "description": "Data collection service for @mdn/browser-compat-data",
-  "version": "3.2.7",
+  "version": "3.2.8",
   "private": true,
   "license": "Apache-2.0",
   "repository": {


### PR DESCRIPTION
This release includes two bug fixes (one minor, one major):

- Check if `crypto` is defined before attempting to create `cryptoKey` instance (minor)
- Use `location.protocol` and `location.host` instead of `location.origin` to provide support for older browsers (major)﻿
