### PR TITLE
Add the ability to test CSS property values to custom-css.json

### DIFF
--- a/build.js
+++ b/build.js
@@ -787,8 +787,9 @@ const buildCSS = (specCSS, customCSS) => {
   }
 
   for (const [name, data] of Object.entries(customCSS.properties)) {
-    const values = "__values" in data ? data["__values"] : [];
-    const additionalValues = "__additional_values" in data ? data["__additional_values"] : {};
+    const values = '__values' in data ? data['__values'] : [];
+    const additionalValues =
+      '__additional_values' in data ? data['__additional_values'] : {};
 
     const mergedValues = new Map(Object.entries(additionalValues));
     for (const value of values) {
@@ -824,9 +825,13 @@ const buildCSS = (specCSS, customCSS) => {
     });
 
     // Tests for values
-    for (const [key, value] of Array.from(properties.get(name).entries()).sort()) {
+    for (const [key, value] of Array.from(
+      properties.get(name).entries()
+    ).sort()) {
       const values = Array.isArray(value) ? value : [value];
-      const code = values.map((value) => `bcd.testCSSPropertyValue("${name}", "${value}")`).join(" || ");
+      const code = values
+        .map((value) => `bcd.testCSSPropertyValue("${name}", "${value}")`)
+        .join(' || ');
       tests[`css.properties.${name}.${key}`] = compileTest({
         raw: {code: code},
         exposure: ['Window']

--- a/custom-css.json
+++ b/custom-css.json
@@ -9,21 +9,31 @@
     "-epub-text-emphasis": {},
     "-epub-text-emphasis-color": {},
     "-epub-text-emphasis-style": {},
-    "-epub-text-orientation": {},
-    "-epub-text-transform": {},
-    "-epub-word-break": {},
+    "-epub-text-orientation": {
+      "__values": ["sideways"]
+    },
+    "-epub-text-transform": {
+      "__values": ["capitalize", "full-size-kana", "full-width"]
+    },
+    "-epub-word-break": {
+      "__values": ["break-word", "keep-all"]
+    },
     "-epub-writing-mode": {},
     "-internal-text-autosizing-status": {},
     "-moz-animation": {},
     "-moz-animation-delay": {},
-    "-moz-animation-direction": {},
+    "-moz-animation-direction": {
+      "__values": ["alternate-reverse", "reverse"]
+    },
     "-moz-animation-duration": {},
     "-moz-animation-fill-mode": {},
     "-moz-animation-iteration-count": {},
     "-moz-animation-name": {},
     "-moz-animation-play-state": {},
     "-moz-animation-timing-function": {},
-    "-moz-appearance": {},
+    "-moz-appearance": {
+      "__values": ["auto", "menulist-button", "none", "textfield"]
+    },
     "-moz-backface-visibility": {},
     "-moz-background-inline-policy": {},
     "-moz-binding": {},
@@ -50,9 +60,13 @@
     "-moz-box-ordinal-group": {},
     "-moz-box-orient": {},
     "-moz-box-pack": {},
-    "-moz-box-sizing": {},
+    "-moz-box-sizing": {
+      "__values": ["padding-box"]
+    },
     "-moz-column-count": {},
-    "-moz-column-fill": {},
+    "-moz-column-fill": {
+      "__values": ["balance-all"]
+    },
     "-moz-column-gap": {},
     "-moz-column-rule": {},
     "-moz-column-rule-color": {},
@@ -71,10 +85,7 @@
     "-moz-margin-end": {},
     "-moz-margin-start": {},
     "-moz-orient": {
-      "__values": [
-        "auto",
-        "inline_and_block"
-      ]
+      "__values": ["auto", "inline_and_block"]
     },
     "-moz-osx-font-smoothing": {},
     "-moz-outline-radius": {},
@@ -93,22 +104,33 @@
     "-moz-transform": {},
     "-moz-transform-origin": {},
     "-moz-transform-style": {},
-    "-moz-transition": {},
+    "-moz-transition": {
+      "__values": ["gradients"]
+    },
     "-moz-transition-delay": {},
     "-moz-transition-duration": {},
-    "-moz-transition-property": {},
+    "-moz-transition-property": {
+      "__values": ["IDENT_value"]
+    },
     "-moz-transition-timing-function": {},
     "-moz-user-focus": {},
     "-moz-user-input": {
+      "__values": ["auto", "disabled", "enabled", "none"]
+    },
+    "-moz-user-modify": {
+      "__values": ["read-write-plaintext-only"]
+    },
+    "-moz-user-select": {
       "__values": [
+        "-moz-none",
+        "all",
         "auto",
-        "disabled",
-        "enabled",
-        "none"
+        "contain",
+        "element",
+        "none",
+        "text"
       ]
     },
-    "-moz-user-modify": {},
-    "-moz-user-select": {},
     "-moz-window-dragging": {},
     "-ms-content-zoom-chaining": {},
     "-ms-content-zoom-limit": {},
@@ -159,7 +181,17 @@
     "-ms-text-combine-horizontal": {},
     "-ms-text-size-adjust": {},
     "-ms-touch-select": {},
-    "-ms-user-select": {},
+    "-ms-user-select": {
+      "__values": [
+        "-moz-none",
+        "all",
+        "auto",
+        "contain",
+        "element",
+        "none",
+        "text"
+      ]
+    },
     "-ms-wrap-flow": {},
     "-ms-wrap-margin": {},
     "-ms-wrap-through": {},
@@ -204,7 +236,9 @@
     "-webkit-column-break-before": {},
     "-webkit-column-break-inside": {},
     "-webkit-column-count": {},
-    "-webkit-column-fill": {},
+    "-webkit-column-fill": {
+      "__values": ["balance-all"]
+    },
     "-webkit-column-gap": {},
     "-webkit-column-progression": {},
     "-webkit-column-rule": {},
@@ -236,9 +270,7 @@
     "-webkit-line-box-contain": {},
     "-webkit-line-break": {},
     "-webkit-line-clamp": {
-      "__values": [
-        "none"
-      ]
+      "__values": ["none"]
     },
     "-webkit-line-grid": {},
     "-webkit-line-snap": {},
@@ -285,7 +317,9 @@
     "-webkit-region-break-inside": {},
     "-webkit-region-fragment": {},
     "-webkit-rtl-ordering": {},
-    "-webkit-ruby-position": {},
+    "-webkit-ruby-position": {
+      "__values": ["alternate", "inter-character"]
+    },
     "-webkit-scroll-snap-coordinate": {},
     "-webkit-scroll-snap-destination": {},
     "-webkit-scroll-snap-points-x": {},
@@ -297,38 +331,47 @@
     "-webkit-svg-shadow": {},
     "-webkit-tap-highlight-color": {},
     "-webkit-text-combine": {},
-    "-webkit-text-decoration": {},
+    "-webkit-text-decoration": {
+      "__values": ["blink"]
+    },
     "-webkit-text-decoration-color": {},
-    "-webkit-text-decoration-line": {},
+    "-webkit-text-decoration-line": {
+      "__values": ["blink"]
+    },
     "-webkit-text-decoration-skip": {},
-    "-webkit-text-decoration-style": {},
+    "-webkit-text-decoration-style": {
+      "__values": ["wavy"]
+    },
     "-webkit-text-decorations-in-effect": {},
     "-webkit-text-emphasis": {},
     "-webkit-text-emphasis-color": {},
-    "-webkit-text-emphasis-position": {},
+    "-webkit-text-emphasis-position": {
+      "__values": ["over", "under"]
+    },
     "-webkit-text-emphasis-style": {},
-    "-webkit-text-orientation": {},
+    "-webkit-text-orientation": {
+      "__values": ["sideways"]
+    },
     "-webkit-text-security": {},
-    "-webkit-text-underline-position": {},
+    "-webkit-text-underline-position": {
+      "__values": ["auto-pos", "from-font", "left", "right", "under"]
+    },
     "-webkit-text-zoom": {},
     "-webkit-touch-callout": {},
     "-webkit-transform-origin-x": {},
     "-webkit-transform-origin-y": {},
     "-webkit-transform-origin-z": {},
     "-webkit-user-drag": {},
-    "-webkit-user-modify": {},
+    "-webkit-user-modify": {
+      "__values": ["read-write-plaintext-only"]
+    },
     "-webkit-writing-mode": {},
     "all": {
-      "__values": [
-        "revert"
-      ]
+      "__values": ["revert"]
     },
     "alt": {},
     "animation-direction": {
-      "__values": [
-        "alternate-reverse",
-        "reverse"
-      ]
+      "__values": ["alternate-reverse", "reverse"]
     },
     "animation-timing-function": {
       "__additional_values": {
@@ -352,12 +395,7 @@
           "textarea"
         ]
       },
-      "__values": [
-        "auto",
-        "menulist-button",
-        "none",
-        "textfield"
-      ]
+      "__values": ["auto", "menulist-button", "none", "textfield"]
     },
     "background": {
       "__additional_values": {
@@ -371,16 +409,10 @@
       "__additional_values": {
         "multiple_backgrounds": "fixed, scroll"
       },
-      "__values": [
-        "fixed",
-        "local"
-      ]
+      "__values": ["fixed", "local"]
     },
     "background-clip": {
-      "__values": [
-        "content-box",
-        "text"
-      ]
+      "__values": ["content-box", "text"]
     },
     "background-image": {
       "__additional_values": {
@@ -395,9 +427,7 @@
       }
     },
     "background-origin": {
-      "__values": [
-        "content-box"
-      ]
+      "__values": ["content-box"]
     },
     "background-position": {
       "__additional_values": {
@@ -419,20 +449,14 @@
       "__additional_values": {
         "2-value": "repeat no-repeat",
         "multiple_backgrounds": "repeat, no-repeat",
-        "round_space": [
-          "space",
-          "round"
-        ]
+        "round_space": ["space", "round"]
       }
     },
     "background-repeat-x": {},
     "background-repeat-y": {},
     "background-size": {
       "__additional_values": {
-        "contain_and_cover": [
-          "contain",
-          "cover"
-        ]
+        "contain_and_cover": ["contain", "cover"]
       }
     },
     "block-size": {
@@ -469,10 +493,7 @@
       }
     },
     "border-image-repeat": {
-      "__values": [
-        "round",
-        "space"
-      ]
+      "__values": ["round", "space"]
     },
     "border-radius": {
       "__additional_values": {
@@ -509,9 +530,7 @@
       }
     },
     "box-sizing": {
-      "__values": [
-        "padding-box"
-      ]
+      "__values": ["padding-box"]
     },
     "break-after": {
       "__values": [
@@ -546,42 +565,28 @@
     },
     "clear": {
       "__additional_values": {
-        "flow_relative_values": [
-          "inline-end",
-          "inline-start"
-        ]
+        "flow_relative_values": ["inline-end", "inline-start"]
       }
     },
     "clip-path": {
       "__additional_values": {
         "-webkit-path": "-webkit-path('M20,20 L50,80 L80,20')",
         "basic_shape": "circle(50px at 0 100px)",
-        "fill_and_stroke_box": [
-          "fill-box",
-          "stroke-box"
-        ],
+        "fill_and_stroke_box": ["fill-box", "stroke-box"],
         "path": "path('M20,20 L50,80 L80,20')"
       }
     },
     "color-profile": {},
     "color-rendering": {},
     "color-scheme": {
-      "__values": [
-        "only",
-        "only_dark",
-        "only_light"
-      ]
+      "__values": ["only", "only_dark", "only_light"]
     },
     "column-fill": {
-      "__values": [
-        "balance-all"
-      ]
+      "__values": ["balance-all"]
     },
     "column-progression": {},
     "contain": {
-      "__values": [
-        "style"
-      ]
+      "__values": ["style"]
     },
     "content": {
       "__additional_values": {
@@ -614,10 +619,7 @@
         ],
         "url": "url(hand.cur), pointer",
         "url_positioning_syntax": "url(cursor_1.png) 4 12, auto",
-        "zoom": [
-          "zoom-in",
-          "zoom-out"
-        ]
+        "zoom": ["zoom-in", "zoom-out"]
       },
       "__values": [
         "-moz-grab",
@@ -650,11 +652,7 @@
     },
     "display": {
       "__additional_values": {
-        "display-outside": [
-          "block",
-          "inline",
-          "run-in"
-        ],
+        "display-outside": ["block", "inline", "run-in"],
         "multi-keyword_values": "inline flow",
         "ruby_values": [
           "ruby",
@@ -673,20 +671,10 @@
           "table-row",
           "table-row-group"
         ],
-        "xul_box_values": [
-          "-moz-box",
-          "-moz-inline-box"
-        ],
+        "xul_box_values": ["-moz-box", "-moz-inline-box"],
         "xul_deck_values": "-moz-deck",
-        "xul_grid_values": [
-          "-moz-grid",
-          "-moz-grid-group",
-          "-moz-grid-line"
-        ],
-        "xul_inline_grid_stack": [
-          "-moz-inline-grid",
-          "-moz-inline-stack"
-        ],
+        "xul_grid_values": ["-moz-grid", "-moz-grid-group", "-moz-grid-line"],
+        "xul_inline_grid_stack": ["-moz-inline-grid", "-moz-inline-stack"],
         "xul_popup_values": "-moz-popup",
         "xul_stack_value": "-moz-stack"
       },
@@ -725,10 +713,7 @@
     },
     "float": {
       "__additional_values": {
-        "flow_relative_values": [
-          "inline-end",
-          "inline-start"
-        ]
+        "flow_relative_values": ["inline-end", "inline-start"]
       }
     },
     "font": {
@@ -746,18 +731,13 @@
     },
     "font-display": {},
     "font-family": {
-      "__values": [
-        "-apple-system",
-        "system_ui"
-      ]
+      "__values": ["-apple-system", "system_ui"]
     },
     "font-size": {
       "__additional_values": {
         "rem_values": "10rem"
       },
-      "__values": [
-        "xxx-large"
-      ]
+      "__values": ["xxx-large"]
     },
     "font-size-adjust": {
       "__additional_values": {
@@ -776,16 +756,10 @@
       }
     },
     "font-synthesis": {
-      "__values": [
-        "small-caps"
-      ]
+      "__values": ["small-caps"]
     },
     "font-variant": {
-      "__values": [
-        "historical-forms",
-        "sub",
-        "super"
-      ]
+      "__values": ["historical-forms", "sub", "super"]
     },
     "font-variant-alternates": {
       "__additional_values": {
@@ -870,14 +844,10 @@
     "layout-grid-mode": {},
     "layout-grid-type": {},
     "line-height": {
-      "__values": [
-        "-moz-block-height"
-      ]
+      "__values": ["-moz-block-height"]
     },
     "list-style": {
-      "__values": [
-        "symbols"
-      ]
+      "__values": ["symbols"]
     },
     "list-style-type": {
       "__values": [
@@ -1013,38 +983,23 @@
       ]
     },
     "margin": {
-      "__values": [
-        "auto"
-      ]
+      "__values": ["auto"]
     },
     "margin-bottom": {
-      "__values": [
-        "auto"
-      ]
+      "__values": ["auto"]
     },
     "margin-left": {
-      "__values": [
-        "auto"
-      ]
+      "__values": ["auto"]
     },
     "margin-right": {
-      "__values": [
-        "auto"
-      ]
+      "__values": ["auto"]
     },
     "margin-top": {
-      "__values": [
-        "auto"
-      ]
+      "__values": ["auto"]
     },
     "marker-offset": {},
     "mask-clip": {
-      "__values": [
-        "border",
-        "content",
-        "padding",
-        "text"
-      ]
+      "__values": ["border", "content", "padding", "text"]
     },
     "mask-image": {
       "__additional_values": {
@@ -1053,17 +1008,9 @@
     },
     "mask-origin": {
       "__additional_values": {
-        "non_standard_values": [
-          "content",
-          "padding",
-          "border"
-        ]
+        "non_standard_values": ["content", "padding", "border"]
       },
-      "__values": [
-        "fill-box",
-        "stroke-box",
-        "view-box"
-      ]
+      "__values": ["fill-box", "stroke-box", "view-box"]
     },
     "mask-position": {
       "__additional_values": {
@@ -1239,44 +1186,28 @@
     },
     "orientation": {},
     "outline-color": {
-      "__values": [
-        "invert"
-      ]
+      "__values": ["invert"]
     },
     "outline-style": {
-      "__values": [
-        "auto"
-      ]
+      "__values": ["auto"]
     },
     "overflow": {
       "__additional_values": {
         "multiple_keywords": "hidden visible"
       },
-      "__values": [
-        "-moz-hidden-unscrollable",
-        "clip"
-      ]
+      "__values": ["-moz-hidden-unscrollable", "clip"]
     },
     "overflow-clip-box": {},
     "overflow-clip-box-block": {},
     "overflow-clip-box-inline": {},
     "overflow-wrap": {
-      "__values": [
-        "anywhere",
-        "break-word"
-      ]
+      "__values": ["anywhere", "break-word"]
     },
     "overflow-x": {
-      "__values": [
-        "-moz-hidden-unscrollable",
-        "clip"
-      ]
+      "__values": ["-moz-hidden-unscrollable", "clip"]
     },
     "overflow-y": {
-      "__values": [
-        "-moz-hidden-unscrollable",
-        "clip"
-      ]
+      "__values": ["-moz-hidden-unscrollable", "clip"]
     },
     "page-orientation": {},
     "pen-action": {},
@@ -1288,11 +1219,7 @@
     "perspective-origin-x": {},
     "perspective-origin-y": {},
     "position": {
-      "__values": [
-        "-webkit-sticky",
-        "fixed",
-        "sticky"
-      ]
+      "__values": ["-webkit-sticky", "fixed", "sticky"]
     },
     "quotes": {
       "__additional_values": {
@@ -1301,10 +1228,7 @@
     },
     "resize": {
       "__additional_values": {
-        "flow_relative_support": [
-          "block",
-          "inline"
-        ]
+        "flow_relative_support": ["block", "inline"]
       }
     },
     "rotate": {
@@ -1313,10 +1237,7 @@
       }
     },
     "ruby-position": {
-      "__values": [
-        "alternate",
-        "inter-character"
-      ]
+      "__values": ["alternate", "inter-character"]
     },
     "scroll-snap-coordinate": {},
     "scroll-snap-destination": {},
@@ -1371,50 +1292,30 @@
     },
     "text-align": {
       "__additional_values": {
-        "block_alignment_values": [
-          "center",
-          "left",
-          "right"
-        ],
-        "flow_relative_values_start_and_end": [
-          "start",
-          "end"
-        ],
+        "block_alignment_values": ["center", "left", "right"],
+        "flow_relative_values_start_and_end": ["start", "end"],
         "string": "'.'"
       },
-      "__values": [
-        "justify-all",
-        "match-parent"
-      ]
+      "__values": ["justify-all", "match-parent"]
     },
     "text-combine-horizontal": {},
     "text-combine-upright": {
-      "__values": [
-        "digits"
-      ]
+      "__values": ["digits"]
     },
     "text-decoration": {
       "__additional_values": {
         "text-decoration-thickness": "solid underline purple 4px"
       },
-      "__values": [
-        "blink"
-      ]
+      "__values": ["blink"]
     },
     "text-decoration-line": {
-      "__values": [
-        "blink"
-      ]
+      "__values": ["blink"]
     },
     "text-decoration-skip-ink": {
-      "__values": [
-        "all"
-      ]
+      "__values": ["all"]
     },
     "text-decoration-style": {
-      "__values": [
-        "wavy"
-      ]
+      "__values": ["wavy"]
     },
     "text-decoration-thickness": {
       "__additional_values": {
@@ -1424,21 +1325,12 @@
     "text-decoration-width": {},
     "text-emphasis-position": {
       "__additional_values": {
-        "left_and_right": [
-          "over left",
-          "over right"
-        ]
+        "left_and_right": ["over left", "over right"]
       },
-      "__values": [
-        "over",
-        "under"
-      ]
+      "__values": ["over", "under"]
     },
     "text-indent": {
-      "__values": [
-        "each-line",
-        "hanging"
-      ]
+      "__values": ["each-line", "hanging"]
     },
     "text-kashida": {},
     "text-kashida-space": {},
@@ -1448,9 +1340,7 @@
     "text-line-through-style": {},
     "text-line-through-width": {},
     "text-orientation": {
-      "__values": [
-        "sideways"
-      ]
+      "__values": ["sideways"]
     },
     "text-overflow": {
       "__additional_values": {
@@ -1466,10 +1356,7 @@
     "text-overline-style": {},
     "text-overline-width": {},
     "text-rendering": {
-      "__values": [
-        "auto",
-        "geometricPrecision"
-      ]
+      "__values": ["auto", "geometricPrecision"]
     },
     "text-size-adjust": {
       "__additional_values": {
@@ -1477,11 +1364,7 @@
       }
     },
     "text-transform": {
-      "__values": [
-        "capitalize",
-        "full-size-kana",
-        "full-width"
-      ]
+      "__values": ["capitalize", "full-size-kana", "full-width"]
     },
     "text-underline": {},
     "text-underline-color": {},
@@ -1493,44 +1376,19 @@
     },
     "text-underline-position": {
       "__additional_values": {
-        "above_below": [
-          "above",
-          "below"
-        ],
-        "left_right": [
-          "left",
-          "right"
-        ]
+        "above_below": ["above", "below"],
+        "left_right": ["left", "right"]
       },
-      "__values": [
-        "auto-pos",
-        "from-font",
-        "left",
-        "right",
-        "under"
-      ]
+      "__values": ["auto-pos", "from-font", "left", "right", "under"]
     },
     "text-underline-style": {},
     "text-underline-width": {},
     "touch-action": {
       "__additional_values": {
-        "axis-pan": [
-          "pan-x",
-          "pan-y"
-        ],
-        "unidirectional-pan": [
-          "pan-up",
-          "pan-down",
-          "pan-left",
-          "pan-right"
-        ]
+        "axis-pan": ["pan-x", "pan-y"],
+        "unidirectional-pan": ["pan-up", "pan-down", "pan-left", "pan-right"]
       },
-      "__values": [
-        "double-tap-zoom",
-        "manipulation",
-        "none",
-        "pinch-zoom"
-      ]
+      "__values": ["double-tap-zoom", "manipulation", "none", "pinch-zoom"]
     },
     "transform": {
       "__additional_values": {
@@ -1542,11 +1400,7 @@
       }
     },
     "transform-box": {
-      "__values": [
-        "border-box",
-        "content-box",
-        "stroke-box"
-      ]
+      "__values": ["border-box", "content-box", "stroke-box"]
     },
     "transform-origin": {
       "__additional_values": {
@@ -1557,14 +1411,10 @@
     "transform-origin-y": {},
     "transform-origin-z": {},
     "transition": {
-      "__values": [
-        "gradients"
-      ]
+      "__values": ["gradients"]
     },
     "transition-property": {
-      "__values": [
-        "IDENT_value"
-      ]
+      "__values": ["IDENT_value"]
     },
     "transition-timing-function": {
       "__additional_values": {
@@ -1586,9 +1436,7 @@
     },
     "unicode-range": {},
     "user-modify": {
-      "__values": [
-        "read-write-plaintext-only"
-      ]
+      "__values": ["read-write-plaintext-only"]
     },
     "user-select": {
       "__values": [
@@ -1604,9 +1452,7 @@
     "user-zoom": {},
     "viewport-fit": {},
     "visibility": {
-      "__values": [
-        "collapse"
-      ]
+      "__values": ["collapse"]
     },
     "white-space": {
       "__values": [
@@ -1640,10 +1486,7 @@
       ]
     },
     "word-break": {
-      "__values": [
-        "break-word",
-        "keep-all"
-      ]
+      "__values": ["break-word", "keep-all"]
     },
     "word-spacing": {
       "__additional_values": {
@@ -1657,18 +1500,8 @@
           "vertical-lr",
           "vertical-rl"
         ],
-        "sideways_values": [
-          "sideways-lr",
-          "sideways-rl"
-        ],
-        "svg_values": [
-          "lr",
-          "lr-tb",
-          "rl",
-          "rl-tb",
-          "tb",
-          "tb-rl"
-        ]
+        "sideways_values": ["sideways-lr", "sideways-rl"],
+        "svg_values": ["lr", "lr-tb", "rl", "rl-tb", "tb", "tb-rl"]
       }
     },
     "z-index": {
@@ -1677,9 +1510,7 @@
       }
     },
     "zoom": {
-      "__values": [
-        "reset"
-      ]
+      "__values": ["reset"]
     }
   }
 }

--- a/custom-css.json
+++ b/custom-css.json
@@ -70,7 +70,12 @@
     "-moz-image-region": {},
     "-moz-margin-end": {},
     "-moz-margin-start": {},
-    "-moz-orient": {},
+    "-moz-orient": {
+      "__values": [
+        "auto",
+        "inline_and_block"
+      ]
+    },
     "-moz-osx-font-smoothing": {},
     "-moz-outline-radius": {},
     "-moz-outline-radius-bottomleft": {},
@@ -94,7 +99,14 @@
     "-moz-transition-property": {},
     "-moz-transition-timing-function": {},
     "-moz-user-focus": {},
-    "-moz-user-input": {},
+    "-moz-user-input": {
+      "__values": [
+        "auto",
+        "disabled",
+        "enabled",
+        "none"
+      ]
+    },
     "-moz-user-modify": {},
     "-moz-user-select": {},
     "-moz-window-dragging": {},
@@ -223,6 +235,11 @@
     "-webkit-line-align": {},
     "-webkit-line-box-contain": {},
     "-webkit-line-break": {},
+    "-webkit-line-clamp": {
+      "__values": [
+        "none"
+      ]
+    },
     "-webkit-line-grid": {},
     "-webkit-line-snap": {},
     "-webkit-locale": {},
@@ -301,9 +318,181 @@
     "-webkit-user-drag": {},
     "-webkit-user-modify": {},
     "-webkit-writing-mode": {},
+    "all": {
+      "__values": [
+        "revert"
+      ]
+    },
     "alt": {},
+    "animation-direction": {
+      "__values": [
+        "alternate-reverse",
+        "reverse"
+      ]
+    },
+    "animation-timing-function": {
+      "__additional_values": {
+        "jump": "steps(1, jump-start)"
+      }
+    },
+    "appearance": {
+      "__additional_values": {
+        "compat-auto": [
+          "button",
+          "checkbox",
+          "listbox",
+          "menulist",
+          "meter",
+          "progress-bar",
+          "push-button",
+          "radio",
+          "searchfield",
+          "slider-horizontal",
+          "square-button",
+          "textarea"
+        ]
+      },
+      "__values": [
+        "auto",
+        "menulist-button",
+        "none",
+        "textfield"
+      ]
+    },
+    "background": {
+      "__additional_values": {
+        "background-clip": "red border-box",
+        "background-origin": "red border-box",
+        "background-size": "url(test.jpg) 10px",
+        "multiple_backgrounds": "url(test.jpg), url(test2.jpg), blue"
+      }
+    },
+    "background-attachment": {
+      "__additional_values": {
+        "multiple_backgrounds": "fixed, scroll"
+      },
+      "__values": [
+        "fixed",
+        "local"
+      ]
+    },
+    "background-clip": {
+      "__values": [
+        "content-box",
+        "text"
+      ]
+    },
+    "background-image": {
+      "__additional_values": {
+        "-moz-element": "-moz-element(#foo)",
+        "-moz-image-rect": "-moz-image-rect(url(test.png), 0%, 50%, 50%, 0%)",
+        "-webkit-image-set": "image-set(url(small-balloons.jpg) 1x, url(large-balloons.jpg) 2x)",
+        "element": "element(#foo)",
+        "gradients": "linear-gradient(#f69d3c, #3f87a6)",
+        "image-rect": "image-rect(url(test.png), 0%, 50%, 50%, 0%)",
+        "image-set": "image-set(url(small-balloons.jpg) 1x, url(large-balloons.jpg) 2x)",
+        "multiple_backgrounds": "url(test.jpg), url(test2.jpg)"
+      }
+    },
+    "background-origin": {
+      "__values": [
+        "content-box"
+      ]
+    },
+    "background-position": {
+      "__additional_values": {
+        "4_value_syntax": "bottom 50px right 100px",
+        "multiple_backgrounds": "bottom, top"
+      }
+    },
+    "background-position-x": {
+      "__additional_values": {
+        "two_value_syntax": "right 3px"
+      }
+    },
+    "background-position-y": {
+      "__additional_values": {
+        "2_value_syntax": "bottom 3px"
+      }
+    },
+    "background-repeat": {
+      "__additional_values": {
+        "2-value": "repeat no-repeat",
+        "multiple_backgrounds": "repeat, no-repeat",
+        "round_space": [
+          "space",
+          "round"
+        ]
+      }
+    },
     "background-repeat-x": {},
     "background-repeat-y": {},
+    "background-size": {
+      "__additional_values": {
+        "contain_and_cover": [
+          "contain",
+          "cover"
+        ]
+      }
+    },
+    "block-size": {
+      "__additional_values": {
+        "fit-content_function": "fit-content(10px)"
+      },
+      "__values": [
+        "-moz-fit-content",
+        "-moz-max-content",
+        "-moz-min-content",
+        "-webkit-fill-available",
+        "fit-content",
+        "max-content",
+        "min-content"
+      ]
+    },
+    "border-bottom-left-radius": {
+      "__additional_values": {
+        "elliptical_corners": "40px 20px",
+        "percentages": "20%"
+      }
+    },
+    "border-bottom-right-radius": {
+      "__additional_values": {
+        "elliptical_corners": "40px 20px",
+        "percentages": "20%"
+      }
+    },
+    "border-image": {
+      "__additional_values": {
+        "fill": "url(test.png) 30 fill",
+        "gradient": "linear-gradient(red, blue)",
+        "optional_border_image_slice": "url(test.png) 30"
+      }
+    },
+    "border-image-repeat": {
+      "__values": [
+        "round",
+        "space"
+      ]
+    },
+    "border-radius": {
+      "__additional_values": {
+        "4_values_for_4_corners": "10px 20px 30px 40px",
+        "elliptical_borders": "40px / 10px",
+        "percentages": "20%"
+      }
+    },
+    "border-top-left-radius": {
+      "__additional_values": {
+        "elliptical_corners": "40px 20px",
+        "percentages": "20%"
+      }
+    },
+    "border-top-right-radius": {
+      "__additional_values": {
+        "elliptical_corners": "40px 20px",
+        "percentages": "20%"
+      }
+    },
     "box-align": {},
     "box-direction": {},
     "box-flex": {},
@@ -312,49 +501,823 @@
     "box-ordinal-group": {},
     "box-orient": {},
     "box-pack": {},
+    "box-shadow": {
+      "__additional_values": {
+        "inset": "inset 5em 1em gold",
+        "multiple_shadows": "3px 3px red, -6px -6px olive",
+        "spread_radius": "12px 12px 2px 1px teal"
+      }
+    },
+    "box-sizing": {
+      "__values": [
+        "padding-box"
+      ]
+    },
+    "break-after": {
+      "__values": [
+        "always",
+        "avoid-column",
+        "avoid-page",
+        "column",
+        "recto",
+        "verso"
+      ]
+    },
+    "break-before": {
+      "__values": [
+        "always",
+        "avoid-column",
+        "avoid-page",
+        "column",
+        "recto",
+        "verso"
+      ]
+    },
     "buffered-rendering": {},
+    "caption-side": {
+      "__additional_values": {
+        "non_standard_values": [
+          "left",
+          "right",
+          "top-outside",
+          "bottom-outside"
+        ]
+      }
+    },
+    "clear": {
+      "__additional_values": {
+        "flow_relative_values": [
+          "inline-end",
+          "inline-start"
+        ]
+      }
+    },
+    "clip-path": {
+      "__additional_values": {
+        "-webkit-path": "-webkit-path('M20,20 L50,80 L80,20')",
+        "basic_shape": "circle(50px at 0 100px)",
+        "fill_and_stroke_box": [
+          "fill-box",
+          "stroke-box"
+        ],
+        "path": "path('M20,20 L50,80 L80,20')"
+      }
+    },
     "color-profile": {},
     "color-rendering": {},
+    "color-scheme": {
+      "__values": [
+        "only",
+        "only_dark",
+        "only_light"
+      ]
+    },
+    "column-fill": {
+      "__values": [
+        "balance-all"
+      ]
+    },
     "column-progression": {},
-    "custom-property": {},
+    "contain": {
+      "__values": [
+        "style"
+      ]
+    },
+    "content": {
+      "__additional_values": {
+        "alt_text": "url(test.png) / 'This is the alt text'",
+        "url": "url(test.png)"
+      }
+    },
+    "counter-reset": {
+      "__additional_values": {
+        "reversed": "reversed(my-counter)"
+      }
+    },
+    "cursor": {
+      "__additional_values": {
+        "bidirectional_resize": [
+          "ew-resize",
+          "nesw-resize",
+          "ns-resize",
+          "nwse-resize"
+        ],
+        "unidirectional_resize": [
+          "n-resize",
+          "e-resize",
+          "s-resize",
+          "w-resize",
+          "ne-resize",
+          "nw-resize",
+          "se-resize",
+          "sw-resize"
+        ],
+        "url": "url(hand.cur), pointer",
+        "url_positioning_syntax": "url(cursor_1.png) 4 12, auto",
+        "zoom": [
+          "zoom-in",
+          "zoom-out"
+        ]
+      },
+      "__values": [
+        "-moz-grab",
+        "-moz-zoom",
+        "-webkit-grab",
+        "-webkit-zoom",
+        "alias",
+        "all-scroll",
+        "auto",
+        "cell",
+        "col-resize",
+        "context-menu",
+        "copy",
+        "crosshair",
+        "default",
+        "grab",
+        "help",
+        "inherit",
+        "move",
+        "no-drop",
+        "none",
+        "not-allowed",
+        "pointer",
+        "progress",
+        "row-resize",
+        "text",
+        "vertical-text",
+        "wait"
+      ]
+    },
+    "display": {
+      "__additional_values": {
+        "display-outside": [
+          "block",
+          "inline",
+          "run-in"
+        ],
+        "multi-keyword_values": "inline flow",
+        "ruby_values": [
+          "ruby",
+          "ruby-base",
+          "ruby-base-container",
+          "ruby-text",
+          "ruby-text-container"
+        ],
+        "table_values": [
+          "table",
+          "table-cell",
+          "table-column",
+          "table-column-group",
+          "table-footer-group",
+          "table-header-group",
+          "table-row",
+          "table-row-group"
+        ],
+        "xul_box_values": [
+          "-moz-box",
+          "-moz-inline-box"
+        ],
+        "xul_deck_values": "-moz-deck",
+        "xul_grid_values": [
+          "-moz-grid",
+          "-moz-grid-group",
+          "-moz-grid-line"
+        ],
+        "xul_inline_grid_stack": [
+          "-moz-inline-grid",
+          "-moz-inline-stack"
+        ],
+        "xul_popup_values": "-moz-popup",
+        "xul_stack_value": "-moz-stack"
+      },
+      "__values": [
+        "-ms-flexbox",
+        "-ms-grid",
+        "-ms-inline-flexbox",
+        "-ms-inline-grid",
+        "-webkit-flex",
+        "-webkit-inline-flex",
+        "contents",
+        "flex",
+        "flow-root",
+        "grid",
+        "inline-block",
+        "inline-flex",
+        "inline-grid",
+        "inline-table",
+        "list-item",
+        "none"
+      ]
+    },
     "enable-background": {},
+    "flex-basis": {
+      "__values": [
+        "-moz-fit-content",
+        "-moz-max-content",
+        "-moz-min-content",
+        "-webkit-auto",
+        "auto",
+        "content",
+        "fit-content",
+        "max-content",
+        "min-content"
+      ]
+    },
+    "float": {
+      "__additional_values": {
+        "flow_relative_values": [
+          "inline-end",
+          "inline-start"
+        ]
+      }
+    },
+    "font": {
+      "__additional_values": {
+        "font_stretch_support": "ultra-expanded 12px sans-serif",
+        "system_fonts": [
+          "caption",
+          "icon",
+          "menu",
+          "message-box",
+          "small-caption",
+          "status-bar"
+        ]
+      }
+    },
     "font-display": {},
+    "font-family": {
+      "__values": [
+        "-apple-system",
+        "system_ui"
+      ]
+    },
+    "font-size": {
+      "__additional_values": {
+        "rem_values": "10rem"
+      },
+      "__values": [
+        "xxx-large"
+      ]
+    },
+    "font-size-adjust": {
+      "__additional_values": {
+        "two-values": "ex-height 0.5"
+      }
+    },
     "font-smooth": {},
+    "font-stretch": {
+      "__additional_values": {
+        "percentage": "50%"
+      }
+    },
+    "font-style": {
+      "__additional_values": {
+        "oblique-angle": "oblique 10deg"
+      }
+    },
+    "font-synthesis": {
+      "__values": [
+        "small-caps"
+      ]
+    },
+    "font-variant": {
+      "__values": [
+        "historical-forms",
+        "sub",
+        "super"
+      ]
+    },
+    "font-variant-alternates": {
+      "__additional_values": {
+        "annotation": "annotation(user-defined-ident)",
+        "character_variant": "character-variant(user-defined-ident)",
+        "ornaments": "ornaments(user-defined-ident)",
+        "styleset": "styleset(user-defined-ident)",
+        "stylistic": "stylistic(user-defined-ident)",
+        "swash": "swash(user-defined-ident)"
+      }
+    },
+    "font-weight": {
+      "__additional_values": {
+        "number": "451"
+      }
+    },
     "glyph-orientation-horizontal": {},
+    "grid-template-columns": {
+      "__additional_values": {
+        "fit-content": "fit-content(40%)",
+        "minmax": "minmax(100px, 1fr)",
+        "repeat": "repeat(3, 200px)"
+      }
+    },
+    "grid-template-rows": {
+      "__additional_values": {
+        "fit-content": "fit-content(40%)",
+        "minmax": "minmax(100px, 1fr)",
+        "repeat": "repeat(3, 200px)"
+      }
+    },
+    "height": {
+      "__additional_values": {
+        "fit-content_function": "fit-content(10px)"
+      },
+      "__values": [
+        "-moz-max-content",
+        "-moz-min-content",
+        "-webkit-fill-available",
+        "-webkit-fit-content",
+        "fit-content",
+        "max-content",
+        "min-content",
+        "stretch"
+      ]
+    },
+    "image-orientation": {
+      "__additional_values": {
+        "flip_and_angle": "90deg flip"
+      }
+    },
+    "image-rendering": {
+      "__values": [
+        "-moz-crisp-edges",
+        "-webkit-optimize-contrast",
+        "crisp-edges",
+        "optimizeQuality",
+        "optimizeSpeed",
+        "pixelated",
+        "smooth"
+      ]
+    },
     "ime-mode": {},
+    "inline-size": {
+      "__additional_values": {
+        "fit-content_function": "fit-content(10px)"
+      },
+      "__values": [
+        "-moz-fit-content",
+        "-moz-max-content",
+        "-moz-min-content",
+        "-webkit-fill-available",
+        "fit-content",
+        "max-content",
+        "min-content"
+      ]
+    },
     "kerning": {},
     "layout-grid": {},
     "layout-grid-char": {},
     "layout-grid-line": {},
     "layout-grid-mode": {},
     "layout-grid-type": {},
+    "line-height": {
+      "__values": [
+        "-moz-block-height"
+      ]
+    },
+    "list-style": {
+      "__values": [
+        "symbols"
+      ]
+    },
+    "list-style-type": {
+      "__values": [
+        "-moz-arabic-indic",
+        "-moz-bengali",
+        "-moz-cjk-earthly-branch",
+        "-moz-cjk-heavenly-stem",
+        "-moz-devanagari",
+        "-moz-ethiopic-halehame",
+        "-moz-ethiopic-halehame-am",
+        "-moz-ethiopic-halehame-ti-er",
+        "-moz-ethiopic-halehame-ti-et",
+        "-moz-ethiopic-numeric",
+        "-moz-gujarati",
+        "-moz-gurmukhi",
+        "-moz-hangul",
+        "-moz-hangul-consonant",
+        "-moz-japanese-formal",
+        "-moz-japanese-informal",
+        "-moz-kannada",
+        "-moz-khmer",
+        "-moz-lao",
+        "-moz-malayalam",
+        "-moz-myanmar",
+        "-moz-oriya",
+        "-moz-persian",
+        "-moz-simp-chinese-formal",
+        "-moz-simp-chinese-informal",
+        "-moz-tamil",
+        "-moz-telugu",
+        "-moz-thai",
+        "-moz-trad-chinese-formal",
+        "-moz-trad-chinese-informal",
+        "-moz-urdu",
+        "afar",
+        "amharic",
+        "amharic-abegede",
+        "arabic-indic",
+        "armenian",
+        "asterisks",
+        "bengali",
+        "binary",
+        "cambodian",
+        "circle",
+        "cjk-decimal",
+        "cjk-earthly-branch",
+        "cjk-heavenly-stem",
+        "cjk-ideographic",
+        "decimal",
+        "decimal-leading-zero",
+        "devanagari",
+        "disc",
+        "disclosure-closed",
+        "disclosure-open",
+        "ethiopic",
+        "ethiopic-abegede",
+        "ethiopic-abegede-am-et",
+        "ethiopic-abegede-gez",
+        "ethiopic-abegede-ti-er",
+        "ethiopic-abegede-ti-et",
+        "ethiopic-halehame",
+        "ethiopic-halehame-aa-er",
+        "ethiopic-halehame-aa-et",
+        "ethiopic-halehame-am",
+        "ethiopic-halehame-am-et",
+        "ethiopic-halehame-gez",
+        "ethiopic-halehame-om-et",
+        "ethiopic-halehame-sid-et",
+        "ethiopic-halehame-so-et",
+        "ethiopic-halehame-ti-er",
+        "ethiopic-halehame-ti-et",
+        "ethiopic-halehame-tig",
+        "ethiopic-numeric",
+        "footnotes",
+        "georgian",
+        "gujarati",
+        "gurmukhi",
+        "hangul",
+        "hangul-consonant",
+        "hebrew",
+        "hiragana",
+        "hiragana-iroha",
+        "japanese-formal",
+        "japanese-informal",
+        "kannada",
+        "katakana",
+        "katakana-iroha",
+        "khmer",
+        "korean-hangul-formal",
+        "korean-hanja-formal",
+        "korean-hanja-informal",
+        "lao",
+        "lower-alpha",
+        "lower-armenian",
+        "lower-greek",
+        "lower-hexadecimal",
+        "lower-latin",
+        "lower-norwegian",
+        "lower-roman",
+        "malayalam",
+        "mongolian",
+        "myanmar",
+        "octal",
+        "oriya",
+        "oromo",
+        "persian",
+        "sidama",
+        "simp-chinese-formal",
+        "simp-chinese-informal",
+        "somali",
+        "square",
+        "string",
+        "symbols",
+        "tamil",
+        "telugu",
+        "thai",
+        "tibetan",
+        "tigre",
+        "tigrinya-er",
+        "tigrinya-er-abegede",
+        "tigrinya-et",
+        "tigrinya-et-abegede",
+        "trad-chinese-formal",
+        "trad-chinese-informal",
+        "upper-alpha",
+        "upper-armenian",
+        "upper-greek",
+        "upper-hexadecimal",
+        "upper-latin",
+        "upper-norwegian",
+        "upper-roman",
+        "urdu"
+      ]
+    },
+    "margin": {
+      "__values": [
+        "auto"
+      ]
+    },
+    "margin-bottom": {
+      "__values": [
+        "auto"
+      ]
+    },
+    "margin-left": {
+      "__values": [
+        "auto"
+      ]
+    },
+    "margin-right": {
+      "__values": [
+        "auto"
+      ]
+    },
+    "margin-top": {
+      "__values": [
+        "auto"
+      ]
+    },
     "marker-offset": {},
+    "mask-clip": {
+      "__values": [
+        "border",
+        "content",
+        "padding",
+        "text"
+      ]
+    },
+    "mask-image": {
+      "__additional_values": {
+        "multiple_mask_images": "image(url(mask.png), skyblue), linear-gradient(rgba(0, 0, 0, 1.0), transparent)"
+      }
+    },
+    "mask-origin": {
+      "__additional_values": {
+        "non_standard_values": [
+          "content",
+          "padding",
+          "border"
+        ]
+      },
+      "__values": [
+        "fill-box",
+        "stroke-box",
+        "view-box"
+      ]
+    },
+    "mask-position": {
+      "__additional_values": {
+        "three_value_syntax": "left top 15px"
+      }
+    },
     "mask-position-x": {},
     "mask-position-y": {},
     "masonry": {},
     "math-style": {},
+    "max-block-size": {
+      "__additional_values": {
+        "fit-content_function": "fit-content(10px)"
+      },
+      "__values": [
+        "-moz-max-content",
+        "-moz-min-content",
+        "-webkit-fill-available",
+        "fit-content",
+        "max-content",
+        "min-content"
+      ]
+    },
+    "max-height": {
+      "__additional_values": {
+        "fit-content_function": "fit-content(10px)"
+      },
+      "__values": [
+        "-moz-fit-content",
+        "-moz-max-content",
+        "-moz-min-content",
+        "-webkit-fill-available",
+        "-webkit-fit-content",
+        "-webkit-max-content",
+        "-webkit-min-content",
+        "fit-content",
+        "intrinsic",
+        "max-content",
+        "min-content",
+        "stretch"
+      ]
+    },
+    "max-inline-size": {
+      "__additional_values": {
+        "fit-content_function": "fit-content(10px)"
+      },
+      "__values": [
+        "-moz-fit-content",
+        "-moz-max-content",
+        "-moz-min-content",
+        "-webkit-fill-available",
+        "fit-content",
+        "max-content",
+        "min-content"
+      ]
+    },
+    "max-width": {
+      "__additional_values": {
+        "fit-content_function": "fit-content(10px)"
+      },
+      "__values": [
+        "-moz-fit-content",
+        "-moz-max-content",
+        "-moz-min-content",
+        "-webkit-fill-available",
+        "-webkit-fit-content",
+        "-webkit-max-content",
+        "-webkit-min-content",
+        "fit-content",
+        "intrinsic",
+        "max-content",
+        "min-content",
+        "stretch"
+      ]
+    },
     "max-zoom": {},
+    "min-block-size": {
+      "__additional_values": {
+        "fit-content_function": "fit-content(10px)"
+      },
+      "__values": [
+        "-moz-max-content",
+        "-moz-min-content",
+        "-webkit-fill-available",
+        "fit-content",
+        "max-content",
+        "min-content"
+      ]
+    },
+    "min-height": {
+      "__additional_values": {
+        "fit-content_function": "fit-content(10px)"
+      },
+      "__values": [
+        "-moz-fit-content",
+        "-moz-max-content",
+        "-moz-min-content",
+        "-webkit-fill-available",
+        "-webkit-fit-content",
+        "-webkit-max-content",
+        "-webkit-min-content",
+        "auto",
+        "fit-content",
+        "intrinsic",
+        "max-content",
+        "min-content",
+        "stretch"
+      ]
+    },
+    "min-inline-size": {
+      "__additional_values": {
+        "fit-content_function": "fit-content(10px)"
+      },
+      "__values": [
+        "-moz-fit-content",
+        "-moz-max-content",
+        "-moz-min-content",
+        "-webkit-fill-available",
+        "fit-content",
+        "max-content",
+        "min-content"
+      ]
+    },
+    "min-width": {
+      "__additional_values": {
+        "fit-content_function": "fit-content(10px)"
+      },
+      "__values": [
+        "-moz-fit-content",
+        "-moz-max-content",
+        "-moz-min-content",
+        "-webkit-fill-available",
+        "-webkit-fit-content",
+        "-webkit-max-content",
+        "-webkit-min-content",
+        "auto",
+        "fit-content",
+        "intrinsic",
+        "max-content",
+        "min-content",
+        "min-intrinsic",
+        "stretch"
+      ]
+    },
     "min-zoom": {},
     "motion": {},
     "motion-distance": {},
     "motion-offset": {},
     "motion-path": {},
     "motion-rotation": {},
+    "object-position": {
+      "__additional_values": {
+        "three_value_syntax": "left top 15px"
+      }
+    },
     "offset-block": {},
     "offset-block-end": {},
     "offset-block-start": {},
     "offset-inline": {},
     "offset-inline-end": {},
     "offset-inline-start": {},
+    "offset-path": {
+      "__additional_values": {
+        "path-support": "path('M20,20 L50,80 L80,20')",
+        "ray-support": "ray(45deg closest-side contain)"
+      }
+    },
     "offset-rotation": {},
+    "opacity": {
+      "__additional_values": {
+        "percentages": "50%"
+      }
+    },
     "orientation": {},
+    "outline-color": {
+      "__values": [
+        "invert"
+      ]
+    },
+    "outline-style": {
+      "__values": [
+        "auto"
+      ]
+    },
+    "overflow": {
+      "__additional_values": {
+        "multiple_keywords": "hidden visible"
+      },
+      "__values": [
+        "-moz-hidden-unscrollable",
+        "clip"
+      ]
+    },
     "overflow-clip-box": {},
     "overflow-clip-box-block": {},
     "overflow-clip-box-inline": {},
+    "overflow-wrap": {
+      "__values": [
+        "anywhere",
+        "break-word"
+      ]
+    },
+    "overflow-x": {
+      "__values": [
+        "-moz-hidden-unscrollable",
+        "clip"
+      ]
+    },
+    "overflow-y": {
+      "__values": [
+        "-moz-hidden-unscrollable",
+        "clip"
+      ]
+    },
     "page-orientation": {},
     "pen-action": {},
+    "perspective-origin": {
+      "__additional_values": {
+        "three_value_syntax": "left top 15px"
+      }
+    },
     "perspective-origin-x": {},
     "perspective-origin-y": {},
+    "position": {
+      "__values": [
+        "-webkit-sticky",
+        "fixed",
+        "sticky"
+      ]
+    },
+    "quotes": {
+      "__additional_values": {
+        "quotes_auto": "auto"
+      }
+    },
+    "resize": {
+      "__additional_values": {
+        "flow_relative_support": [
+          "block",
+          "inline"
+        ]
+      }
+    },
+    "rotate": {
+      "__additional_values": {
+        "x_y_z_angle": "x 90deg"
+      }
+    },
+    "ruby-position": {
+      "__values": [
+        "alternate",
+        "inter-character"
+      ]
+    },
     "scroll-snap-coordinate": {},
     "scroll-snap-destination": {},
     "scroll-snap-margin": {},
@@ -374,11 +1337,109 @@
     "scrollbar-highlight-color": {},
     "scrollbar-shadow-color": {},
     "scrollbar-track-color": {},
+    "shape-image-threshold": {
+      "__additional_values": {
+        "percentages": "50%"
+      }
+    },
+    "shape-outside": {
+      "__additional_values": {
+        "circle": "circle(50px at 0 100px)",
+        "gradient": "linear-gradient(45deg, rgba(255, 255, 255, 0) 150px, red 150px)",
+        "image": "url(test.png)",
+        "inset": "inset(10px 10px 10px 10px)",
+        "polygon": "polygon(10px 10px, 20px 20px, 30px 30px)",
+        "three_value_syntax": "left top 15px"
+      }
+    },
     "size": {},
+    "speak-as": {
+      "__values": [
+        "digits",
+        "literal-punctuation",
+        "no-punctuation",
+        "normal",
+        "spell-out"
+      ]
+    },
     "src": {},
     "supported-color-schemes": {},
+    "tab-size": {
+      "__additional_values": {
+        "length": "20px"
+      }
+    },
+    "text-align": {
+      "__additional_values": {
+        "block_alignment_values": [
+          "center",
+          "left",
+          "right"
+        ],
+        "flow_relative_values_start_and_end": [
+          "start",
+          "end"
+        ],
+        "string": "'.'"
+      },
+      "__values": [
+        "justify-all",
+        "match-parent"
+      ]
+    },
     "text-combine-horizontal": {},
+    "text-combine-upright": {
+      "__values": [
+        "digits"
+      ]
+    },
+    "text-decoration": {
+      "__additional_values": {
+        "text-decoration-thickness": "solid underline purple 4px"
+      },
+      "__values": [
+        "blink"
+      ]
+    },
+    "text-decoration-line": {
+      "__values": [
+        "blink"
+      ]
+    },
+    "text-decoration-skip-ink": {
+      "__values": [
+        "all"
+      ]
+    },
+    "text-decoration-style": {
+      "__values": [
+        "wavy"
+      ]
+    },
+    "text-decoration-thickness": {
+      "__additional_values": {
+        "percentage": "50%"
+      }
+    },
     "text-decoration-width": {},
+    "text-emphasis-position": {
+      "__additional_values": {
+        "left_and_right": [
+          "over left",
+          "over right"
+        ]
+      },
+      "__values": [
+        "over",
+        "under"
+      ]
+    },
+    "text-indent": {
+      "__values": [
+        "each-line",
+        "hanging"
+      ]
+    },
     "text-kashida": {},
     "text-kashida-space": {},
     "text-line-through": {},
@@ -386,23 +1447,239 @@
     "text-line-through-mode": {},
     "text-line-through-style": {},
     "text-line-through-width": {},
+    "text-orientation": {
+      "__values": [
+        "sideways"
+      ]
+    },
+    "text-overflow": {
+      "__additional_values": {
+        "fade_function": "fade(20px)",
+        "fade_value": "fade",
+        "string": " [...]",
+        "two_value_syntax": "clip ellipsis"
+      }
+    },
     "text-overline": {},
     "text-overline-color": {},
     "text-overline-mode": {},
     "text-overline-style": {},
     "text-overline-width": {},
+    "text-rendering": {
+      "__values": [
+        "auto",
+        "geometricPrecision"
+      ]
+    },
+    "text-size-adjust": {
+      "__additional_values": {
+        "percentages": "50%"
+      }
+    },
+    "text-transform": {
+      "__values": [
+        "capitalize",
+        "full-size-kana",
+        "full-width"
+      ]
+    },
     "text-underline": {},
     "text-underline-color": {},
     "text-underline-mode": {},
+    "text-underline-offset": {
+      "__additional_values": {
+        "percentage": "50%"
+      }
+    },
+    "text-underline-position": {
+      "__additional_values": {
+        "above_below": [
+          "above",
+          "below"
+        ],
+        "left_right": [
+          "left",
+          "right"
+        ]
+      },
+      "__values": [
+        "auto-pos",
+        "from-font",
+        "left",
+        "right",
+        "under"
+      ]
+    },
     "text-underline-style": {},
     "text-underline-width": {},
+    "touch-action": {
+      "__additional_values": {
+        "axis-pan": [
+          "pan-x",
+          "pan-y"
+        ],
+        "unidirectional-pan": [
+          "pan-up",
+          "pan-down",
+          "pan-left",
+          "pan-right"
+        ]
+      },
+      "__values": [
+        "double-tap-zoom",
+        "manipulation",
+        "none",
+        "pinch-zoom"
+      ]
+    },
+    "transform": {
+      "__additional_values": {
+        "3d": [
+          "scale3d(2.5, 1.2, 0.3)",
+          "rotate3d(1, 2.0, 3.0, 10deg)",
+          "translate3d(12px, 50%, 3em)"
+        ]
+      }
+    },
+    "transform-box": {
+      "__values": [
+        "border-box",
+        "content-box",
+        "stroke-box"
+      ]
+    },
+    "transform-origin": {
+      "__additional_values": {
+        "three_value_syntax": "left top 15px"
+      }
+    },
     "transform-origin-x": {},
     "transform-origin-y": {},
     "transform-origin-z": {},
+    "transition": {
+      "__values": [
+        "gradients"
+      ]
+    },
+    "transition-property": {
+      "__values": [
+        "IDENT_value"
+      ]
+    },
+    "transition-timing-function": {
+      "__additional_values": {
+        "jump": "steps(5, jump-both)"
+      }
+    },
+    "unicode-bidi": {
+      "__values": [
+        "-moz-isolate",
+        "-moz-isolate-override",
+        "-moz-plaintext",
+        "-webkit-isolate",
+        "-webkit-isolate-override",
+        "-webkit-plaintext",
+        "isolate",
+        "isolate-override",
+        "plaintext"
+      ]
+    },
     "unicode-range": {},
-    "user-modify": {},
+    "user-modify": {
+      "__values": [
+        "read-write-plaintext-only"
+      ]
+    },
+    "user-select": {
+      "__values": [
+        "-moz-none",
+        "all",
+        "auto",
+        "contain",
+        "element",
+        "none",
+        "text"
+      ]
+    },
     "user-zoom": {},
     "viewport-fit": {},
-    "zoom": {}
+    "visibility": {
+      "__values": [
+        "collapse"
+      ]
+    },
+    "white-space": {
+      "__values": [
+        "-moz-pre-wrap",
+        "break-spaces",
+        "nowrap",
+        "pre",
+        "pre-line",
+        "pre-wrap"
+      ]
+    },
+    "width": {
+      "__additional_values": {
+        "fit-content_function": "fit-content(10px)"
+      },
+      "__values": [
+        "-moz-available",
+        "-moz-fit-content",
+        "-moz-max-content",
+        "-moz-min-content",
+        "-webkit-fill-available",
+        "-webkit-fit-content",
+        "-webkit-max-content",
+        "fill",
+        "fit-content",
+        "intrinsic",
+        "max-content",
+        "min-content",
+        "min-intrinsic",
+        "stretch"
+      ]
+    },
+    "word-break": {
+      "__values": [
+        "break-word",
+        "keep-all"
+      ]
+    },
+    "word-spacing": {
+      "__additional_values": {
+        "percentages": "50%"
+      }
+    },
+    "writing-mode": {
+      "__additional_values": {
+        "horizontal_vertical_values": [
+          "horizontal-tb",
+          "vertical-lr",
+          "vertical-rl"
+        ],
+        "sideways_values": [
+          "sideways-lr",
+          "sideways-rl"
+        ],
+        "svg_values": [
+          "lr",
+          "lr-tb",
+          "rl",
+          "rl-tb",
+          "tb",
+          "tb-rl"
+        ]
+      }
+    },
+    "z-index": {
+      "__additional_values": {
+        "negative_values": "-451"
+      }
+    },
+    "zoom": {
+      "__values": [
+        "reset"
+      ]
+    }
   }
 }

--- a/static/resources/harness.js
+++ b/static/resources/harness.js
@@ -205,6 +205,58 @@
     };
   }
 
+  function cssPropertyToIDLAttribute(property, lowercaseFirst) {
+    var output = '';
+    var uppercaseNext = false;
+
+    if (lowercaseFirst) {
+      property = property.substr(1);
+    }
+
+    for (var i = 0; i < property.length; i++) {
+      var c = property[i];
+
+      if (c === '-') {
+        uppercaseNext = true;
+      } else if (uppercaseNext) {
+        uppercaseNext = false;
+        output += c.toUpperCase();
+      } else {
+        output += c;
+      }
+    }
+
+    return output;
+  }
+
+  function testCSSProperty(name) {
+    if ("CSS" in window && window.CSS.supports) {
+      return window.CSS.supports(name, "inherit");
+    }
+
+    var attrs = [name];
+    attrs.push(cssPropertyToIDLAttribute(name, name.startsWith('-')));
+    for (var i = 0; i < attrs.length; i++) {
+      var attr = attrs[i];
+      if (attr in document.body.style) {
+        return true;
+      }
+    }
+
+    return false;
+  }
+
+  function testCSSPropertyValue(name, value) {
+    if ("CSS" in window && window.CSS.supports) {
+      return window.CSS.supports(name, value);
+    }
+
+    var div = document.createElement('div');
+    div.style[name] = "";
+    div.style[name] = value;
+    return div.style.getPropertyValue(name) !== "";
+  }
+
   // Once a test is evaluated and run, it calls this function with the result.
   // This function then compiles a result object from the given result value,
   // and then passes the result to `callback()` (or if the result is not true
@@ -937,6 +989,8 @@
   global.bcd = {
     testConstructor: testConstructor,
     testObjectName: testObjectName,
+    testCSSProperty: testCSSProperty,
+    testCSSPropertyValue: testCSSPropertyValue,
     addInstance: addInstance,
     addTest: addTest,
     runTests: runTests,

--- a/unittest/unit/build.js
+++ b/unittest/unit/build.js
@@ -1325,25 +1325,43 @@ describe('build', () => {
 
     const customCSS = {
       properties: {
+        'font-family': {
+          __values: ['emoji', 'system-ui'],
+          __additional_values: {
+            historic: ['sans-serif', 'serif']
+          }
+        },
         zoom: {}
       }
     };
 
     assert.deepEqual(buildCSS(webrefCSS, customCSS), {
       'css.properties.font-family': {
-        code: '"fontFamily" in document.body.style || "font-family" in document.body.style',
+        code: 'bcd.testCSSProperty("font-family")',
+        exposure: ['Window']
+      },
+      'css.properties.font-family.emoji': {
+        code: 'bcd.testCSSPropertyValue("font-family", "emoji")',
+        exposure: ['Window']
+      },
+      'css.properties.font-family.historic': {
+        code: 'bcd.testCSSPropertyValue("font-family", "sans-serif") || bcd.testCSSPropertyValue("font-family", "serif")',
+        exposure: ['Window']
+      },
+      'css.properties.font-family.system-ui': {
+        code: 'bcd.testCSSPropertyValue("font-family", "system-ui")',
         exposure: ['Window']
       },
       'css.properties.font-weight': {
-        code: '"fontWeight" in document.body.style || "font-weight" in document.body.style',
+        code: 'bcd.testCSSProperty("font-weight")',
         exposure: ['Window']
       },
       'css.properties.grid': {
-        code: '"grid" in document.body.style',
+        code: 'bcd.testCSSProperty("grid")',
         exposure: ['Window']
       },
       'css.properties.zoom': {
-        code: '"zoom" in document.body.style',
+        code: 'bcd.testCSSProperty("zoom")',
         exposure: ['Window']
       }
     });


### PR DESCRIPTION
This also adds a lot of the more easily found values that either differ between {Chrome, Firefox, Safari} _or_ where entries already exist in BCD for them.

This almost certainly isn't quite what we want, but it's a starting point. Notably this produces significant changes to BCD data, as (unsurprisingly) plenty of this data is outdated.

Fixes #705, based on @foolip's earlier experience with #1221.