### PR TITLE
Update tests for TextDecoder/TextEncoder

### DIFF
--- a/custom-tests.yaml
+++ b/custom-tests.yaml
@@ -2061,9 +2061,17 @@ api:
       var instance
       = el.childNodes[0];
   TextDecoder:
-    __base: var instance = new TextDecoder();
+    __base: >-
+      if (!('TextDecoder' in self)) {
+        return false;
+      };
+      var instance = new TextDecoder();
   TextEncoder:
-    __base: var instance = new TextEncoder();
+    __base: >-
+      if (!('TextEncoder' in self)) {
+        return false;
+      };
+      var instance = new TextEncoder();
   TextMetrics:
     __base: >-
       <%api.CanvasRenderingContext2D:canvas%>


### PR DESCRIPTION
This PR updates the tests for the `TextDecoder` and `TextEncoder` APIs.  Both of these need to be constructed before they can be used, so this﻿ PR checks whether they're defined first.
