### PR TITLE
Remove custom test for api.Document.documentURI.readonly

### DIFF
--- a/custom-tests.yaml
+++ b/custom-tests.yaml
@@ -535,17 +535,6 @@ api:
       createElementNS.options: >-
         <%api.Document:d%>
         return !!d.createElement('span', {});
-      documentURI.readonly: >-
-        <%api.Document:d%>
-        var orig = d.documentURI;
-        try {
-          d.documentURI = 'http://example.org/';
-          var result = d.documentURI === orig;
-          d.documentURI = orig; // Reset just in case
-          return result;
-        } catch(e) {
-          return e instanceof TypeError;
-        }
   DocumentFragment:
     __base: var instance = document.createDocumentFragment();
   DocumentType:


### PR DESCRIPTION
This PR removes the custom test  for `api.Document.documentURI.readonly`.  Correlates with the subsequent removal in BCD (https://github.com/mdn/browser-compat-data/pull/12276).﻿
