### PR TITLE
Fix add-new-bcd

### DIFF
--- a/add-new-bcd.js
+++ b/add-new-bcd.js
@@ -42,9 +42,9 @@ const recursiveAdd = (ident, i, data, obj) => {
   const part = ident[i];
 
   data[part] =
-    i + 1 < ident.length
-      ? recursiveAdd(ident, i + 1, part in data ? data[part] : {}, obj)
-      : Object.assign({}, obj);
+    i + 1 < ident.length ?
+      recursiveAdd(ident, i + 1, part in data ? data[part] : {}, obj) :
+      Object.assign({}, obj);
 
   return data;
 };


### PR DESCRIPTION
This PR fixes `add-new-bcd`, which seemed to have been non-functional since our recent refactorings of the scripts.

Todo: add unittests for `add-new-bcd`
