### PR TITLE
Make auto-tag action use the correct version

### DIFF
--- a/.github/workflows/push.yml
+++ b/.github/workflows/push.yml
@@ -34,6 +34,7 @@ jobs:
       name: GitHub Tag
       uses: mathieudutour/github-tag-action@v5.6
       with:
+        custom_tag: ${{ steps.version-updated.outputs.current-package-version }}
         github_token: ${{ secrets.GITHUB_TOKEN }}
     - uses: actions/checkout@v2
     - uses: google-github-actions/setup-gcloud@master


### PR DESCRIPTION
For some reason, the auto-tag action does its own version bumping rather than using the assigned version number.  This corrects that by passing in the version number reported by our updated package checker.