### PR TITLE
Load JSON3 polyfill only when needed

### DIFF
--- a/static/resources/harness.js
+++ b/static/resources/harness.js
@@ -764,50 +764,70 @@
     resultsEl.appendChild(resultEl);
   }
 
+  function sendReport(results) {
+    var body = JSON.stringify(results);
+
+    var client;
+    if ('XMLHttpRequest' in self) {
+      client = new XMLHttpRequest();
+    } else if ('ActiveXObject' in self) {
+      client = new ActiveXObject('Microsoft.XMLHTTP');
+    }
+
+    if (!client) {
+      updateStatus(
+        'Cannot upload results: XMLHttpRequest is not supported.',
+        'error-notice'
+      );
+      return;
+    }
+
+    var resultsURL =
+      (location.origin || location.protocol + '//' + location.host) +
+      '/api/results?for=' +
+      encodeURIComponent(location.href);
+
+    client.open('POST', resultsURL);
+    client.setRequestHeader('Content-Type', 'application/json;charset=UTF-8');
+    client.send(body);
+    client.onreadystatechange = function () {
+      if (client.readyState == 4) {
+        if (client.status >= 200 && client.status <= 299) {
+          document.getElementById('export-download').disabled = false;
+          document.getElementById('export-github').disabled = false;
+          updateStatus('Results uploaded.', 'success-notice');
+        } else {
+          updateStatus(
+            'Failed to upload results: server error.',
+            'error-notice'
+          );
+          consoleLog('Server response: ' + client.response);
+        }
+      }
+    };
+  }
+
   function report(results, hideResults) {
     updateStatus('Tests complete. Posting results to server...');
 
     try {
-      var body = JSON.stringify(results);
+      if ('JSON' in self && 'parse' in JSON) {
+        sendReport(results);
+      } else {
+        // Load JSON polyfill if needed
+        var polyfill = document.createElement('script');
+        polyfill.src = '/resources/json3.min.js';
 
-      var client;
-      if ('XMLHttpRequest' in self) {
-        client = new XMLHttpRequest();
-      } else if ('ActiveXObject' in self) {
-        client = new ActiveXObject('Microsoft.XMLHTTP');
-      }
-
-      if (!client) {
-        updateStatus(
-          'Cannot upload results: XMLHttpRequest is not supported.',
-          'error-notice'
+        polyfill.addEventListener(
+          'load',
+          function () {
+            sendReport(results);
+          },
+          false
         );
-        return;
+
+        document.body.appendChild(polyfill);
       }
-
-      var resultsURL =
-        (location.origin || location.protocol + '//' + location.host) +
-        '/api/results?for=' +
-        encodeURIComponent(location.href);
-
-      client.open('POST', resultsURL);
-      client.setRequestHeader('Content-Type', 'application/json;charset=UTF-8');
-      client.send(body);
-      client.onreadystatechange = function () {
-        if (client.readyState == 4) {
-          if (client.status >= 200 && client.status <= 299) {
-            document.getElementById('export-download').disabled = false;
-            document.getElementById('export-github').disabled = false;
-            updateStatus('Results uploaded.', 'success-notice');
-          } else {
-            updateStatus(
-              'Failed to upload results: server error.',
-              'error-notice'
-            );
-            console.log('Server response: ' + client.response);
-          }
-        }
-      };
     } catch (e) {
       updateStatus('Failed to upload results: client error.', 'error-notice');
       consoleError(e);

--- a/static/resources/harness.js
+++ b/static/resources/harness.js
@@ -833,7 +833,6 @@
       }
     } catch (e) {
       updateStatus('Failed to upload results: client error.', 'error-notice');
-      alert(e.message);
       consoleError(e);
     }
 

--- a/static/resources/harness.js
+++ b/static/resources/harness.js
@@ -818,18 +818,22 @@
         var polyfill = document.createElement('script');
         polyfill.src = '/resources/json3.min.js';
 
-        polyfill.addEventListener(
-          'load',
-          function () {
+        if ('onload' in polyfill) {
+          polyfill.onload = function () {
             sendReport(results);
-          },
-          false
-        );
+          };
+        } else {
+          // If we can't determine when the polyfill loads, use a delay
+          setTimeout(function () {
+            sendReport(results);
+          }, 500);
+        }
 
         document.body.appendChild(polyfill);
       }
     } catch (e) {
       updateStatus('Failed to upload results: client error.', 'error-notice');
+      alert(e.message);
       consoleError(e);
     }
 

--- a/static/resources/serviceworker.js
+++ b/static/resources/serviceworker.js
@@ -14,7 +14,6 @@
 
 /* global self, caches, Request, Response, bcd */
 
-self.importScripts('json3.min.js');
 self.importScripts('harness.js');
 
 self.addEventListener('install', function (event) {

--- a/static/resources/sharedworker.js
+++ b/static/resources/sharedworker.js
@@ -14,7 +14,6 @@
 
 /* global self, bcd */
 
-self.importScripts('json3.min.js');
 self.importScripts('harness.js');
 
 self.onconnect = function (connectEvent) {

--- a/static/resources/worker.js
+++ b/static/resources/worker.js
@@ -14,7 +14,6 @@
 
 /* global self, bcd */
 
-self.importScripts('json3.min.js');
 self.importScripts('harness.js');
 
 self.onmessage = function (event) {

--- a/views/index.ejs
+++ b/views/index.ejs
@@ -64,7 +64,6 @@
     <li>Detection for features under alternative names are not yet supported</li>
     <li>In older browsers, some attributes aren't initialized in the API prototypes, resulting in false negatives (see <a href="https://github.com/foolip/mdn-bcd-collector/issues/406">#406</a>)</li>
     <li>Some APIs are accessed through other APIs and aren't exposed on their own; custom tests have not been written for them all</li>
-    <li>The test page uses a JSON polyfill for core functionality; tests for <code>javascript.builtins.JSON</code> should not be trusted</li>
   </ul>
 
   <p class="error-notice">If you find any errors in feature detection, please <a href="https://github.com/foolip/mdn-bcd-collector/issues/new"><span class="mdi mdi-alert-circle-outline"></span> file an issue</a> in the GitHub repository.</p>

--- a/views/tests.ejs
+++ b/views/tests.ejs
@@ -40,7 +40,6 @@
 </div>
 
 <!-- TODO: https://github.com/foolip/mdn-bcd-collector/issues/407 -->
-<script src="/resources/json3.min.js"></script>
 <script src="/resources/harness.js"></script>
 <script>
   <% for (const [instanceId, instance] of Object.entries(resources)


### PR DESCRIPTION
This PR updates our code to only load JSON3 when it's needed, in two ways:

- Only load JSON3 _after_ all the tests; it's not needed for worker tests at all since workers were added after JSON support
- Check if we need to load the polyfill in the first place; if the browser has the JSON support we need, don't load the script