### PR TITLE
Fix test for XPathResult in old Firefox versions

### DIFF
--- a/custom-tests.yaml
+++ b/custom-tests.yaml
@@ -2426,7 +2426,7 @@ api:
   XPathResult:
     __base: >-
       <%api.XPathExpression:exp%>
-      var instance = exp.evaluate(document);
+      var instance = exp.evaluate(document, 0, null);
 
 css:
   properties:


### PR DESCRIPTION
In versions of Firefox below 58, the other two parameters are required.  This PR adds them in to fix the test in older Firefox versions.﻿
