### PR TITLE
Add custom tests for file system APIs

### DIFF
--- a/build.js
+++ b/build.js
@@ -104,7 +104,8 @@ const getCustomTestAPI = (name, member, type) => {
   if (name in customTests.api) {
     const testbase = customTests.api[name].__base || '';
     const promise = testbase.includes('var promise');
-    const callback = testbase.includes('callback(');
+    const callback =
+      testbase.includes('callback(') || testbase.includes(':callback%>');
 
     if (member === undefined) {
       if ('__test' in customTests.api[name]) {

--- a/custom-tests.yaml
+++ b/custom-tests.yaml
@@ -770,8 +770,8 @@ api:
     __base: >-
       window.webkitRequestFileSystem(TEMPORARY, 8*1024 /* 8KB */, function(fs) {
         callback(fs);
-      }, function(event) {
-        fail(event.message);
+      }, function(error) {
+        fail(error.message);
       });
   FileSystemEntry:
     __base: <%api.FileSystemDirectoryEntry:callback%>

--- a/custom-tests.yaml
+++ b/custom-tests.yaml
@@ -766,6 +766,37 @@ api:
       var instance = new FetchEvent('fetch', { request: req });
   FileReader:
     __base: var instance = new FileReader();
+  FileSystem:
+    __base: >-
+      window.webkitRequestFileSystem(TEMPORARY, 8*1024 /* 8KB */, function(fs) {
+        callback(fs);
+      }, function(event) {
+        fail(event.message);
+      });
+  FileSystemEntry:
+    __base: <%api.FileSystemDirectoryEntry:callback%>
+  FileSystemDirectoryEntry:
+    __base: >-
+      <%api.FileSystem:fsCallback%>
+      function fsCallback(fs) {
+        callback(fs.root);
+      }
+  FileSystemDirectoryReader:
+    __base: >-
+      <%api.FileSystemDirectoryEntry:dirCallback%>
+      function dirCallback(dir) {
+        callback(dir.createReader());
+      }
+  FileSystemFileEntry:
+    __base: >-
+      <%api.FileSystem:fsCallback%>
+      function fsCallback(fs) {
+        fs.root.getFile('foo.txt', { create: true }, function(file) {
+          callback(file);
+        }, function(event) {
+          fail(event.message);
+        });
+      }
   FocusEvent:
     __base: >-
       var instance;


### PR DESCRIPTION
This PR adds custom tests for the file system APIs, which fixes #1670.  As a part of these additions, a slight adjustment to `build.js` has been made to make importing a callback as the instance a little easier.

Note: the custom test code looks a little ugly right now, but that will be resolved by #1668 later down the line.
