### PR TITLE
Add required request parameter to FetchEvent constructor

### DIFF
--- a/custom-tests.yaml
+++ b/custom-tests.yaml
@@ -760,7 +760,9 @@ api:
   External:
     __base: var instance = window.external;
   FetchEvent:
-    __base: var instance = new FetchEvent('fetch');
+    __base: >-
+      <%api.Request:req%>
+      var instance = new FetchEvent('fetch', { request: req });
   FileReader:
     __base: var instance = new FileReader();
   FocusEvent:


### PR DESCRIPTION
Even with this change the test doesn't work as far back as FetchEvent is
probably supported, but at least it now works for current browsers.