### PR TITLE
Make sure to include collector version in exporter.getReportMeta

### DIFF
--- a/exporter.js
+++ b/exporter.js
@@ -59,7 +59,8 @@ const getReportMeta = (report) => {
     title,
     slug,
     filename,
-    branch
+    branch,
+    version
   };
 };
 


### PR DESCRIPTION
This fixes a problem where the "dev version" warning will not show up in results PR bodies.﻿
