### PR TITLE
Rename api.BaseAudioContext.decodeAudioData.promise_syntax -> returns_promise

### DIFF
--- a/custom-tests.yaml
+++ b/custom-tests.yaml
@@ -241,7 +241,7 @@ api:
     __base: var instance = reusableInstances.audioContext;
     __test: return 'BaseAudioContext' in self
     __additional:
-      decodeAudioData.promise_syntax: >-
+      decodeAudioData.returns_promise: >-
         <%api.BaseAudioContext:ctx%>
         return ctx.decodeAudioData.length === 1;
   # XXX Freezes in many versions of Chrome and Firefox


### PR DESCRIPTION
This is to go along with its renaming in BCD.
