### PR TITLE
Fix styling for inputs and light background

### DIFF
--- a/style.scss
+++ b/style.scss
@@ -31,13 +31,17 @@ $colors: (
     dark: #bbf,
     light: #44f
   ),
+  input-fg: (
+    dark: white,
+    light: white
+  ),
   input-bg: (
-    dark: #3d8a3f,
-    light: #3d8a3f
+    dark: #2d672f,
+    light: #2d672f
   ),
   input-hover-bg: (
-    dark: #4caf50,
-    light: #4caf50
+    dark: #3d8a3f,
+    light: #3d8a3f
   ),
   input-disabled-bg: (
     dark: #636363,
@@ -128,8 +132,8 @@ $colors: (
   @media (prefers-color-scheme: light) {
     @include gradient-base(
       $direction,
-      map-deep-get($colors, $color-1, 'dark'),
-      map-deep-get($colors, $color-2, 'dark')
+      map-deep-get($colors, $color-1, 'light'),
+      map-deep-get($colors, $color-2, 'light')
     );
   }
 }
@@ -176,7 +180,7 @@ button,
 select,
 input {
   @include themedProperty(background, 'input-bg');
-  @include themedProperty(color, 'text');
+  @include themedProperty(color, 'input-fg');
   border: none;
   text-align: center;
   text-decoration: none;


### PR DESCRIPTION
This PR performs two styling updates for light theme and contrast:

- Fixes the background on light themes.  Both were set to use the dark theme colors due to a copy-paste error.
- Fixes the input's colors by adding an `input-fg` which is set to `white` for both modes (since the other input colors are the same).
- Fixes the contrast of inputs to meet WCAG AA compliance.  Closes #1418, fixes #1410.  (I picked different colors because I wanted the hue to remain the same.)
