### PR TITLE
Fix custom IDL export

### DIFF
--- a/custom-idl/index.js
+++ b/custom-idl/index.js
@@ -39,4 +39,4 @@ const parseIDL = async () => {
   return results;
 };
 
-export default parseIDL();
+export default await parseIDL();


### PR DESCRIPTION
This PR is an alternative to #1590 that retains the function, and adds the missing `await` to the default export.﻿
