### PR TITLE
Simplify the RTCPeerConnection test

### DIFF
--- a/custom-tests.yaml
+++ b/custom-tests.yaml
@@ -1505,10 +1505,6 @@ api:
       if (!constructor) {
         return false;
       }
-      var cnstResult = bcd.testConstructor(constructor);
-      if (cnstResult.result !== true) {
-        return cnstResult;
-      }
       var instance = new constructor({iceServers: []});
   Screen:
     __base: var instance = window.screen;


### PR DESCRIPTION
The use of bcd.testConstructor ought to be unnecessary:
https://github.com/foolip/mdn-bcd-collector/pull/1409/files#r692927844