### PR TITLE
Set to production by default if NODE_ENV = production

### DIFF
--- a/app.js
+++ b/app.js
@@ -40,7 +40,7 @@ const storage = getStorage();
 
 /* c8 ignore start */
 const appVersion =
-  process.env.NODE_ENV === 'production' && process.env.GAE_VERSION !== 'staging' ?
+  process.env.NODE_ENV === 'production' ?
     (await fs.readJson(new URL('./package.json', import.meta.url))).version :
     'Dev';
 

--- a/app.js
+++ b/app.js
@@ -40,7 +40,7 @@ const storage = getStorage();
 
 /* c8 ignore start */
 const appVersion =
-  process.env.GAE_VERSION === 'production' ?
+  process.env.NODE_ENV === 'production' && process.env.GAE_VERSION !== 'staging' ?
     (await fs.readJson(new URL('./package.json', import.meta.url))).version :
     'Dev';
 


### PR DESCRIPTION
This PR reverses the preference of staging vs. production when `NODE_ENV` is production.  Currently, the website is only in production mode when the `GAE_VERSION` is set to `production`.  However, this essentially means that with our current code, we can only launch a production deployment on Google App Engine.  This PR reverses the preference, so that production is the default when `NODE_ENV` is `production`. ~~, and staging deployment is on when `GAE_VERSION` is `staging`.~~

~~@foolip, can you confirm the staging version has `GAE_VERSION=staging`?~~

Edit: since the staging version was removed from GAE, this PR has now been adjusted so that it is only based upon `NODE_ENV` and has no logic for `GAE_VERSION`.
