### PR TITLE
Fix the comment for RTCPeerConnection

### DIFF
--- a/custom-tests.yaml
+++ b/custom-tests.yaml
@@ -1504,16 +1504,14 @@ api:
       var constructor = (window.RTCPeerConnection || window.mozRTCPeerConnection || window.webkitRTCPeerConnection);
       if (!constructor) {
         return false;
-      }
+      };
 
-      // Earlier versions of Firefox expose mozRTCPeerConnection 
-      // but it is not a valid constructor. Check to see if the constructor
-      // is valid first.
+      /* Earlier versions of Firefox expose mozRTCPeerConnection but it is not a valid constructor. Check to see if the constructor is valid first. */
       var cnstResult = bcd.testConstructor(constructor);
       if (cnstResult.result !== true) {
         return cnstResult;
-      }
-
+      };
+      
       var instance = new constructor({iceServers: []});
   Screen:
     __base: var instance = window.screen;

--- a/custom-tests.yaml
+++ b/custom-tests.yaml
@@ -1511,7 +1511,7 @@ api:
       if (cnstResult.result !== true) {
         return cnstResult;
       };
-      
+
       var instance = new constructor({iceServers: []});
   Screen:
     __base: var instance = window.screen;


### PR DESCRIPTION
This PR fixes the comment regarding the constructor for RTCPeerConnection by using `/* */` for comments rather than `//`.  This fixes the conflict with Prettier formatting.﻿
