### PR TITLE
Send the right tests to SharedWorker and ServiceWorker

### DIFF
--- a/static/resources/harness.js
+++ b/static/resources/harness.js
@@ -471,7 +471,7 @@
         myWorker.port.postMessage(
           JSON.stringify({
             instances: reusableInstances.__sources,
-            tests: pending.Worker
+            tests: pending.SharedWorker
           })
         );
       } else {
@@ -530,7 +530,7 @@
               reg.active.postMessage(
                 JSON.stringify({
                   instances: reusableInstances.__sources,
-                  tests: pending.Worker
+                  tests: pending.ServiceWorker
                 }),
                 [messageChannel.port2]
               );


### PR DESCRIPTION
The tests for Worker were always sent here, which is right often enough
that nobody noticed until now. However, when there are no Worker tests,
it breaks.

This doesn't change the generated tests, but it will change which tests
are actually run, and so might have a big impact on the results.

Fixes https://github.com/foolip/mdn-bcd-collector/issues/1478.