### PR TITLE
Release script: simplify test list

### DIFF
--- a/release.js
+++ b/release.js
@@ -164,13 +164,12 @@ const getTestChanges = () => {
         changed = changed.filter(simplifyTestChangesList);
 
         ctx.testChanges =
-          '\n#### Added\n<details>\n' +
-          added.join('<br />\n') +
-          '\n</details>\n\n#### Removed\n<details>\n' +
-          removed.join('<br />\n') +
-          '\n</details>\n\n#### Changed\n<details>\n' +
-          changed.join('<br />\n') +
-          '\n</details>\n';
+          '\n#### Added\n\n' +
+          added.map((x) => '- ' + x).join('\n') +
+          '\n\n#### Removed\n\n' +
+          removed.map((x) => '- ' + x).join('\n') +
+          '\n\n#### Changed\n\n' +
+          changed.map((x) => '- ' + x).join('\n');
       }
     },
     {

--- a/release.js
+++ b/release.js
@@ -162,12 +162,13 @@ const getTestChanges = () => {
         changed = changed.filter(simplifyTestChangesList);
 
         ctx.testChanges =
-          '\n#### Added\n' +
-          added.join('\n') +
-          '\n#### Removed\n' +
-          removed.join('\n') +
-          '\n#### Changed\n' +
-          changed.join('\n');
+          '\n#### Added\n<details>\n' +
+          added.join('<br />\n') +
+          '\n</details>\n\n#### Removed\n<details>\n' +
+          removed.join('<br />\n') +
+          '\n</details>\n\n#### Changed\n<details>\n' +
+          changed.join('<br />\n') +
+          '\n</details>\n';
       }
     },
     {

--- a/release.js
+++ b/release.js
@@ -90,6 +90,18 @@ const getNewVersion = async (ctx, task) => {
   }
 };
 
+const simplifyTestChangesList = (el, _, list) => {
+  const parts = el.split('.');
+  let p = '';
+
+  for (let i = 0; i < parts.length - 1; i++) {
+    p += (i > 0 ? '.' : '') + parts[i];
+    if (list.includes(p)) return false;
+  }
+
+  return true;
+};
+
 const getTestChanges = () => {
   return [
     {
@@ -135,14 +147,19 @@ const getTestChanges = () => {
         const oldTestKeys = Object.keys(oldTests);
         const newTestKeys = Object.keys(newTests);
 
-        const added = newTestKeys.filter((k) => !oldTestKeys.includes(k));
-        const removed = oldTestKeys.filter((k) => !newTestKeys.includes(k));
-        const changed = [];
+        const added = newTestKeys
+          .filter((k) => !oldTestKeys.includes(k))
+          .filter(simplifyTestChangesList);
+        const removed = oldTestKeys
+          .filter((k) => !newTestKeys.includes(k))
+          .filter(simplifyTestChangesList);
+        let changed = [];
         for (const t of newTestKeys.filter((k) => oldTestKeys.includes(k))) {
           if (oldTests[t].code != newTests[t].code) {
             changed.push(t);
           }
         }
+        changed = changed.filter(simplifyTestChangesList);
 
         ctx.testChanges =
           '\n#### Added\n' +

--- a/release.js
+++ b/release.js
@@ -96,7 +96,9 @@ const simplifyTestChangesList = (el, _, list) => {
 
   for (let i = 0; i < parts.length - 1; i++) {
     p += (i > 0 ? '.' : '') + parts[i];
-    if (list.includes(p)) return false;
+    if (list.includes(p)) {
+      return false;
+    }
   }
 
   return true;


### PR DESCRIPTION
This PR updates the changed test lists by consolidating the lists so that all the children won't be listed if the parent has been modified (i.e. if 'api.AbortController' was added, 'api.AbortController.someProperty' won't be included in the list)
