### PR TITLE
Generate toString tests for named stringifiers in IDL

### DIFF
--- a/build.js
+++ b/build.js
@@ -412,6 +412,13 @@ const flattenMembers = (iface) => {
     }
   }
 
+  // Catch named stringifiers
+  for (const _ of members.filter(
+    (member) => member.special === 'stringifier'
+  )) {
+    members.push({name: 'toString', type: 'operation'});
+  }
+
   // Add members from ExtAttrs
   if (getExtAttr(iface, 'LegacyFactoryFunction')) {
     members.push({

--- a/build.js
+++ b/build.js
@@ -413,7 +413,7 @@ const flattenMembers = (iface) => {
   }
 
   // Catch named stringifiers
-  if (member.some((member) => member.special === 'stringifier')) {
+  if (members.some((member) => member.special === 'stringifier')) {
     members.push({name: 'toString', type: 'operation'});
   }
 

--- a/build.js
+++ b/build.js
@@ -413,9 +413,7 @@ const flattenMembers = (iface) => {
   }
 
   // Catch named stringifiers
-  for (const _ of members.filter(
-    (member) => member.special === 'stringifier'
-  )) {
+  if (member.some((member) => member.special === 'stringifier')) {
     members.push({name: 'toString', type: 'operation'});
   }
 

--- a/unittest/unit/build.js
+++ b/unittest/unit/build.js
@@ -1061,6 +1061,30 @@ describe('build', () => {
       });
     });
 
+    it('interface with named stringifier', () => {
+      const ast = WebIDL2.parse(
+        `[Exposed=Window]
+           interface HTMLAreaElement {
+             stringifier readonly attribute USVString href;
+           };`
+      );
+
+      assert.deepEqual(buildIDLTests(ast, []), {
+        'api.HTMLAreaElement': {
+          code: '"HTMLAreaElement" in self',
+          exposure: ['Window']
+        },
+        'api.HTMLAreaElement.href': {
+          code: '"href" in HTMLAreaElement.prototype',
+          exposure: ['Window']
+        },
+        'api.HTMLAreaElement.toString': {
+          code: '"toString" in HTMLAreaElement.prototype',
+          exposure: ['Window']
+        }
+      });
+    });
+
     it('operator variations', () => {
       const ast = WebIDL2.parse(
         `[Exposed=Window]


### PR DESCRIPTION
This PR updates the build script to add `toString` tests for any _named_ attributes with the `stringifier` special attribute.  This case can be found in the `HTMLHyperlinkElementUtils` mixin and `WorkerLocation`﻿interface.

Fixes #1057.