### PR TITLE
Limit deploy action to only run one at a time

### DIFF
--- a/.github/workflows/push.yml
+++ b/.github/workflows/push.yml
@@ -20,8 +20,9 @@ jobs:
     name: Deploy
     needs: test
     runs-on: ubuntu-latest
-    strategy:
-      max-parallel: 1
+    concurrency:
+      group: deploy
+      cancel-in-progress: true
     steps:
     - uses: MontyD/package-json-updated-action@1.0.1
       id: version-updated


### PR DESCRIPTION
This PR replaces the non-functional `max-parallel` parameter with `concurrency`, which is supposed to ensure that only one deployment job runs at a time.  This will cancel any in-progress deployment to ensure that we'll always deploy the latest version.