### PR TITLE
Automatically tag new releases

### DIFF
--- a/.github/workflows/push.yml
+++ b/.github/workflows/push.yml
@@ -29,6 +29,9 @@ jobs:
         path: package.json
       env:
         GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}
+    - if: steps.version-updated.outputs.has-updated
+      name: GitHub Tag
+      uses: mathieudutour/github-tag-action@v5.6
     - uses: actions/checkout@v2
     - uses: google-github-actions/setup-gcloud@master
       with:


### PR DESCRIPTION
This PR updates the `push` workflow to automatically tag new releases as needed.