### PR TITLE
Add custom tests for HTML[Anchor/Area]Element/WorkerLocation toString

### DIFF
--- a/custom-tests.yaml
+++ b/custom-tests.yaml
@@ -827,9 +827,15 @@ api:
   HTMLAnchorElement:
     __base: var instance = document.createElement('a');
     __test: return bcd.testObjectName(instance, 'HTMLAnchorElement');
+    toString: |-
+      instance.href = 'https://mdn-bcd-collector.appspot.com/';
+      return instance.toString() == instance.href;
   HTMLAreaElement:
     __base: var instance = document.createElement('area');
     __test: return bcd.testObjectName(instance, 'HTMLAreaElement');
+    toString: |-
+      instance.href = 'https://mdn-bcd-collector.appspot.com/';
+      return instance.toString() == instance.href;
   HTMLAudioElement:
     __base: var instance = document.createElement('audio');
     __test: return bcd.testObjectName(instance, 'HTMLAudioElement');
@@ -2437,6 +2443,9 @@ api:
     __base: var instance = self;
   WorkerLocation:
     __base: var instance = location;
+    toString: |-
+      instance.href = 'https://mdn-bcd-collector.appspot.com/';
+      return instance.toString() == instance.href;
   WorkerNavigator:
     __base: var instance = navigator;
   WritableStreamDefaultController:

--- a/custom-tests.yaml
+++ b/custom-tests.yaml
@@ -2443,9 +2443,7 @@ api:
     __base: var instance = self;
   WorkerLocation:
     __base: var instance = location;
-    toString: |-
-      instance.href = 'https://mdn-bcd-collector.appspot.com/';
-      return instance.toString() == instance.href;
+    toString: return instance.toString() == instance.href;
   WorkerNavigator:
     __base: var instance = navigator;
   WritableStreamDefaultController:


### PR DESCRIPTION
This PR adds custom tests for the `toString` method of the `HTMLAnchorElement`, `HTMLAreaElement`, and `WorkerLocation` interfaces.  This is a sister PR to #1716, which updates `build.js` to include these members.﻿
