### PR TITLE
Remove insufficient tests for document.createElement() options

### DIFF
--- a/custom-tests.yaml
+++ b/custom-tests.yaml
@@ -528,13 +528,6 @@ api:
       }
   Document:
     __base: var instance = document;
-    __additional:
-      createElement.options: >-
-        <%api.Document:d%>
-        return !!d.createElement('span', {});
-      createElementNS.options: >-
-        <%api.Document:d%>
-        return !!d.createElement('span', {});
   DocumentFragment:
     __base: var instance = document.createDocumentFragment();
   DocumentType:


### PR DESCRIPTION
These tests will return true even if the options are completely ignored.