### PR TITLE
Catch errors when passing return value within a callback

### DIFF
--- a/build.js
+++ b/build.js
@@ -116,7 +116,14 @@ const getCustomTestAPI = (name, member, type) => {
             (promise ?
               `return promise.then(function(instance) {return ${returnValue}});` :
               callback ?
-              `function callback(instance) {success(${returnValue})}; return 'callback';` :
+              `function callback(instance) {
+                  try {
+                    success(${returnValue});
+                  } catch(e) {
+                    fail(e);
+                  }
+                };
+                return 'callback';` :
               `return ${returnValue};`) :
           false;
       }
@@ -141,7 +148,14 @@ const getCustomTestAPI = (name, member, type) => {
               (promise ?
                 `return promise.then(function(instance) {return ${returnValue}});` :
                 callback ?
-                `function callback(instance) {success(${returnValue})}; return 'callback';` :
+                `function callback(instance) {
+                   try {
+                     success(${returnValue});
+                   } catch(e) {
+                     fail(e);
+                   }
+                 };
+                 return 'callback';` :
                 `return ${returnValue};`) :
             false;
         }


### PR DESCRIPTION
This PR fixes an issue that's causing the tests to freeze between Chrome 7 and 10, due to the callback throwing an error trying to find the member in the instance (`'member' in instance`) without validating the instance isn't null first.﻿
