### PR TITLE
Fix find-missing-results

### DIFF
--- a/find-missing-results.js
+++ b/find-missing-results.js
@@ -46,12 +46,12 @@ const generateReportMap = (allResults) => {
       if (browserKey == 'ie') {
         // Ignore super old IE releases
         result[browserKey] = result[browserKey].filter((v) =>
-          compareVersions.compare(v, '6', '>')
+          compareVersions.compare(v, '6', '>=')
         );
       } else if (browserKey == 'safari') {
         // Ignore super old Safari releases
         result[browserKey] = result[browserKey].filter((v) =>
-          compareVersions.compare(v, '4', '>')
+          compareVersions.compare(v, '4', '>=')
         );
       } else if (browserKey == 'opera') {
         // Ignore all Opera versions besides 12.1, 15, and the latest stable

--- a/find-missing-results.js
+++ b/find-missing-results.js
@@ -45,12 +45,10 @@ const generateReportMap = (allResults) => {
     if (!allResults) {
       if (browserKey == 'ie') {
         // Ignore super old IE releases
-        result[browserKey] = result[browserKey].filter((v) => v >= '6');
+        result[browserKey] = result[browserKey].filter((v) => v >= 6);
       } else if (browserKey == 'safari') {
-        // Ignore super old Safari releases, and Safari 6.1
-        result[browserKey] = result[browserKey].filter(
-          (v) => v >= '4' && v != '6.1'
-        );
+        // Ignore super old Safari releases
+        result[browserKey] = result[browserKey].filter((v) => v >= 4);
       } else if (browserKey == 'opera') {
         // Ignore all Opera versions besides 12.1, 15, and the latest stable
         result[browserKey] = result[browserKey].filter(

--- a/find-missing-results.js
+++ b/find-missing-results.js
@@ -45,10 +45,14 @@ const generateReportMap = (allResults) => {
     if (!allResults) {
       if (browserKey == 'ie') {
         // Ignore super old IE releases
-        result[browserKey] = result[browserKey].filter((v) => v >= 6);
+        result[browserKey] = result[browserKey].filter((v) =>
+          compareVersions.compare(v, '6', '>')
+        );
       } else if (browserKey == 'safari') {
         // Ignore super old Safari releases
-        result[browserKey] = result[browserKey].filter((v) => v >= 4);
+        result[browserKey] = result[browserKey].filter((v) =>
+          compareVersions.compare(v, '4', '>')
+        );
       } else if (browserKey == 'opera') {
         // Ignore all Opera versions besides 12.1, 15, and the latest stable
         result[browserKey] = result[browserKey].filter(


### PR DESCRIPTION
This PR fixes the find-missing-results script.  Apparently, when performing `'15' > '4'`, the strings are not converted to numbers during comparison, but rather compared lexicographically.  This PR fixes that by replacing one of the sides of the comparison with an integer, so that IE 10 and 11 are included in the list, as well as Safari 10 or higher.

Additionally, this removes the clause to exclude Safari 6.1, since BCD no longer has 6.1 in its data.
