### PR TITLE
Use performance.getEntries() to get PerformanceEntry instance

### DIFF
--- a/custom-tests.yaml
+++ b/custom-tests.yaml
@@ -1416,7 +1416,12 @@ api:
       };
       var instance = performance;
   PerformanceEntry:
-    __base: <%api.PerformanceMark:instance%>
+    __base: >-
+      <%api.Performance:prf%>
+      if (!('getEntries' in prf)) {
+        return false;
+      }
+      var instance = prf.getEntries()[0];
   PerformanceMark:
     __base: >-
       if (!('performance' in self)) {


### PR DESCRIPTION
Addresses https://github.com/mdn/browser-compat-data/pull/12033.﻿
