### PR TITLE
Simplify release process instructions

### DIFF
--- a/README.md
+++ b/README.md
@@ -180,7 +180,7 @@ npm run clean
 
 ## Release process
 
-These are the manual steps to release and deploy a new version on https://mdn-bcd-collector.appspot.com/:
+To create a release, run the following command:
 
 ```sh
 npm run release


### PR DESCRIPTION
Now that we have the release script, the old instructions are no longer needed.  This PR replaces them.

(We could also keep them around as "legacy instructions" too?)