### PR TITLE
Remove MediaStreamTrackProcessor custom IDL

### DIFF
--- a/custom-idl/mediacapture-transform.idl
+++ b/custom-idl/mediacapture-transform.idl
@@ -1,17 +1,6 @@
 // https://alvestrand.github.io/mediacapture-transform/chrome-96.html#idl-index
 
 [Exposed=Window]
-interface MediaStreamTrackProcessor {
-    constructor(MediaStreamTrackProcessorInit init);
-    attribute ReadableStream readable;
-};
-
-dictionary MediaStreamTrackProcessorInit {
-  required MediaStreamTrack track;
-  [EnforceRange] unsigned short maxBufferSize;
-};
-
-[Exposed=Window]
 interface MediaStreamTrackGenerator : MediaStreamTrack {
     constructor(MediaStreamTrackGeneratorInit init);
     attribute WritableStream writable;  // VideoFrame or AudioFrame


### PR DESCRIPTION
This was included in @webref/idl 2.12.0:
https://github.com/w3c/webref/pull/450