### PR TITLE
Fix test for ImageCapture interface

### DIFF
--- a/custom-tests.yaml
+++ b/custom-tests.yaml
@@ -1115,10 +1115,12 @@ api:
   ImageCapture:
     __base: >-
       <%api.MediaDevices:mediaDevices%>
-      var track = mediaDevices.getUserMedia({video: true});
-      track.then(function() {});
-      var promise = track.then(function(t) {
-        return new ImageCapture(t);
+      var stream = mediaDevices.getUserMedia({video: true});
+      stream.then(function() {});
+      var promise = stream.then(function(s) {
+        var tracks = s.getTracks();
+        console.log(tracks);
+        return new ImageCapture(tracks[0]);
       });
   ImageData:
     __base: >-

--- a/custom-tests.yaml
+++ b/custom-tests.yaml
@@ -1119,7 +1119,6 @@ api:
       stream.then(function() {});
       var promise = stream.then(function(s) {
         var tracks = s.getVideoTracks();
-        console.log(tracks);
         return new ImageCapture(tracks[0]);
       });
   ImageData:

--- a/custom-tests.yaml
+++ b/custom-tests.yaml
@@ -1118,7 +1118,7 @@ api:
       var stream = mediaDevices.getUserMedia({video: true});
       stream.then(function() {});
       var promise = stream.then(function(s) {
-        var tracks = s.getTracks();
+        var tracks = s.getVideoTracks();
         console.log(tracks);
         return new ImageCapture(tracks[0]);
       });


### PR DESCRIPTION
This PR fixes the test for the `ImageCapture` API.  `getUserMedia` returns a media _stream,_ rather than a media stream's track, but this was not accounted for.  This PR fixes the custom test by ensuring we're grabbing the video track.﻿
