### PR TITLE
Keep UA parse results specific to the request, not the app

### DIFF
--- a/app.js
+++ b/app.js
@@ -87,9 +87,11 @@ app.use(express.json({limit: '32mb'}));
 app.use(express.static('static'));
 app.use(express.static('generated'));
 
+app.locals.appVersion = appVersion;
+
+// Get user agent
 app.use((req, res, next) => {
-  app.locals.appVersion = appVersion;
-  app.locals.browser = parseUA(req.get('User-Agent'), bcdBrowsers);
+  res.locals.browser = parseUA(req.get('User-Agent'), bcdBrowsers);
   next();
 });
 


### PR DESCRIPTION
This PR fixes the bug addressed in #1049.  After reading the documentation for Express, it turns out that I was misusing `app.locals`.  `app.locals` is for the lifetime of the _server,_ which is fitting for variables like the app's version.  For per-request variables, however, we want to use `res.locals` instead.﻿
