### PR TITLE
Add support for wildcard exposures

### DIFF
--- a/build.js
+++ b/build.js
@@ -429,9 +429,9 @@ const getExtAttr = (node, name) => {
   return node.extAttrs && node.extAttrs.find((i) => i.name === name);
 };
 
-// https://webidl.spec.whatwg.org/#dfn-exposure-set
+// https://webidl.spec.whatwg.org/#Exposed
 const getExposureSet = (node) => {
-  // step 6-8
+  // step 6-8 of https://webidl.spec.whatwg.org/#dfn-exposure-set
   const attr = getExtAttr(node, 'Exposed');
   if (!attr) {
     throw new Error(
@@ -445,6 +445,16 @@ const getExposureSet = (node) => {
       break;
     case 'identifier-list':
       for (const {value} of attr.rhs.value) {
+        exposure.add(value);
+      }
+      break;
+    case '*':
+      for (const value of [
+        'Window',
+        'Worker',
+        'SharedWorker',
+        'ServiceWorker'
+      ]) {
         exposure.add(value);
       }
       break;

--- a/build.js
+++ b/build.js
@@ -438,14 +438,14 @@ const getExposureSet = (node) => {
       `Exposed extended attribute not found on ${node.type} ${node.name}`
     );
   }
-  const globals = new Set();
+  const exposure = new Set();
   switch (attr.rhs.type) {
     case 'identifier':
-      globals.add(attr.rhs.value);
+      exposure.add(attr.rhs.value);
       break;
     case 'identifier-list':
       for (const {value} of attr.rhs.value) {
-        globals.add(value);
+        exposure.add(value);
       }
       break;
     /* istanbul ignore next */
@@ -453,12 +453,12 @@ const getExposureSet = (node) => {
       throw new Error(`Unexpected RHS for Exposed extended attribute`);
   }
 
-  if (globals.has('DedicatedWorker')) {
-    globals.delete('DedicatedWorker');
-    globals.add('Worker');
+  if (exposure.has('DedicatedWorker')) {
+    exposure.delete('DedicatedWorker');
+    exposure.add('Worker');
   }
 
-  return globals;
+  return exposure;
 };
 
 const validateIDL = (ast) => {

--- a/build.js
+++ b/build.js
@@ -348,6 +348,7 @@ const flattenIDL = (specIDLs, customIDLs) => {
   const scopes = ast
     .filter((dfn) => getExtAttr(dfn, 'Global'))
     .map((dfn) => dfn.name.replace('GlobalScope', ''));
+  scopes.push('Worker', 'Worklet');
 
   return {ast, globals, scopes};
 };

--- a/build.js
+++ b/build.js
@@ -473,7 +473,6 @@ const getExposureSet = (node, scopes) => {
 
   for (const e of exposure) {
     if (!scopes.includes(e)) {
-      console.log(scopes);
       throw new Error(
         `${node.type} ${node.name} is exposed on ${e} but ${e} is not a valid scope`
       );

--- a/build.js
+++ b/build.js
@@ -346,9 +346,11 @@ const flattenIDL = (specIDLs, customIDLs) => {
 
   // Get all possible scopes
   const scopes = ast
-    .filter((dfn) => getExtAttr(dfn, 'Global'))
-    .map((dfn) => dfn.name.replace('GlobalScope', ''));
-  scopes.push('Worker', 'Worklet');
+    .filter((dfn) => dfn.name && getExtAttr(dfn, 'Global'))
+    .map((dfn) =>
+      dfn.name.replace('DedicatedWorker', 'Worker').replace('GlobalScope', '')
+    );
+  scopes.push('Worklet');
 
   return {ast, globals, scopes};
 };

--- a/build.js
+++ b/build.js
@@ -471,11 +471,11 @@ const getExposureSet = (node, scopes) => {
   const exposure = new Set();
   switch (attr.rhs.type) {
     case 'identifier':
-      exposure.add(attr.rhs.value.replace('GlobalScope', ''));
+      exposure.add(attr.rhs.value);
       break;
     case 'identifier-list':
       for (const {value} of attr.rhs.value) {
-        exposure.add(value.replace('GlobalScope', ''));
+        exposure.add(value);
       }
       break;
     case '*':
@@ -486,6 +486,14 @@ const getExposureSet = (node, scopes) => {
     /* istanbul ignore next */
     default:
       throw new Error(`Unexpected RHS for Exposed extended attribute`);
+  }
+
+  // Special case RTCIdentityProviderGlobalScope since it doesn't use the
+  // Exposed extended attribute correctly:
+  // https://github.com/w3c/webrtc-identity/pull/36
+  if (exposure.has('RTCIdentityProviderGlobalScope')) {
+    exposure.delete('RTCIdentityProviderGlobalScope');
+    exposure.add('RTCIdentityProvider');
   }
 
   if (exposure.has('DedicatedWorker')) {

--- a/build.js
+++ b/build.js
@@ -346,10 +346,8 @@ const flattenIDL = (specIDLs, customIDLs) => {
 
   // Get all possible scopes
   const scopes = ast
-    .filter((dfn) => dfn.name && dfn.name.includes('GlobalScope'))
-    .map((dfn) => dfn.name.substr(0, dfn.name.length - 'GlobalScope'.length));
-  // There is no 'WindowGlobalScope'
-  scopes.push('Window');
+    .filter((dfn) => getExtAttr(dfn, 'Global'))
+    .map((dfn) => dfn.name.replace('GlobalScope', ''));
 
   return {ast, globals, scopes};
 };

--- a/build.js
+++ b/build.js
@@ -355,9 +355,11 @@ const flattenIDL = (specIDLs, customIDLs) => {
       continue;
     }
 
-    const attr = getExtAttrSet(dfn, 'Global', false);
-    for (const s of attr) {
-      scopes.add(s);
+    const attr = getExtAttrSet(dfn, 'Global');
+    if (attr) {
+      for (const s of attr) {
+        scopes.add(s);
+      }
     }
   }
 
@@ -446,16 +448,10 @@ const getExtAttr = (node, name) => {
   return node.extAttrs && node.extAttrs.find((i) => i.name === name);
 };
 
-const getExtAttrSet = (node, name, throwError = true) => {
+const getExtAttrSet = (node, name) => {
   const attr = getExtAttr(node, name);
   if (!attr) {
-    if (throwError) {
-      throw new Error(
-        `${name} extended attribute not found on ${node.type} ${node.name}`
-      );
-    } else {
-      return new Set();
-    }
+    return null;
   }
 
   const set = new Set();
@@ -485,6 +481,11 @@ const getExtAttrSet = (node, name, throwError = true) => {
 const getExposureSet = (node, scopes) => {
   // step 6-8 of https://webidl.spec.whatwg.org/#dfn-exposure-set
   const exposure = getExtAttrSet(node, 'Exposed');
+  if (!exposure) {
+    throw new Error(
+      `Exposed extended attribute not found on ${node.type} ${node.name}`
+    );
+  }
 
   // Handle wildcard exposures
   if (exposure.has('*')) {

--- a/build.js
+++ b/build.js
@@ -449,11 +449,11 @@ const getExposureSet = (node, scopes) => {
   const exposure = new Set();
   switch (attr.rhs.type) {
     case 'identifier':
-      exposure.add(attr.rhs.value);
+      exposure.add(attr.rhs.value.replace('GlobalScope', ''));
       break;
     case 'identifier-list':
       for (const {value} of attr.rhs.value) {
-        exposure.add(value);
+        exposure.add(value.replace('GlobalScope', ''));
       }
       break;
     case '*':

--- a/build.js
+++ b/build.js
@@ -469,6 +469,15 @@ const getExposureSet = (node, scopes) => {
     exposure.add('Worker');
   }
 
+  for (const e of exposure) {
+    if (!scopes.includes(e)) {
+      console.log(scopes);
+      throw new Error(
+        `${node.type} ${node.name} is exposed on ${e} but ${e} is not a valid scope`
+      );
+    }
+  }
+
   return exposure;
 };
 

--- a/build.js
+++ b/build.js
@@ -488,7 +488,7 @@ const getExposureSet = (node, scopes) => {
 
   // Handle wildcard exposures
   if (exposure.has('*')) {
-    exposure.remove('*');
+    exposure.delete('*');
     for (const value of scopes) {
       exposure.add(value);
     }

--- a/build.js
+++ b/build.js
@@ -348,6 +348,8 @@ const flattenIDL = (specIDLs, customIDLs) => {
   const scopes = ast
     .filter((dfn) => dfn.name && dfn.name.includes('GlobalScope'))
     .map((dfn) => dfn.name.substr(0, dfn.name.length - 'GlobalScope'.length));
+  // There is no 'WindowGlobalScope'
+  scopes.push('Window');
 
   return {ast, globals, scopes};
 };

--- a/build.js
+++ b/build.js
@@ -496,6 +496,10 @@ const getExposureSet = (node, scopes) => {
     exposure.add('RTCIdentityProvider');
   }
 
+  // Some specs use "DedicatedWorker" for the exposure while others use
+  // "Worker". We spawn a dedicated worker for the "Worker" exposure.
+  // This code ensures we generate tests for either exposure.
+  // https://github.com/foolip/mdn-bcd-collector/pull/811
   if (exposure.has('DedicatedWorker')) {
     exposure.delete('DedicatedWorker');
     exposure.add('Worker');

--- a/unittest/unit/build.js
+++ b/unittest/unit/build.js
@@ -610,6 +610,13 @@ describe('build', () => {
   describe('getExposureSet', () => {
     // Combining spec and custom IDL is not important to these tests.
     const customIDLs = {};
+    const scopes = [
+      'Window',
+      'Worker',
+      'SharedWorker',
+      'ServiceWorker',
+      'AudioWorklet'
+    ];
 
     it('no defined exposure set', () => {
       const specIDLs = {
@@ -641,7 +648,7 @@ describe('build', () => {
       };
       const {ast} = flattenIDL(specIDLs, customIDLs);
       const interfaces = ast.filter((dfn) => dfn.type === 'interface');
-      const exposureSet = getExposureSet(interfaces[0]);
+      const exposureSet = getExposureSet(interfaces[0], scopes);
       assert.hasAllKeys(exposureSet, ['Worker']);
     });
 
@@ -656,8 +663,23 @@ describe('build', () => {
       };
       const {ast} = flattenIDL(specIDLs, customIDLs);
       const interfaces = ast.filter((dfn) => dfn.type === 'interface');
-      const exposureSet = getExposureSet(interfaces[0]);
+      const exposureSet = getExposureSet(interfaces[0], scopes);
       assert.hasAllKeys(exposureSet, ['Window', 'Worker']);
+    });
+
+    it('wildcard exposure', () => {
+      const specIDLs = {
+        first: WebIDL2.parse(
+          `[Exposed=*]
+             interface Dummy {
+               readonly attribute boolean imadumdum;
+             };`
+        )
+      };
+      const {ast} = flattenIDL(specIDLs, customIDLs);
+      const interfaces = ast.filter((dfn) => dfn.type === 'interface');
+      const exposureSet = getExposureSet(interfaces[0], scopes);
+      assert.hasAllKeys(exposureSet, scopes);
     });
 
     it('exposed to DedicatedWorker', () => {
@@ -671,7 +693,7 @@ describe('build', () => {
       };
       const {ast} = flattenIDL(specIDLs, customIDLs);
       const interfaces = ast.filter((dfn) => dfn.type === 'interface');
-      const exposureSet = getExposureSet(interfaces[0]);
+      const exposureSet = getExposureSet(interfaces[0], scopes);
       assert.hasAllKeys(exposureSet, ['Worker']);
     });
   });

--- a/unittest/unit/build.js
+++ b/unittest/unit/build.js
@@ -618,7 +618,8 @@ describe('build', () => {
       'Worker',
       'SharedWorker',
       'ServiceWorker',
-      'AudioWorklet'
+      'AudioWorklet',
+      'RTCIdentityProvider'
     ];
 
     it('no defined exposure set', () => {
@@ -700,10 +701,10 @@ describe('build', () => {
       assert.hasAllKeys(exposureSet, ['Worker']);
     });
 
-    it('"GlobalScope" stripped from exposure set names', () => {
+    it('Special case for RTCIdentityProviderGlobalScope', () => {
       const specIDLs = {
         first: WebIDL2.parse(
-          `[Exposed=AudioWorkletGlobalScope]
+          `[Exposed=RTCIdentityProviderGlobalScope]
              interface Dummy {
                readonly attribute boolean imadumdum;
              };`
@@ -712,7 +713,7 @@ describe('build', () => {
       const {ast} = flattenIDL(specIDLs, customIDLs);
       const interfaces = ast.filter((dfn) => dfn.type === 'interface');
       const exposureSet = getExposureSet(interfaces[0], scopes);
-      assert.hasAllKeys(exposureSet, ['AudioWorklet']);
+      assert.hasAllKeys(exposureSet, ['RTCIdentityProvider']);
     });
 
     it('invalid exposure', () => {

--- a/unittest/unit/build.js
+++ b/unittest/unit/build.js
@@ -630,7 +630,7 @@ describe('build', () => {
       const interfaces = ast.filter((dfn) => dfn.type === 'interface');
       assert.throws(
         () => {
-          getExposureSet(interfaces[0]);
+          getExposureSet(interfaces[0], scopes);
         },
         Error,
         'Exposed extended attribute not found on interface Dummy'
@@ -695,6 +695,26 @@ describe('build', () => {
       const interfaces = ast.filter((dfn) => dfn.type === 'interface');
       const exposureSet = getExposureSet(interfaces[0], scopes);
       assert.hasAllKeys(exposureSet, ['Worker']);
+    });
+
+    it('invalid exposure', () => {
+      const specIDLs = {
+        first: WebIDL2.parse(
+          `[Exposed=WrongGlobalScope]
+          interface Dummy {
+               readonly attribute boolean imadumdum;
+             };`
+        )
+      };
+      const {ast} = flattenIDL(specIDLs, customIDLs);
+      const interfaces = ast.filter((dfn) => dfn.type === 'interface');
+      assert.throws(
+        () => {
+          getExposureSet(interfaces[0], scopes);
+        },
+        Error,
+        'interface Dummy is exposed on WrongGlobalScope but WrongGlobalScope is not a valid scope'
+      );
     });
   });
 

--- a/unittest/unit/build.js
+++ b/unittest/unit/build.js
@@ -613,14 +613,14 @@ describe('build', () => {
   describe('getExposureSet', () => {
     // Combining spec and custom IDL is not important to these tests.
     const customIDLs = {};
-    const scopes = [
+    const scopes = new Set([
       'Window',
       'Worker',
       'SharedWorker',
       'ServiceWorker',
       'AudioWorklet',
       'RTCIdentityProvider'
-    ];
+    ]);
 
     it('no defined exposure set', () => {
       const specIDLs = {
@@ -738,13 +738,13 @@ describe('build', () => {
   });
 
   describe('buildIDLTests', () => {
-    const scopes = [
+    const scopes = new Set([
       'Window',
       'Worker',
       'SharedWorker',
       'ServiceWorker',
       'AudioWorklet'
-    ];
+    ]);
 
     it('interface with attribute', () => {
       const ast = WebIDL2.parse(

--- a/unittest/unit/build.js
+++ b/unittest/unit/build.js
@@ -683,7 +683,7 @@ describe('build', () => {
       const {ast} = flattenIDL(specIDLs, customIDLs);
       const interfaces = ast.filter((dfn) => dfn.type === 'interface');
       const exposureSet = getExposureSet(interfaces[0], scopes);
-      assert.hasAllKeys(exposureSet, scopes);
+      assert.hasAllKeys(exposureSet, [...scopes]);
     });
 
     it('DedicatedWorker remaps to Worker', () => {

--- a/unittest/unit/build.js
+++ b/unittest/unit/build.js
@@ -410,7 +410,10 @@ describe('build', () => {
 
   it('buildIDL', () => {
     const specIDLs = {
-      first: WebIDL2.parse(`[Exposed=Window] interface DOMError {};`),
+      first: WebIDL2.parse(
+        `[Global=Window, Exposed=Window] interface Window {};
+        [Exposed=Window] interface DOMError {};`
+      ),
       second: WebIDL2.parse(`[Exposed=Window] interface XSLTProcessor {};`)
     };
 
@@ -734,6 +737,14 @@ describe('build', () => {
   });
 
   describe('buildIDLTests', () => {
+    const scopes = [
+      'Window',
+      'Worker',
+      'SharedWorker',
+      'ServiceWorker',
+      'AudioWorklet'
+    ];
+
     it('interface with attribute', () => {
       const ast = WebIDL2.parse(
         `[Exposed=Window]
@@ -741,7 +752,7 @@ describe('build', () => {
              attribute any name;
            };`
       );
-      assert.deepEqual(buildIDLTests(ast, []), {
+      assert.deepEqual(buildIDLTests(ast, [], scopes), {
         'api.Attr': {
           code: '"Attr" in self',
           exposure: ['Window']
@@ -760,7 +771,7 @@ describe('build', () => {
              boolean contains(Node? other);
            };`
       );
-      assert.deepEqual(buildIDLTests(ast, []), {
+      assert.deepEqual(buildIDLTests(ast, [], scopes), {
         'api.Node': {
           code: '"Node" in self',
           exposure: ['Window']
@@ -780,7 +791,7 @@ describe('build', () => {
            };`
       );
 
-      assert.deepEqual(buildIDLTests(ast, []), {
+      assert.deepEqual(buildIDLTests(ast, [], scopes), {
         'api.MediaSource': {
           code: '"MediaSource" in self',
           exposure: ['Window']
@@ -800,7 +811,7 @@ describe('build', () => {
            };`
       );
 
-      assert.deepEqual(buildIDLTests(ast, []), {
+      assert.deepEqual(buildIDLTests(ast, [], scopes), {
         'api.Window': {
           code: '"Window" in self',
           exposure: ['Window']
@@ -833,7 +844,7 @@ describe('build', () => {
           };`
       );
 
-      assert.deepEqual(buildIDLTests(ast, []), {
+      assert.deepEqual(buildIDLTests(ast, [], scopes), {
         'api.ANGLE_instanced_arrays': {
           code: "(function() {\n  var canvas = document.createElement('canvas');\n  var gl = canvas.getContext('webgl');\n  var instance = gl.getExtension('ANGLE_instanced_arrays');\n  return !!instance;\n})();",
           exposure: ['Window']
@@ -870,7 +881,7 @@ describe('build', () => {
         `[Exposed=Window, LegacyNamespace]
            interface Legacy {};`
       );
-      assert.deepEqual(buildIDLTests(ast, []), {});
+      assert.deepEqual(buildIDLTests(ast, [], scopes), {});
     });
 
     it('global interface', () => {
@@ -882,7 +893,7 @@ describe('build', () => {
            };`
       );
 
-      assert.deepEqual(buildIDLTests(ast, []), {
+      assert.deepEqual(buildIDLTests(ast, [], scopes), {
         'api.WorkerGlobalScope': {
           code: '"WorkerGlobalScope" in self',
           exposure: ['Worker']
@@ -902,7 +913,7 @@ describe('build', () => {
            };`
       );
 
-      assert.deepEqual(buildIDLTests(ast, []), {
+      assert.deepEqual(buildIDLTests(ast, [], scopes), {
         'api.Number': {
           code: '"Number" in self',
           exposure: ['Window']
@@ -921,7 +932,7 @@ describe('build', () => {
              iterable<double>;
            };`
       );
-      assert.deepEqual(buildIDLTests(ast, []), {
+      assert.deepEqual(buildIDLTests(ast, [], scopes), {
         'api.DoubleList': {
           code: '"DoubleList" in self',
           exposure: ['Window']
@@ -956,7 +967,7 @@ describe('build', () => {
              maplike<DOMString, double>;
            };`
       );
-      assert.deepEqual(buildIDLTests(ast, []), {
+      assert.deepEqual(buildIDLTests(ast, [], scopes), {
         'api.DoubleMap': {
           code: '"DoubleMap" in self',
           exposure: ['Window']
@@ -1015,7 +1026,7 @@ describe('build', () => {
              setlike<double>;
            };`
       );
-      assert.deepEqual(buildIDLTests(ast, []), {
+      assert.deepEqual(buildIDLTests(ast, [], scopes), {
         'api.DoubleSet': {
           code: '"DoubleSet" in self',
           exposure: ['Window']
@@ -1071,7 +1082,7 @@ describe('build', () => {
              setter undefined (GetMe data, optional unsigned long index);
            };`
       );
-      assert.deepEqual(buildIDLTests(ast, []), {
+      assert.deepEqual(buildIDLTests(ast, [], scopes), {
         'api.GetMe': {
           code: '"GetMe" in self',
           exposure: ['Window']
@@ -1086,7 +1097,7 @@ describe('build', () => {
            [Exposed=(Window,Worker)] interface MessageChannel {};
            [Exposed=Window] namespace console {};`
       );
-      assert.deepEqual(buildIDLTests(ast, []), {
+      assert.deepEqual(buildIDLTests(ast, [], scopes), {
         'api.console': {
           code: '"console" in self',
           exposure: ['Window']
@@ -1114,7 +1125,7 @@ describe('build', () => {
            };`
       );
 
-      assert.deepEqual(buildIDLTests(ast, []), {
+      assert.deepEqual(buildIDLTests(ast, [], scopes), {
         'api.Number': {
           code: '"Number" in self',
           exposure: ['Window']
@@ -1135,7 +1146,7 @@ describe('build', () => {
              undefined disconnect (AudioNode destinationNode);
            };`
       );
-      assert.deepEqual(buildIDLTests(ast, []), {
+      assert.deepEqual(buildIDLTests(ast, [], scopes), {
         'api.AudioNode': {
           code: '"AudioNode" in self',
           exposure: ['Window']
@@ -1154,7 +1165,7 @@ describe('build', () => {
              readonly attribute any paintWorklet;
            };`
       );
-      assert.deepEqual(buildIDLTests(ast, []), {
+      assert.deepEqual(buildIDLTests(ast, [], scopes), {
         'api.CSS': {
           code: '"CSS" in self',
           exposure: ['Window']
@@ -1173,7 +1184,7 @@ describe('build', () => {
              boolean supports(CSSOMString property, CSSOMString value);
            };`
       );
-      assert.deepEqual(buildIDLTests(ast, []), {
+      assert.deepEqual(buildIDLTests(ast, [], scopes), {
         'api.CSS': {
           code: '"CSS" in self',
           exposure: ['Window']
@@ -1193,7 +1204,7 @@ describe('build', () => {
            };`
       );
 
-      assert.deepEqual(buildIDLTests(ast, []), {
+      assert.deepEqual(buildIDLTests(ast, [], scopes), {
         'api.Scope': {
           code: '(function() {\n  var scope = Scope;\n  return !!scope;\n})();',
           exposure: ['Window']
@@ -1214,7 +1225,7 @@ describe('build', () => {
            interface HTMLImageElement {};`
       );
 
-      assert.deepEqual(buildIDLTests(ast, []), {
+      assert.deepEqual(buildIDLTests(ast, [], scopes), {
         'api.HTMLImageElement': {
           code: '"HTMLImageElement" in self',
           exposure: ['Window']
@@ -1240,7 +1251,7 @@ describe('build', () => {
            };`
       );
 
-      assert.deepEqual(buildIDLTests(ast, globals), {
+      assert.deepEqual(buildIDLTests(ast, globals, scopes), {
         'api.Dummy': {
           code: '"Dummy" in self',
           exposure: ['Window']


### PR DESCRIPTION
This PR adds support for [wildcard exposure sets](https://webidl.spec.whatwg.org/#ref-for-dfn-xattr-wildcard%E2%91%A0).  While this feature is rarely used (currently only in a WICG draft spec, https://wicg.github.io/compression/#compression-stream), it was included in Webref/idl v3, which is blocking #1747.  This maps the wildcard to the four main exposure sets (window, worker, shared worker, and service worker).

Additionally, this renames the "globals" variable within `getExposureSet()` to `exposure` for better naming.
