### PR TITLE
Fix reusable instances code display

### DIFF
--- a/static/resources/harness.js
+++ b/static/resources/harness.js
@@ -728,24 +728,23 @@
       var reusedInstances = result.info.code.match(
         /reusableInstances\.([^.);]*)/g
       );
-      var reusedInstances = [];
-      for (var i = 0; i < rawReusedInstances.length; i++) {
-        var reusedInstance = rawReusedInstances[i].replace(
-          'reusableInstances.',
-          ''
-        );
-        // De-duplicate reusable instances list
-        if (reusedInstances.indexOf(reusedInstance) == -1) {
-          reusedInstances.push(reusedInstance);
-        }
-      }
+      var addedInstances = [];
 
       if (reusedInstances) {
         for (var i = 0; i < reusedInstances.length; i++) {
-          var reusedInstance = reusedInstances[i];
+          var reusedInstance = reusedInstances[i].replace(
+            'reusableInstances.',
+            ''
+          );
+
+          // De-duplicate instances
+          if (addedInstances.indexOf(reusedInstance) > -1) {
+            continue;
+          }
+          addedInstances.push(reusedInstance);
+
           code =
-            'reusableInstances.' +
-            reusedInstance +
+            reusedInstances[i] +
             ' = ' +
             reusableInstances.__sources[reusedInstance] +
             '\n\n' +


### PR DESCRIPTION
This PR fixes #1500 by updating the regex used to determine what reusable instances are called for by our tests, as well as de-duplicating the code injection.
