### PR TITLE
Use 'git describe' to generate version number for dev version

### DIFF
--- a/app.js
+++ b/app.js
@@ -35,6 +35,7 @@ import parseResults from './results.js';
 import {getStorage} from './storage.js';
 import {parseUA} from './ua-parser.js';
 import Tests from './tests.js';
+import {exec} from './scripts.js';
 
 const storage = getStorage();
 
@@ -42,7 +43,7 @@ const storage = getStorage();
 const appVersion =
   process.env.NODE_ENV === 'production' ?
     (await fs.readJson(new URL('./package.json', import.meta.url))).version :
-    'Dev';
+    'Dev-' + String(exec('git describe --tags')).substr(1);
 
 const secrets = await fs.readJson(
   new URL(

--- a/app.js
+++ b/app.js
@@ -40,18 +40,22 @@ import {exec} from './scripts.js';
 const storage = getStorage();
 
 /* c8 ignore start */
-let appVersion;
-if (process.env.NODE_ENV === 'production') {
-  appVersion = (await fs.readJson(new URL('./package.json', import.meta.url)))
+const getAppVersion = () => {
+  let version = (await fs.readJson(new URL('./package.json', import.meta.url)))
     .version;
-} else {
-  try {
-    appVersion = 'Dev-' + String(exec('git describe --tags')).substr(1);
-  } catch (e) {
-    // If anything happens, i.e. git isn't installed, ignore
-    appVersion = 'Dev';
+  if (process.env.NODE_ENV === 'production') {
+    return version;
+  } else {
+    try {
+      return 'Dev-' + String(exec('git describe --tags')).substr(1);
+    } catch (e) {
+      // If anything happens, i.e. git isn't installed, ignore
+      return 'Dev-' + version;
+    }
   }
-}
+};
+
+const appVersion = getAppVersion();
 
 const secrets = await fs.readJson(
   new URL(

--- a/app.js
+++ b/app.js
@@ -49,7 +49,7 @@ const getAppVersion = async () => {
   }
 
   try {
-    return 'Dev-' + String(exec('git describe --tags')).substr(1);
+    return 'Dev-' + String(exec('git describe --tags')).replace(/^v/, '');
   } catch (e) {
     // If anything happens, i.e. git isn't installed, ignore
     return 'Dev-' + version;

--- a/app.js
+++ b/app.js
@@ -40,10 +40,18 @@ import {exec} from './scripts.js';
 const storage = getStorage();
 
 /* c8 ignore start */
-const appVersion =
-  process.env.NODE_ENV === 'production' ?
-    (await fs.readJson(new URL('./package.json', import.meta.url))).version :
-    'Dev-' + String(exec('git describe --tags')).substr(1);
+let appVersion;
+if (process.env.NODE_ENV === 'production') {
+  appVersion = (await fs.readJson(new URL('./package.json', import.meta.url)))
+    .version;
+} else {
+  try {
+    appVersion = 'Dev-' + String(exec('git describe --tags')).substr(1);
+  } catch (e) {
+    // If anything happens, i.e. git isn't installed, ignore
+    appVersion = 'Dev';
+  }
+}
 
 const secrets = await fs.readJson(
   new URL(

--- a/app.js
+++ b/app.js
@@ -49,10 +49,11 @@ const getAppVersion = async () => {
   }
 
   try {
-    return 'Dev-' + String(exec('git describe --tags')).replace(/^v/, '');
+    return String(exec('git describe --tags')).replace(/^v/, '');
   } catch (e) {
-    // If anything happens, i.e. git isn't installed, ignore
-    return 'Dev-' + version;
+    // If anything happens, e.g., git isn't installed, just use the version
+    // from package.json with -dev appended.
+    return `${version}-dev`;
   }
 };
 

--- a/app.js
+++ b/app.js
@@ -40,22 +40,23 @@ import {exec} from './scripts.js';
 const storage = getStorage();
 
 /* c8 ignore start */
-const getAppVersion = () => {
-  let version = (await fs.readJson(new URL('./package.json', import.meta.url)))
-    .version;
+const getAppVersion = async () => {
+  const version = (
+    await fs.readJson(new URL('./package.json', import.meta.url))
+  ).version;
   if (process.env.NODE_ENV === 'production') {
     return version;
-  } else {
-    try {
-      return 'Dev-' + String(exec('git describe --tags')).substr(1);
-    } catch (e) {
-      // If anything happens, i.e. git isn't installed, ignore
-      return 'Dev-' + version;
-    }
+  }
+
+  try {
+    return 'Dev-' + String(exec('git describe --tags')).substr(1);
+  } catch (e) {
+    // If anything happens, i.e. git isn't installed, ignore
+    return 'Dev-' + version;
   }
 };
 
-const appVersion = getAppVersion();
+const appVersion = await getAppVersion();
 
 const secrets = await fs.readJson(
   new URL(

--- a/exporter.js
+++ b/exporter.js
@@ -73,7 +73,7 @@ const createBody = (meta) => {
     }` +
     `\nHash Digest: ${meta.digest}` +
     `\nTest URLs: ${meta.urls.join(', ')}` +
-    (meta.version == 'Dev' ?
+    (meta.version.startsWith('Dev') ?
       '\n\n**WARNING:** this PR was created from a development/staging version!' :
       '')
   );

--- a/exporter.js
+++ b/exporter.js
@@ -73,7 +73,7 @@ const createBody = (meta) => {
     }` +
     `\nHash Digest: ${meta.digest}` +
     `\nTest URLs: ${meta.urls.join(', ')}` +
-    (meta.version.includes('Dev') ?
+    (meta.version.includes('-') ?
       '\n\n**WARNING:** this PR was created from a development/staging version!' :
       '')
   );

--- a/exporter.js
+++ b/exporter.js
@@ -73,7 +73,7 @@ const createBody = (meta) => {
     }` +
     `\nHash Digest: ${meta.digest}` +
     `\nTest URLs: ${meta.urls.join(', ')}` +
-    (meta.version.startsWith('Dev') ?
+    (meta.version.includes('Dev') ?
       '\n\n**WARNING:** this PR was created from a development/staging version!' :
       '')
   );

--- a/unittest/unit/exporter.js
+++ b/unittest/unit/exporter.js
@@ -39,20 +39,20 @@ const REPORTS = [
   },
   {
     report: {
-      __version: 'Dev',
+      __version: '1.2.3-dev',
       results: {},
       userAgent:
         'Mozilla/5.0 (Macintosh; Intel Mac OS X 11_0_0) AppleWebKit/537.36 (KHTML, like Gecko) Chrome/86.0.4240.198 Safari/537.36'
     },
     expected: {
-      slug: 'dev-chrome-86.0.4240.198-mac-os-11.0.0-31072b9b56',
-      title: 'Results from Chrome 86 / Mac OS 11.0.0 / Collector vDev',
-      body: 'User Agent: Mozilla/5.0 (Macintosh; Intel Mac OS X 11_0_0) AppleWebKit/537.36 (KHTML, like Gecko) Chrome/86.0.4240.198 Safari/537.36\nBrowser: Chrome 86 (on Mac OS 11.0.0)\nHash Digest: 31072b9b56\nTest URLs: \n\n**WARNING:** this PR was created from a development/staging version!'
+      slug: '1.2.3-dev-chrome-86.0.4240.198-mac-os-11.0.0-32f70f2e14',
+      title: 'Results from Chrome 86 / Mac OS 11.0.0 / Collector v1.2.3-dev',
+      body: 'User Agent: Mozilla/5.0 (Macintosh; Intel Mac OS X 11_0_0) AppleWebKit/537.36 (KHTML, like Gecko) Chrome/86.0.4240.198 Safari/537.36\nBrowser: Chrome 86 (on Mac OS 11.0.0)\nHash Digest: 32f70f2e14\nTest URLs: \n\n**WARNING:** this PR was created from a development/staging version!'
     }
   },
   {
     report: {
-      __version: 'Dev',
+      __version: '1.2.3',
       results: {
         'https://mdn-bcd-collector.appspot.com/tests/': {}
       },
@@ -60,14 +60,14 @@ const REPORTS = [
         'Mozilla/5.0 (Linux; Android 11; Pixel 2) AppleWebKit/537.36 (KHTML, like Gecko) SamsungBrowser/12.1 Chrome/79.0.3945.136 Mobile Safari/537.36'
     },
     expected: {
-      slug: 'dev-samsunginternet-android-12.1-android-11-e688b80286',
-      title: 'Results from Samsung Internet 12.1 / Android 11 / Collector vDev',
-      body: 'User Agent: Mozilla/5.0 (Linux; Android 11; Pixel 2) AppleWebKit/537.36 (KHTML, like Gecko) SamsungBrowser/12.1 Chrome/79.0.3945.136 Mobile Safari/537.36\nBrowser: Samsung Internet 12.1 (on Android 11)\nHash Digest: e688b80286\nTest URLs: https://mdn-bcd-collector.appspot.com/tests/\n\n**WARNING:** this PR was created from a development/staging version!'
+      slug: '1.2.3-samsunginternet-android-12.1-android-11-a3a2bf6696',
+      title: 'Results from Samsung Internet 12.1 / Android 11 / Collector v1.2.3',
+      body: 'User Agent: Mozilla/5.0 (Linux; Android 11; Pixel 2) AppleWebKit/537.36 (KHTML, like Gecko) SamsungBrowser/12.1 Chrome/79.0.3945.136 Mobile Safari/537.36\nBrowser: Samsung Internet 12.1 (on Android 11)\nHash Digest: a3a2bf6696\nTest URLs: https://mdn-bcd-collector.appspot.com/tests/'
     }
   },
   {
     report: {
-      __version: 'Dev',
+      __version: '1.2.3',
       results: {
         'https://mdn-bcd-collector.appspot.com/tests/?exposure=Window': {},
         'https://mdn-bcd-collector.appspot.com/tests/?exposure=Worker': {}
@@ -76,9 +76,9 @@ const REPORTS = [
         'Mozilla/5.0 (Macintosh; Intel Mac OS X 11_0_0) AppleWebKit/537.36 (KHTML, like Gecko) Chrome/800.0.1.2 Safari/537.36'
     },
     expected: {
-      slug: 'dev-chrome-800.0.1.2-mac-os-11.0.0-79a7b52d99',
-      title: 'Results from Chrome 800.0 / Mac OS 11.0.0 / Collector vDev',
-      body: 'User Agent: Mozilla/5.0 (Macintosh; Intel Mac OS X 11_0_0) AppleWebKit/537.36 (KHTML, like Gecko) Chrome/800.0.1.2 Safari/537.36\nBrowser: Chrome 800.0 (on Mac OS 11.0.0) - **Not in BCD**\nHash Digest: 79a7b52d99\nTest URLs: https://mdn-bcd-collector.appspot.com/tests/?exposure=Window, https://mdn-bcd-collector.appspot.com/tests/?exposure=Worker\n\n**WARNING:** this PR was created from a development/staging version!'
+      slug: '1.2.3-chrome-800.0.1.2-mac-os-11.0.0-bd85ffd312',
+      title: 'Results from Chrome 800.0 / Mac OS 11.0.0 / Collector v1.2.3',
+      body: 'User Agent: Mozilla/5.0 (Macintosh; Intel Mac OS X 11_0_0) AppleWebKit/537.36 (KHTML, like Gecko) Chrome/800.0.1.2 Safari/537.36\nBrowser: Chrome 800.0 (on Mac OS 11.0.0) - **Not in BCD**\nHash Digest: bd85ffd312\nTest URLs: https://mdn-bcd-collector.appspot.com/tests/?exposure=Window, https://mdn-bcd-collector.appspot.com/tests/?exposure=Worker'
     }
   }
 ];
@@ -86,7 +86,7 @@ const REPORTS = [
 describe('GitHub export', () => {
   const octokit = new Octokit();
 
-  describe('happy path', async () => {
+  describe('happy path', () => {
     // eslint-disable-next-line guard-for-in
     for (const i in REPORTS) {
       it(`Report #${Number(i) + 1}`, async () => {


### PR DESCRIPTION
This PR updates the app to use `git describe` to create a version number for the development version.
