### PR TITLE
Remove mitigation of Firefox 3.6.17 UA parsing bug

### DIFF
--- a/ua-parser.js
+++ b/ua-parser.js
@@ -9,9 +9,7 @@ const getMajorMinorVersion = (version) => {
 };
 
 const parseUA = (userAgent, browsers) => {
-  // XXX Removal of .NET is for Firefox 3.6.17 on BrowserStack
-  // See https://github.com/faisalman/ua-parser-js/issues/461
-  const ua = uaParser(userAgent.replace(' (.NET CLR 3.5.21022)', ''));
+  const ua = uaParser(userAgent);
   const data = {
     browser: {id: null, name: null},
     version: null,


### PR DESCRIPTION
This bug was fixed upstream, so our mitigation is no longer needed.
