### PR TITLE
Remove unreachable code in build.js

### DIFF
--- a/build.js
+++ b/build.js
@@ -657,13 +657,6 @@ const buildIDLMemberTests = (
             };
           }
           break;
-        case 'const':
-          if (isGlobal) {
-            expr = {property: member.name, owner: 'self'};
-          } else {
-            expr = {property: member.name, owner: iface.name};
-          }
-          break;
         case 'constructor':
           expr = {property: `constructor.${member.name}`, owner: iface.name};
           break;


### PR DESCRIPTION
This PR removes code that generates tests for constants.  We are filtering out all constants in earlier code, so this section is never reached.
