### PR TITLE
Don't set BCD to false if BCD has version number greater than our data

### DIFF
--- a/unittest/unit/bcd.test.js
+++ b/unittest/unit/bcd.test.js
@@ -76,6 +76,9 @@ export default {
     },
     RemovedInterface: {
       __compat: {support: {chrome: {version_added: null}}}
+    },
+    SuperNewInterface: {
+      __compat: {support: {chrome: {version_added: '100'}}}
     }
   },
   browsers: {

--- a/unittest/unit/find-missing-features.js
+++ b/unittest/unit/find-missing-features.js
@@ -40,6 +40,7 @@ describe('find-missing-features', () => {
         'api.ExperimentalInterface',
         'api.NullAPI',
         'api.RemovedInterface',
+        'api.SuperNewInterface',
         'css.properties.font-family',
         'css.properties.font-face',
         'javascript.builtins.Array',
@@ -64,6 +65,7 @@ describe('find-missing-features', () => {
         'api.TryingOutInterface',
         'api.NullAPI',
         'api.RemovedInterface',
+        'api.SuperNewInterface',
         'css.properties.font-family',
         'css.properties.font-face',
         'javascript.builtins.Array',
@@ -91,10 +93,11 @@ describe('find-missing-features', () => {
           'api.ExperimentalInterface',
           'api.NullAPI',
           'api.RemovedInterface',
+          'api.SuperNewInterface',
           'css.properties.font-face',
           'javascript.builtins.Date'
         ],
-        total: 17
+        total: 18
       });
     });
 
@@ -118,9 +121,10 @@ describe('find-missing-features', () => {
           'api.DummyAPI.dummy',
           'api.ExperimentalInterface',
           'api.NullAPI',
-          'api.RemovedInterface'
+          'api.RemovedInterface',
+          'api.SuperNewInterface'
         ],
-        total: 13
+        total: 14
       });
     });
 
@@ -138,10 +142,11 @@ describe('find-missing-features', () => {
           'api.ExperimentalInterface',
           'api.NullAPI',
           'api.RemovedInterface',
+          'api.SuperNewInterface',
           'css.properties.font-face',
           'javascript.builtins.Date'
         ],
-        total: 17
+        total: 18
       });
 
       assert.isTrue(

--- a/unittest/unit/update-bcd.js
+++ b/unittest/unit/update-bcd.js
@@ -84,6 +84,11 @@ const reports = [
           result: true
         },
         {
+          name: 'api.SuperNewInterface',
+          info: {exposure: 'Window'},
+          result: false
+        },
+        {
           name: 'css.properties.font-family',
           info: {exposure: 'Window'},
           result: true
@@ -159,6 +164,11 @@ const reports = [
           result: false
         },
         {
+          name: 'api.SuperNewInterface',
+          info: {exposure: 'Window'},
+          result: false
+        },
+        {
           name: 'css.properties.font-family',
           info: {exposure: 'Window'},
           result: true
@@ -226,6 +236,11 @@ const reports = [
           name: 'api.RemovedInterface',
           info: {exposure: 'Window'},
           result: true
+        },
+        {
+          name: 'api.SuperNewInterface',
+          info: {exposure: 'Window'},
+          result: false
         },
         {
           name: 'css.properties.font-family',
@@ -331,6 +346,7 @@ describe('BCD updater', () => {
           ['api.ExperimentalInterface', true],
           ['api.NullAPI', null],
           ['api.RemovedInterface', true],
+          ['api.SuperNewInterface', false],
           ['css.properties.font-family', true],
           ['css.properties.font-face', true]
         ])
@@ -351,6 +367,7 @@ describe('BCD updater', () => {
           ['api.NewInterfaceNotInBCD', false],
           ['api.NullAPI', null],
           ['api.RemovedInterface', false],
+          ['api.SuperNewInterface', false],
           ['css.properties.font-family', true],
           ['css.properties.font-face', true]
         ])
@@ -522,6 +539,20 @@ describe('BCD updater', () => {
             ])
           ],
           [
+            'api.SuperNewInterface',
+            new Map([
+              [
+                'chrome',
+                new Map([
+                  ['82', null],
+                  ['83', false],
+                  ['84', false],
+                  ['85', false]
+                ])
+              ]
+            ])
+          ],
+          [
             'css.properties.font-family',
             new Map([
               [
@@ -595,6 +626,9 @@ describe('BCD updater', () => {
           {version_added: '0> ≤83', version_removed: '84'},
           {version_added: '85'}
         ]
+      },
+      'api.SuperNewInterface': {
+        chrome: [{version_added: false}]
       },
       'css.properties.font-family': {chrome: [{version_added: '84'}]},
       'css.properties.font-face': {chrome: []}
@@ -739,6 +773,9 @@ describe('BCD updater', () => {
             //   {version_added: '≤83', version_removed: '84'}
             // ]}}
             __compat: {support: {chrome: {version_added: null}}}
+          },
+          SuperNewInterface: {
+            __compat: {support: {chrome: {version_added: '100'}}}
           }
         },
         browsers: {

--- a/update-bcd.js
+++ b/update-bcd.js
@@ -317,6 +317,29 @@ const update = (bcd, supportMatrix, filter) => {
       }
 
       if (
+        inferredStatement.version_added === false &&
+        typeof simpleStatement.version_added === 'string'
+      ) {
+        // Make sure not to update BCD if it is set to a version newer than we have in our data
+
+        for (const [version, result] of Array.from(
+          versionMap.entries()
+        ).reverse()) {
+          if (
+            result !== null &&
+            compareVersions.compare(
+              version,
+              simpleStatement.version_added.replace('≤', ''),
+              '<='
+            )
+          ) {
+            // A version we have data for is the same or newer than the version in BCD
+            return false;
+          }
+        }
+      }
+
+      if (
         typeof simpleStatement.version_added === 'string' &&
         typeof inferredStatement.version_added === 'string' &&
         inferredStatement.version_added.includes('≤')

--- a/update-bcd.js
+++ b/update-bcd.js
@@ -316,6 +316,7 @@ const update = (bcd, supportMatrix, filter) => {
         continue;
       }
 
+      let dataIsOlder = false;
       if (
         inferredStatement.version_added === false &&
         typeof simpleStatement.version_added === 'string'
@@ -334,12 +335,15 @@ const update = (bcd, supportMatrix, filter) => {
             )
           ) {
             // A version we have data for is the same or newer than the version in BCD
-            return false;
+            dataIsOlder = true;
+            break;
           }
         }
       }
 
-      if (
+      if (dataIsOlder) {
+        continue;
+      } else if (
         typeof simpleStatement.version_added === 'string' &&
         typeof inferredStatement.version_added === 'string' &&
         inferredStatement.version_added.includes('≤')


### PR DESCRIPTION
This PR updates the `update-bcd` to ensure that the script won't replace a version with `false` if the version number is newer than the data we have.  For example, if BCD's version is set to "17", but we only have results up to "16" and "false" is inferred, BCD will remain set to "17".  Fixes #659.
