### PR TITLE
Add @@iterator symbol on maplike and setlike interfaces

### DIFF
--- a/build.js
+++ b/build.js
@@ -369,6 +369,7 @@ const flattenMembers = (iface) => {
         break;
       case 'maplike':
         members.push(
+          {name: '@@iterator', type: 'symbol'},
           {name: 'entries', type: 'operation'},
           {name: 'forEach', type: 'operation'},
           {name: 'get', type: 'operation'},
@@ -387,6 +388,7 @@ const flattenMembers = (iface) => {
         break;
       case 'setlike':
         members.push(
+          {name: '@@iterator', type: 'symbol'},
           {name: 'entries', type: 'operation'},
           {name: 'forEach', type: 'operation'},
           {name: 'has', type: 'operation'},

--- a/unittest/unit/build.js
+++ b/unittest/unit/build.js
@@ -904,6 +904,10 @@ describe('build', () => {
           code: '"DoubleMap" in self',
           exposure: ['Window']
         },
+        'api.DoubleMap.@@iterator': {
+          code: '"Symbol" in self && "iterator" in Symbol && Symbol.iterator in DoubleMap.prototype',
+          exposure: ['Window']
+        },
         'api.DoubleMap.clear': {
           code: '"clear" in DoubleMap.prototype',
           exposure: ['Window']
@@ -957,6 +961,10 @@ describe('build', () => {
       assert.deepEqual(buildIDLTests(ast, []), {
         'api.DoubleSet': {
           code: '"DoubleSet" in self',
+          exposure: ['Window']
+        },
+        'api.DoubleSet.@@iterator': {
+          code: '"Symbol" in self && "iterator" in Symbol && Symbol.iterator in DoubleSet.prototype',
           exposure: ['Window']
         },
         'api.DoubleSet.add': {


### PR DESCRIPTION
As it turns out, both `maplike` and `setlike` interfaces have an `@@iterator` symbol upon them, as stated in the [WebIDL spec](https://webidl.spec.whatwg.org/#es-iterators).  This PR ensures we are creating these symbols.﻿
