### PR TITLE
Update Attr API custom test

### DIFF
--- a/custom-tests.yaml
+++ b/custom-tests.yaml
@@ -98,7 +98,12 @@ api:
     __base: |-
       var el = document.createElement('b');
       el.setAttribute('data-foo', 'bar');
-      var instance = el.getAttributeNode('data-foo');
+      var instance;
+      if ('getAttributeNode' in el) {
+        instance = el.getAttributeNode('data-foo');
+      } else if ('attributes' in el) {
+        instance = el.attributes.item(0);
+      }
   ANGLE_instanced_arrays:
     __resources:
       - webGL1


### PR DESCRIPTION
This PR updates the custom test for the Attr API to use `Element.attributes` as a fallback, particularly for older browsers like IE.  Fixes #955.﻿
