### PR TITLE
Prevent tests from starting twice

### DIFF
--- a/static/resources/harness.js
+++ b/static/resources/harness.js
@@ -579,6 +579,11 @@
     };
 
     var startTests = function () {
+      if (state.started) {
+        consoleError('Warning: Tests started twice!');
+        return;
+      }
+
       state.started = true;
 
       var timeout = setTimeout(function () {
@@ -685,6 +690,7 @@
         }
       } catch (e) {
         // Couldn't use resource loading code, start anyways
+        clearTimeout(resourceTimeout);
         consoleError(e);
         startTests();
       }


### PR DESCRIPTION
This PR adds two pieces of code to prevent the tests from starting multiple times:

- Clears the timeout on waiting for resources to load if the resources failed to load
- If `startTests()` is called multiple times, log to the console and return

This provides critical performance improvements for old browsers.﻿
