### PR TITLE
Simplify window.crypto custom test

### DIFF
--- a/custom-tests.yaml
+++ b/custom-tests.yaml
@@ -2385,7 +2385,7 @@ api:
       }
   Window:
     __base: var instance = window;
-    crypto: return 'crypto' in instance && !!instance.crypto;
+    crypto: return !!self.crypto;
   WindowOrWorkerGlobalScope:
     __base: var instance = self;
   WorkerGlobalScope:


### PR DESCRIPTION
First checking `'crypto' in window` is redundant.