### PR TITLE
Fix test for RTCPeerConnection

### DIFF
--- a/custom-tests.yaml
+++ b/custom-tests.yaml
@@ -1500,7 +1500,7 @@ api:
       if (!constructor) {
         return false;
       }
-      var instance = new constructor();
+      var instance = new constructor({iceServers: []});
   Screen:
     __base: var instance = window.screen;
   ScriptProcessorNode:

--- a/custom-tests.yaml
+++ b/custom-tests.yaml
@@ -1500,6 +1500,10 @@ api:
       if (!constructor) {
         return false;
       }
+      var cnstResult = bcd.testConstructor(constructor);
+      if (cnstResult.result !== true) {
+        return cnstResult;
+      }
       var instance = new constructor({iceServers: []});
   Screen:
     __base: var instance = window.screen;


### PR DESCRIPTION
- Fix test for RTCPeerConnection for older browsers
- Use bcd.testConstructor to check if the constructor is one
