### PR TITLE
Fix Safari bug for window.crypto

### DIFF
--- a/custom-tests.yaml
+++ b/custom-tests.yaml
@@ -2373,6 +2373,7 @@ api:
       }
   Window:
     __base: var instance = window;
+    crypto: return 'crypto' in instance && !!instance.crypto;
   WindowOrWorkerGlobalScope:
     __base: var instance = self;
   WorkerGlobalScope:


### PR DESCRIPTION
This PR fixes a results bug in earlier Safari versions, where `window.crypto` exists and is explicitly being defined as `undefined` (see https://github.com/mdn/browser-compat-data/pull/12152#discussion_r702260957).﻿
