### PR TITLE
Fix regex to catch reusableInstances in tests

### DIFF
--- a/static/resources/harness.js
+++ b/static/resources/harness.js
@@ -805,7 +805,7 @@
 
       // Display the code that creates the reusable instance in results
       var reusedInstances = result.info.code.match(
-        /reusableInstances\.([^.);]*)/g
+        /reusableInstances\.([^.());]*)/g
       );
       var addedInstances = [];
 


### PR DESCRIPTION
This PR tweaks the regex used to get which reusable instances were reused in hte custom test.  This should fix the code display in `api.CSSConditionRule`.
