### PR TITLE
Handle Android WebView 4.4.3 in ua-parser

### DIFF
--- a/ua-parser.js
+++ b/ua-parser.js
@@ -82,6 +82,7 @@ const parseUA = (userAgent, browsers) => {
     compareVersions.compare(data.fullVersion, '4.4.3', '>=') &&
     compareVersions.compare(data.fullVersion, '5.0', '<')
   ) {
+    data.version = '4.4.3';
     data.inBcd = true;
     return data;
   }

--- a/ua-parser.js
+++ b/ua-parser.js
@@ -83,7 +83,7 @@ const parseUA = (userAgent, browsers) => {
     compareVersions.compare(data.fullVersion, '5.0', '<')
   ) {
     data.inBcd = true;
-    return true;
+    return data;
   }
 
   // Certain Safari versions are backports of newer versions, but contain less

--- a/ua-parser.js
+++ b/ua-parser.js
@@ -74,6 +74,18 @@ const parseUA = (userAgent, browsers) => {
   const versions = Object.keys(browsers[data.browser.id].releases);
   versions.sort(compareVersions);
 
+  // Android 4.4.3 needs to be handled as a special case, because its data
+  // differs from 4.4, and the code below will strip out the patch versions from
+  // our version numbers.
+  if (
+    data.browser.id === 'webview_android' &&
+    compareVersions.compare(data.fullVersion, '4.4.3', '>=') &&
+    compareVersions.compare(data.fullVersion, '5.0', '<')
+  ) {
+    data.inBcd = true;
+    return true;
+  }
+
   // Certain Safari versions are backports of newer versions, but contain less
   // features, particularly ones involving OS integration. We are explicitly
   // marking these versions as "not in BCD" to avoid confusion.

--- a/unittest/unit/ua-parser.js
+++ b/unittest/unit/ua-parser.js
@@ -338,6 +338,38 @@ describe('parseUA', () => {
     );
   });
 
+  it('WebView Android (Android Browser, 4.4.3, Chrome 33)', () => {
+    assert.deepEqual(
+      parseUA(
+        'Mozilla/5.0 (Linux; U; Android 4.4.3; en-us; HTC_0P6B130 Build/KTU84L) AppleWebKit/534.30 (KHTML, like Gecko) Version/4.0 Mobile Safari/534.30',
+        browsers
+      ),
+      {
+        browser: {id: 'webview_android', name: 'WebView Android'},
+        version: '4.4.3',
+        fullVersion: '4.4.3',
+        os: {name: 'Android', version: '4.4.3'},
+        inBcd: true
+      }
+    );
+  });
+
+  it('WebView Android (Android Browser, 4.4.4, Chrome 33)', () => {
+    assert.deepEqual(
+      parseUA(
+        'Mozilla/5.0 (Linux; U; Android 4.4.4; en-us; HTC_0P6B130 Build/KTU84L) AppleWebKit/534.30 (KHTML, like Gecko) Version/4.0 Mobile Safari/534.30',
+        browsers
+      ),
+      {
+        browser: {id: 'webview_android', name: 'WebView Android'},
+        version: '4.4.3',
+        fullVersion: '4.4.4',
+        os: {name: 'Android', version: '4.4.4'},
+        inBcd: true
+      }
+    );
+  });
+
   it('WebView Android (Android Browser, 5.0.2, Chrome 37)', () => {
     assert.deepEqual(
       parseUA(


### PR DESCRIPTION
Looks like because we're stripping the patch version from the version number, we're accidentally mapping 4.4.3 to 4.4 -- see https://github.com/foolip/mdn-bcd-results/pull/2719.﻿
