### PR TITLE
Attach GitHub token to auto-tag action

### DIFF
--- a/.github/workflows/push.yml
+++ b/.github/workflows/push.yml
@@ -32,6 +32,8 @@ jobs:
     - if: steps.version-updated.outputs.has-updated
       name: GitHub Tag
       uses: mathieudutour/github-tag-action@v5.6
+      with:
+        github_token: ${{ secrets.GITHUB_TOKEN }}
     - uses: actions/checkout@v2
     - uses: google-github-actions/setup-gcloud@master
       with:


### PR DESCRIPTION
Forgot to attach the GitHub token to the auto-tag action beforehand, whoops!  This is a quick fix to attach it.