### PR TITLE
Ignore Safari backported releases

### DIFF
--- a/ua-parser.js
+++ b/ua-parser.js
@@ -74,6 +74,15 @@ const parseUA = (userAgent, browsers) => {
   const versions = Object.keys(browsers[data.browser.id].releases);
   versions.sort(compareVersions);
 
+  // Certain Safari versions are backports of newer versions, but contain less
+  // features, particularly ones involving OS integration. We will ignore these
+  // versions instead of remapping them to other versions to avoid confusion.
+  if (data.browser.id === 'safari') {
+    if (['4.1', '6.1', '6.2', '7.1'].includes(data.version)) {
+      return data;
+    }
+  }
+
   // The |version| from the UA string is typically more precise than |versions|
   // from BCD, and some "uninteresting" releases are missing from BCD. To deal
   // with this, find the pair of versions in |versions| that sandwiches


### PR DESCRIPTION
This PR updates the UA parser to ignore known backported releases of Safari, rather than remapping them to the versions they backport (due to OS integration differences causing some features to report as false) or worse, to their prior versions.  This is practically the opposite of #1244.
