### PR TITLE
Update custom test for ImageData

### DIFF
--- a/custom-tests.yaml
+++ b/custom-tests.yaml
@@ -1114,8 +1114,13 @@ api:
       });
   ImageData:
     __base: >-
-      <%api.CanvasRenderingContext2D:ctx%>
-      var instance = ctx.createImageData(16, 16);
+      var instance;
+      if ('ImageData' in self) {
+        instance = new ImageData(5, 5);
+      } else if ('document' in self) {
+        <%api.CanvasRenderingContext2D:ctx%>
+        instance = ctx.createImageData(16, 16);
+      }
   InstallEvent:
     __base: var instance = new InstallEvent('install');
   KeyboardEvent:


### PR DESCRIPTION
This PR updates the custom test for the `ImageData` API.  Initially the test relied only on a canvas rendering context, but this API also has a constructor.  Now, this test attempts the constructor first, and if the constructor doesn't work, fallback to using the canvas rendering context.﻿
