### PR TITLE
Updates for event custom tests

### DIFF
--- a/custom-tests.yaml
+++ b/custom-tests.yaml
@@ -1512,7 +1512,11 @@ api:
       }
       var instance = reusableInstances.audioContext.createScriptProcessor();
   SecurityPolicyViolationEvent:
-    __base: var instance = new SecurityPolicyViolationEvent('securitypolicyviolation');
+    __base: >-
+      if (!('SecurityPolicyViolationEvent' in self)) {
+        return false;
+      }
+      var instance = new SecurityPolicyViolationEvent('securitypolicyviolation');
   Selection:
     __base: var instance = window.getSelection();
   ShadowRoot:

--- a/custom-tests.yaml
+++ b/custom-tests.yaml
@@ -122,7 +122,14 @@ api:
       try {
         instance = new AnimationEvent('animationend');
       } catch(e) {
-        instance = document.createEvent('AnimationEvent');
+        try {
+          instance = document.createEvent('AnimationEvent');
+        } catch(e) {
+          if (e.name === 'NotSupportedError') {
+            return false;
+          }
+          throw e;
+        }
       }
   ApplicationCache:
     __base: var instance = window.applicationCache;
@@ -181,7 +188,14 @@ api:
       try {
         instance = new AudioProcessingEvent('audioprocess');
       } catch(e) {
-        instance = document.createEvent('AudioProcessingEvent');
+        try {
+          instance = document.createEvent('AudioProcessingEvent');
+        } catch(e) {
+          if (e.name === 'NotSupportedError') {
+            return false;
+          }
+          throw e;
+        }
       }
   AudioScheduledSourceNode:
     __resources:
@@ -239,7 +253,15 @@ api:
   #     var promise = navigator.getBattery();
   #     promise.then(function() {});
   BeforeUnloadEvent:
-    __base: var instance = document.createEvent('BeforeUnloadEvent');
+    __base: >-
+      try {
+        var instance = document.createEvent('BeforeUnloadEvent');
+      } catch(e) {
+        if (e.name === 'NotSupportedError') {
+          return false;
+        }
+        throw e;
+      }
   BiquadFilterNode:
     __resources:
       - audioContext
@@ -307,7 +329,14 @@ api:
       try {
         instance = new CloseEvent('close');
       } catch(e) {
-        instance = document.createEvent('CloseEvent');
+        try {
+          instance = document.createEvent('CloseEvent');
+        } catch(e) {
+          if (e.name === 'NotSupportedError') {
+            return false;
+          }
+          throw e;
+        }
       }
   CompositionEvent:
     __base: >-
@@ -315,7 +344,14 @@ api:
       try {
         instance = new CompositionEvent('compositionstart');
       } catch(e) {
-        instance = document.createEvent('CompositionEvent');
+        try {
+          instance = document.createEvent('CompositionEvent');
+        } catch(e) {
+          if (e.name === 'NotSupportedError') {
+            return false;
+          }
+          throw e;
+        }
       }
   ConstantSourceNode:
     __resources:
@@ -443,7 +479,14 @@ api:
       try {
         instance = new CustomEvent('custom');
       } catch(e) {
-        instance = document.createEvent('CustomEvent');
+        try {
+          instance = document.createEvent('CustomEvent');
+        } catch(e) {
+          if (e.name === 'NotSupportedError') {
+            return false;
+          }
+          throw e;
+        }
       }
   DelayNode:
     __resources:
@@ -459,7 +502,14 @@ api:
       try {
         instance = new DeviceMotionEvent('devicemotion');
       } catch(e) {
-        instance = document.createEvent('DeviceMotionEvent');
+        try {
+          instance = document.createEvent('DeviceMotionEvent');
+        } catch(e) {
+          if (e.name === 'NotSupportedError') {
+            return false;
+          }
+          throw e;
+        }
       }
   DeviceOrientationEvent:
     __base: >-
@@ -467,7 +517,14 @@ api:
       try {
         instance = new DeviceOrientationEvent('deviceorientation');
       } catch(e) {
-        instance = document.createEvent('DeviceOrientationEvent');
+        try {
+          instance = document.createEvent('DeviceOrientationEvent');
+        } catch(e) {
+          if (e.name === 'NotSupportedError') {
+            return false;
+          }
+          throw e;
+        }
       }
   Document:
     __base: var instance = document;
@@ -529,7 +586,14 @@ api:
       try {
         instance = new DragEvent('drag');
       } catch(e) {
-        instance = document.createEvent('DragEvent');
+        try {
+          instance = document.createEvent('DragEvent');
+        } catch(e) {
+          if (e.name === 'NotSupportedError') {
+            return false;
+          }
+          throw e;
+        }
       }
   DynamicsCompressorNode:
     __resources:
@@ -553,7 +617,14 @@ api:
       try {
         instance = new ErrorEvent('error');
       } catch(e) {
-        instance = document.createEvent('ErrorEvent');
+        try {
+          instance = document.createEvent('ErrorEvent');
+        } catch(e) {
+          if (e.name === 'NotSupportedError') {
+            return false;
+          }
+          throw e;
+        }
       }
   Event:
     __base: >-
@@ -561,7 +632,14 @@ api:
       try {
         instance = new Event('type');
       } catch(e) {
-        instance = document.createEvent('Event');
+        try {
+          instance = document.createEvent('Event');
+        } catch(e) {
+          if (e.name === 'NotSupportedError') {
+            return false;
+          }
+          throw e;
+        }
       }
   EventSource:
     __base: var instance = new EventSource('/eventstream');
@@ -691,7 +769,14 @@ api:
       try {
         instance = new FocusEvent('focus');
       } catch(e) {
-        instance = document.createEvent('FocusEvent');
+        try {
+          instance = document.createEvent('FocusEvent');
+        } catch(e) {
+          if (e.name === 'NotSupportedError') {
+            return false;
+          }
+          throw e;
+        }
       }
   FontFace:
     __base: var instance = new FontFace('Material Design Icons', 'url(/fonts/materialdesignicons-webfont.woff)');
@@ -713,7 +798,14 @@ api:
       try {
         instance = new HashChangeEvent('hashchange');
       } catch(e) {
-        instance = document.createEvent('HashChangeEvent');
+        try {
+          instance = document.createEvent('HashChangeEvent');
+        } catch(e) {
+          if (e.name === 'NotSupportedError') {
+            return false;
+          }
+          throw e;
+        }
       }
   History:
     __base: var instance = history;
@@ -980,7 +1072,14 @@ api:
       try {
         instance = new IDBVersionChangeEvent('upgradeneeded');
       } catch(e) {
-        instance = document.createEvent('IDBVersionChangeEvent');
+        try {
+          instance = document.createEvent('IDBVersionChangeEvent');
+        } catch(e) {
+          if (e.name === 'NotSupportedError') {
+            return false;
+          }
+          throw e;
+        }
       }
   IIRFilterNode:
     __resources:
@@ -1014,7 +1113,14 @@ api:
       try {
         instance = new KeyboardEvent('keypress');
       } catch(e) {
-        instance = document.createEvent('KeyboardEvent');
+        try {
+          instance = document.createEvent('KeyboardEvent');
+        } catch(e) {
+          if (e.name === 'NotSupportedError') {
+            return false;
+          }
+          throw e;
+        }
       }
   KHR_parallel_shader_compile:
     __resources:
@@ -1115,7 +1221,14 @@ api:
       try {
         instance = new MessageEvent('message');
       } catch(e) {
-        instance = document.createEvent('MessageEvent');
+        try {
+          instance = document.createEvent('MessageEvent');
+        } catch(e) {
+          if (e.name === 'NotSupportedError') {
+            return false;
+          }
+          throw e;
+        }
       }
   MessageChannel:
     __base: >-
@@ -1137,10 +1250,25 @@ api:
       try {
         instance = new MouseEvent('click');
       } catch(e) {
-        instance = document.createEvent('MouseEvent');
+        try {
+          instance = document.createEvent('MouseEvent');
+        } catch(e) {
+          if (e.name === 'NotSupportedError') {
+            return false;
+          }
+          throw e;
+        }
       }
   MutationEvent:
-    __base: var instance = document.createEvent('MutationEvent');
+    __base: >-
+      try {
+        var instance = document.createEvent('MutationEvent');
+      } catch(e) {
+        if (e.name === 'NotSupportedError') {
+          return false;
+        }
+        throw e;
+      }
   NamedNodeMap:
     __base: var instance = document.body.attributes;
   Navigator:
@@ -1264,7 +1392,14 @@ api:
       try {
         instance = new PageTransitionEvent('pageshow');
       } catch(e) {
-        instance = document.createEvent('PageTransitionEvent');
+        try {
+          instance = document.createEvent('PageTransitionEvent');
+        } catch(e) {
+          if (e.name === 'NotSupportedError') {
+            return false;
+          }
+          throw e;
+        }
       }
   PannerNode:
     __resources:
@@ -1328,7 +1463,14 @@ api:
       try {
         instance = new PopStateEvent('popstate');
       } catch(e) {
-        instance = document.createEvent('PopStateEvent');
+        try {
+          instance = document.createEvent('PopStateEvent');
+        } catch(e) {
+          if (e.name === 'NotSupportedError') {
+            return false;
+          }
+          throw e;
+        }
       }
   ProcessingInstruction:
     __base: >-
@@ -1392,7 +1534,14 @@ api:
       try {
         instance = new SpeechRecognitionErrorEvent('error');
       } catch(e) {
-        instance = document.createEvent('SpeechRecognitionErrorEvent');
+        try {
+          instance = document.createEvent('SpeechRecognitionErrorEvent');
+        } catch(e) {
+          if (e.name === 'NotSupportedError') {
+            return false;
+          }
+          throw e;
+        }
       }
   SpeechRecognitionEvent:
     __base: >-
@@ -1400,7 +1549,14 @@ api:
       try {
         instance = new SpeechRecognitionEvent('result');
       } catch(e) {
-        instance = document.createEvent('SpeechRecognitionEvent');
+        try {
+          instance = document.createEvent('SpeechRecognitionEvent');
+        } catch(e) {
+          if (e.name === 'NotSupportedError') {
+            return false;
+          }
+          throw e;
+        }
       }
   SpeechSynthesisErrorEvent:
     __base: >-
@@ -1408,7 +1564,14 @@ api:
       try {
         instance = new SpeechSynthesisErrorEvent('error');
       } catch(e) {
-        instance = document.createEvent('SpeechSynthesisErrorEvent');
+        try {
+          instance = document.createEvent('SpeechSynthesisErrorEvent');
+        } catch(e) {
+          if (e.name === 'NotSupportedError') {
+            return false;
+          }
+          throw e;
+        }
       }
   SpeechSynthesisEvent:
     __base: >-
@@ -1416,7 +1579,14 @@ api:
       try {
         instance = new SpeechSynthesisEvent('start');
       } catch(e) {
-        instance = document.createEvent('SpeechSynthesisEvent');
+        try {
+          instance = document.createEvent('SpeechSynthesisEvent');
+        } catch(e) {
+          if (e.name === 'NotSupportedError') {
+            return false;
+          }
+          throw e;
+        }
       }
   StereoPannerNode:
     __resources:
@@ -1432,7 +1602,14 @@ api:
       try {
         instance = new StorageEvent('storage');
       } catch(e) {
-        instance = document.createEvent('StorageEvent');
+        try {
+          instance = document.createEvent('StorageEvent');
+        } catch(e) {
+          if (e.name === 'NotSupportedError') {
+            return false;
+          }
+          throw e;
+        }
       }
   StyleMedia:
     __base: var instance = window.styleMedia;
@@ -1866,14 +2043,28 @@ api:
       try {
         instance = new TrackEvent('addtrack');
       } catch(e) {
-        instance = document.createEvent('TrackEvent');
+        try {
+          instance = document.createEvent('TrackEvent');
+        } catch(e) {
+          if (e.name === 'NotSupportedError') {
+            return false;
+          }
+          throw e;
+        }
       }
   TransitionEvent:
     __base: >-
       var instance;
         try {instance = new TransitionEvent('transitionend');
       } catch(e) {
-        instance = document.createEvent('TransitionEvent');
+        try {
+          instance = document.createEvent('TransitionEvent');
+        } catch(e) {
+          if (e.name === 'NotSupportedError') {
+            return false;
+          }
+          throw e;
+        }
       }
   TreeWalker:
     __base: var instance = document.createTreeWalker(document);
@@ -1883,7 +2074,14 @@ api:
       try {
         instance = new UIEvent('');
       } catch(e) {
-        instance = document.createEvent('UIEvent');
+        try {
+          instance = document.createEvent('UIEvent');
+        } catch(e) {
+          if (e.name === 'NotSupportedError') {
+            return false;
+          }
+          throw e;
+        }
       }
   URL:
     __base: >-
@@ -1928,7 +2126,14 @@ api:
       try {
         instance = new WebGLContextEvent('webglcontextlost');
       } catch(e) {
-        instance = document.createEvent('WebGLContextEvent');
+        try {
+          instance = document.createEvent('WebGLContextEvent');
+        } catch(e) {
+          if (e.name === 'NotSupportedError') {
+            return false;
+          }
+          throw e;
+        }
       }
   WebGLRenderingContext:
     __resources:
@@ -2092,7 +2297,14 @@ api:
       try {
         instance = new WebKitAnimationEvent('webkitAnimationEnd');
       } catch(e) {
-        instance = document.createEvent('WebKitAnimationEvent');
+        try {
+          instance = document.createEvent('WebKitAnimationEvent');
+        } catch(e) {
+          if (e.name === 'NotSupportedError') {
+            return false;
+          }
+          throw e;
+        }
       }
   WebKitTransitionEvent:
     __base: >-
@@ -2100,7 +2312,14 @@ api:
       try {
         instance = new WebKitTransitionEvent('webkitTransitionEnd');
       } catch(e) {
-        instance = document.createEvent('WebKitTransitionEvent');
+        try {
+          instance = document.createEvent('WebKitTransitionEvent');
+        } catch(e) {
+          if (e.name === 'NotSupportedError') {
+            return false;
+          }
+          throw e;
+        }
       }
   WebSocket:
     __base: >-
@@ -2115,7 +2334,14 @@ api:
       try {
         instance = new WheelEvent('wheel');
       } catch(e) {
-        instance = document.createEvent('WheelEvent');
+        try {
+          instance = document.createEvent('WheelEvent');
+        } catch(e) {
+          if (e.name === 'NotSupportedError') {
+            return false;
+          }
+          throw e;
+        }
       }
   Window:
     __base: var instance = window;

--- a/custom-tests.yaml
+++ b/custom-tests.yaml
@@ -125,7 +125,7 @@ api:
         try {
           instance = document.createEvent('AnimationEvent');
         } catch(e) {
-          if (e.name === 'NotSupportedError') {
+          if (e.name === 'NotSupportedError' || e.name === 'NOT_SUPPORTED_ERR') {
             return false;
           }
           throw e;
@@ -191,7 +191,7 @@ api:
         try {
           instance = document.createEvent('AudioProcessingEvent');
         } catch(e) {
-          if (e.name === 'NotSupportedError') {
+          if (e.name === 'NotSupportedError' || e.name === 'NOT_SUPPORTED_ERR') {
             return false;
           }
           throw e;
@@ -257,7 +257,7 @@ api:
       try {
         var instance = document.createEvent('BeforeUnloadEvent');
       } catch(e) {
-        if (e.name === 'NotSupportedError') {
+        if (e.name === 'NotSupportedError' || e.name === 'NOT_SUPPORTED_ERR') {
           return false;
         }
         throw e;
@@ -332,7 +332,7 @@ api:
         try {
           instance = document.createEvent('CloseEvent');
         } catch(e) {
-          if (e.name === 'NotSupportedError') {
+          if (e.name === 'NotSupportedError' || e.name === 'NOT_SUPPORTED_ERR') {
             return false;
           }
           throw e;
@@ -347,7 +347,7 @@ api:
         try {
           instance = document.createEvent('CompositionEvent');
         } catch(e) {
-          if (e.name === 'NotSupportedError') {
+          if (e.name === 'NotSupportedError' || e.name === 'NOT_SUPPORTED_ERR') {
             return false;
           }
           throw e;
@@ -482,7 +482,7 @@ api:
         try {
           instance = document.createEvent('CustomEvent');
         } catch(e) {
-          if (e.name === 'NotSupportedError') {
+          if (e.name === 'NotSupportedError' || e.name === 'NOT_SUPPORTED_ERR') {
             return false;
           }
           throw e;
@@ -505,7 +505,7 @@ api:
         try {
           instance = document.createEvent('DeviceMotionEvent');
         } catch(e) {
-          if (e.name === 'NotSupportedError') {
+          if (e.name === 'NotSupportedError' || e.name === 'NOT_SUPPORTED_ERR') {
             return false;
           }
           throw e;
@@ -520,7 +520,7 @@ api:
         try {
           instance = document.createEvent('DeviceOrientationEvent');
         } catch(e) {
-          if (e.name === 'NotSupportedError') {
+          if (e.name === 'NotSupportedError' || e.name === 'NOT_SUPPORTED_ERR') {
             return false;
           }
           throw e;
@@ -589,7 +589,7 @@ api:
         try {
           instance = document.createEvent('DragEvent');
         } catch(e) {
-          if (e.name === 'NotSupportedError') {
+          if (e.name === 'NotSupportedError' || e.name === 'NOT_SUPPORTED_ERR') {
             return false;
           }
           throw e;
@@ -620,7 +620,7 @@ api:
         try {
           instance = document.createEvent('ErrorEvent');
         } catch(e) {
-          if (e.name === 'NotSupportedError') {
+          if (e.name === 'NotSupportedError' || e.name === 'NOT_SUPPORTED_ERR') {
             return false;
           }
           throw e;
@@ -635,7 +635,7 @@ api:
         try {
           instance = document.createEvent('Event');
         } catch(e) {
-          if (e.name === 'NotSupportedError') {
+          if (e.name === 'NotSupportedError' || e.name === 'NOT_SUPPORTED_ERR') {
             return false;
           }
           throw e;
@@ -772,7 +772,7 @@ api:
         try {
           instance = document.createEvent('FocusEvent');
         } catch(e) {
-          if (e.name === 'NotSupportedError') {
+          if (e.name === 'NotSupportedError' || e.name === 'NOT_SUPPORTED_ERR') {
             return false;
           }
           throw e;
@@ -801,7 +801,7 @@ api:
         try {
           instance = document.createEvent('HashChangeEvent');
         } catch(e) {
-          if (e.name === 'NotSupportedError') {
+          if (e.name === 'NotSupportedError' || e.name === 'NOT_SUPPORTED_ERR') {
             return false;
           }
           throw e;
@@ -1075,7 +1075,7 @@ api:
         try {
           instance = document.createEvent('IDBVersionChangeEvent');
         } catch(e) {
-          if (e.name === 'NotSupportedError') {
+          if (e.name === 'NotSupportedError' || e.name === 'NOT_SUPPORTED_ERR') {
             return false;
           }
           throw e;
@@ -1116,7 +1116,7 @@ api:
         try {
           instance = document.createEvent('KeyboardEvent');
         } catch(e) {
-          if (e.name === 'NotSupportedError') {
+          if (e.name === 'NotSupportedError' || e.name === 'NOT_SUPPORTED_ERR') {
             return false;
           }
           throw e;
@@ -1224,7 +1224,7 @@ api:
         try {
           instance = document.createEvent('MessageEvent');
         } catch(e) {
-          if (e.name === 'NotSupportedError') {
+          if (e.name === 'NotSupportedError' || e.name === 'NOT_SUPPORTED_ERR') {
             return false;
           }
           throw e;
@@ -1253,7 +1253,7 @@ api:
         try {
           instance = document.createEvent('MouseEvent');
         } catch(e) {
-          if (e.name === 'NotSupportedError') {
+          if (e.name === 'NotSupportedError' || e.name === 'NOT_SUPPORTED_ERR') {
             return false;
           }
           throw e;
@@ -1264,7 +1264,7 @@ api:
       try {
         var instance = document.createEvent('MutationEvent');
       } catch(e) {
-        if (e.name === 'NotSupportedError') {
+        if (e.name === 'NotSupportedError' || e.name === 'NOT_SUPPORTED_ERR') {
           return false;
         }
         throw e;
@@ -1395,7 +1395,7 @@ api:
         try {
           instance = document.createEvent('PageTransitionEvent');
         } catch(e) {
-          if (e.name === 'NotSupportedError') {
+          if (e.name === 'NotSupportedError' || e.name === 'NOT_SUPPORTED_ERR') {
             return false;
           }
           throw e;
@@ -1466,7 +1466,7 @@ api:
         try {
           instance = document.createEvent('PopStateEvent');
         } catch(e) {
-          if (e.name === 'NotSupportedError') {
+          if (e.name === 'NotSupportedError' || e.name === 'NOT_SUPPORTED_ERR') {
             return false;
           }
           throw e;
@@ -1537,7 +1537,7 @@ api:
         try {
           instance = document.createEvent('SpeechRecognitionErrorEvent');
         } catch(e) {
-          if (e.name === 'NotSupportedError') {
+          if (e.name === 'NotSupportedError' || e.name === 'NOT_SUPPORTED_ERR') {
             return false;
           }
           throw e;
@@ -1552,7 +1552,7 @@ api:
         try {
           instance = document.createEvent('SpeechRecognitionEvent');
         } catch(e) {
-          if (e.name === 'NotSupportedError') {
+          if (e.name === 'NotSupportedError' || e.name === 'NOT_SUPPORTED_ERR') {
             return false;
           }
           throw e;
@@ -1567,7 +1567,7 @@ api:
         try {
           instance = document.createEvent('SpeechSynthesisErrorEvent');
         } catch(e) {
-          if (e.name === 'NotSupportedError') {
+          if (e.name === 'NotSupportedError' || e.name === 'NOT_SUPPORTED_ERR') {
             return false;
           }
           throw e;
@@ -1582,7 +1582,7 @@ api:
         try {
           instance = document.createEvent('SpeechSynthesisEvent');
         } catch(e) {
-          if (e.name === 'NotSupportedError') {
+          if (e.name === 'NotSupportedError' || e.name === 'NOT_SUPPORTED_ERR') {
             return false;
           }
           throw e;
@@ -1605,7 +1605,7 @@ api:
         try {
           instance = document.createEvent('StorageEvent');
         } catch(e) {
-          if (e.name === 'NotSupportedError') {
+          if (e.name === 'NotSupportedError' || e.name === 'NOT_SUPPORTED_ERR') {
             return false;
           }
           throw e;
@@ -2046,7 +2046,7 @@ api:
         try {
           instance = document.createEvent('TrackEvent');
         } catch(e) {
-          if (e.name === 'NotSupportedError') {
+          if (e.name === 'NotSupportedError' || e.name === 'NOT_SUPPORTED_ERR') {
             return false;
           }
           throw e;
@@ -2060,7 +2060,7 @@ api:
         try {
           instance = document.createEvent('TransitionEvent');
         } catch(e) {
-          if (e.name === 'NotSupportedError') {
+          if (e.name === 'NotSupportedError' || e.name === 'NOT_SUPPORTED_ERR') {
             return false;
           }
           throw e;
@@ -2077,7 +2077,7 @@ api:
         try {
           instance = document.createEvent('UIEvent');
         } catch(e) {
-          if (e.name === 'NotSupportedError') {
+          if (e.name === 'NotSupportedError' || e.name === 'NOT_SUPPORTED_ERR') {
             return false;
           }
           throw e;
@@ -2129,7 +2129,7 @@ api:
         try {
           instance = document.createEvent('WebGLContextEvent');
         } catch(e) {
-          if (e.name === 'NotSupportedError') {
+          if (e.name === 'NotSupportedError' || e.name === 'NOT_SUPPORTED_ERR') {
             return false;
           }
           throw e;
@@ -2300,7 +2300,7 @@ api:
         try {
           instance = document.createEvent('WebKitAnimationEvent');
         } catch(e) {
-          if (e.name === 'NotSupportedError') {
+          if (e.name === 'NotSupportedError' || e.name === 'NOT_SUPPORTED_ERR') {
             return false;
           }
           throw e;
@@ -2315,7 +2315,7 @@ api:
         try {
           instance = document.createEvent('WebKitTransitionEvent');
         } catch(e) {
-          if (e.name === 'NotSupportedError') {
+          if (e.name === 'NotSupportedError' || e.name === 'NOT_SUPPORTED_ERR') {
             return false;
           }
           throw e;
@@ -2337,7 +2337,7 @@ api:
         try {
           instance = document.createEvent('WheelEvent');
         } catch(e) {
-          if (e.name === 'NotSupportedError') {
+          if (e.name === 'NotSupportedError' || e.name === 'NOT_SUPPORTED_ERR') {
             return false;
           }
           throw e;

--- a/selenium.js
+++ b/selenium.js
@@ -62,7 +62,7 @@ const ignore = {
     12: gumTests,
     13: gumTests,
     14: gumTests,
-    15: gumTests,
+    15: ['SecurityPolicyViolationEvent', ...gumTests],
     16: gumTests,
     17: gumTests,
     18: gumTests


### PR DESCRIPTION
This PR is a follow-up to the event interface tests, fixing a few bugs.

- During creation, we now catch when `document.createEvent` throws a `NotSupportedError` error, and we treat that as "no support".﻿
- If `SecurityPolicyViolationEvent` is undefined, don't attempt to construct it and instead return false.
- Edge 15 reloads the page when a `SecurityPolicyViolationEvent` is created; ignore it in Selenium.