### PR TITLE
Restore custom IDL by tweaking the export of custom-idl/index.js

### DIFF
--- a/custom-idl/index.js
+++ b/custom-idl/index.js
@@ -20,23 +20,20 @@ import * as WebIDL2 from 'webidl2';
 
 // Load text (UTF-8) files from a directory and return an object mapping each
 // name (sans extension) to the parsed result of that text.
-const parseIDL = async () => {
-  const files = await fs.readdir(new URL('.', import.meta.url));
-  files.sort();
-  const results = {};
-  for (const file of files) {
-    /* istanbul ignore next */
-    if (path.extname(file) !== '.idl') {
-      continue;
-    }
-    const name = path.parse(file).name;
-    const text = await fs.readFile(
-      new URL(`./${file}`, import.meta.url),
-      'utf8'
-    );
-    results[name] = WebIDL2.parse(text);
+const files = await fs.readdir(new URL('.', import.meta.url));
+files.sort();
+const results = {};
+for (const file of files) {
+  /* istanbul ignore next */
+  if (path.extname(file) !== '.idl') {
+    continue;
   }
-  return results;
-};
+  const name = path.parse(file).name;
+  const text = await fs.readFile(
+    new URL(`./${file}`, import.meta.url),
+    'utf8'
+  );
+  results[name] = WebIDL2.parse(text);
+}
 
-export default parseIDL();
+export default results;


### PR DESCRIPTION
In the ESM migration this code was rewritten to be async, but the
default export was just the return value of invoking parseIDL(), which
is a promise. Instead just remove parseIDL() and use top-level await.

Fixes https://github.com/foolip/mdn-bcd-collector/issues/1588.