### PR TITLE
Use a single storage bucket with app version as path prefix

### DIFF
--- a/app.js
+++ b/app.js
@@ -37,8 +37,6 @@ import {parseUA} from './ua-parser.js';
 import Tests from './tests.js';
 import {exec} from './scripts.js';
 
-const storage = getStorage();
-
 /* c8 ignore start */
 const getAppVersion = async () => {
   const version = (
@@ -68,6 +66,8 @@ const secrets = await fs.readJson(
   )
 );
 /* c8 ignore stop */
+
+const storage = getStorage(appVersion);
 
 const tests = new Tests({
   tests: await fs.readJson(new URL('./tests.json', import.meta.url)),

--- a/app.yaml
+++ b/app.yaml
@@ -15,4 +15,3 @@
 runtime: nodejs16
 env_variables:
   GCLOUD_STORAGE_BUCKET: mdn-bcd-buffer
-  GCLOUD_STORAGE_BUCKET_STAGING: mdn-bcd-buffer-staging

--- a/storage.js
+++ b/storage.js
@@ -19,14 +19,17 @@ import fs from 'fs-extra';
 import {Storage} from '@google-cloud/storage';
 
 class CloudStorage {
-  constructor(projectId, bucketName) {
+  constructor(projectId, bucketName, appVersion) {
     const storage = new Storage({projectId});
     this._bucket = storage.bucket(bucketName);
+    // appVersion is used as a prefix for all paths, so that multiple
+    // deployments can use the same bucket without risk of collision.
+    this._version = appVersion;
   }
 
   async put(sessionId, key, value) {
     assert(sessionId.length > 0);
-    const name = `${sessionId}/${encodeURIComponent(key)}`;
+    const name = `${this._version}/sessions/${sessionId}/${encodeURIComponent(key)}`;
     const file = this._bucket.file(name);
     const data = JSON.stringify(value);
     await file.save(data);
@@ -34,7 +37,7 @@ class CloudStorage {
 
   async getAll(sessionId) {
     assert(sessionId.length > 0);
-    const prefix = `${sessionId}/`;
+    const prefix = `${this._version}/sessions/${sessionId}/`;
     const files = (await this._bucket.getFiles({prefix}))[0];
     const result = {};
     await Promise.all(
@@ -50,14 +53,14 @@ class CloudStorage {
 
   async saveFile(filename, data) {
     assert(!filename.includes('..'));
-    const name = `files/${filename}`;
+    const name = `${this._version}/files/${filename}`;
     const file = this._bucket.file(name);
     await file.save(data);
   }
 
   async readFile(filename) {
     assert(!filename.includes('..'));
-    const name = `files/${filename}`;
+    const name = `${this._version}/files/${filename}`;
     const file = this._bucket.file(name);
     return (await file.download())[0];
   }
@@ -104,17 +107,13 @@ class MemoryStorage {
   }
 }
 
-const getStorage = () => {
+const getStorage = (appVersion) => {
   // Use CloudStorage on Google AppEngine.
   const project = process.env.GOOGLE_CLOUD_PROJECT;
   if (project) {
-    // Use GCLOUD_STORAGE_BUCKET or GCLOUD_STORAGE_BUCKET_STAGING from app.yaml,
-    // depending on the version we're running.
-    const bucketName =
-      process.env.GAE_VERSION == 'production' ?
-        process.env.GCLOUD_STORAGE_BUCKET :
-        process.env.GCLOUD_STORAGE_BUCKET_STAGING;
-    return new CloudStorage(project, bucketName);
+    // Use GCLOUD_STORAGE_BUCKET from app.yaml.
+    const bucketName = process.env.GCLOUD_STORAGE_BUCKET;
+    return new CloudStorage(project, bucketName, appVersion);
   }
 
   // Use MemoryStorage storage for local deployment and testing.

--- a/unittest/unit/storage.js
+++ b/unittest/unit/storage.js
@@ -139,37 +139,23 @@ describe('storage', () => {
 
   describe('getStorage', () => {
     it('testing', () => {
-      const storage = getStorage();
+      const storage = getStorage('test-version');
       assert(storage instanceof MemoryStorage);
     });
 
     it('production', () => {
-      process.env.GOOGLE_CLOUD_PROJECT = 'testing-project';
-      process.env.GAE_VERSION = 'production';
-      process.env.GCLOUD_STORAGE_BUCKET = 'prod-bucket';
-      process.env.GCLOUD_STORAGE_BUCKET_STAGING = 'staging-bucket';
+      process.env.GOOGLE_CLOUD_PROJECT = 'test-project';
+      process.env.GCLOUD_STORAGE_BUCKET = 'test-bucket';
 
-      const storage = getStorage();
+      const storage = getStorage('test-version');
       assert(storage instanceof CloudStorage);
-      assert.equal(storage._bucket.name, 'prod-bucket');
-    });
-
-    it('staging', () => {
-      process.env.GOOGLE_CLOUD_PROJECT = 'testing-project';
-      process.env.GAE_VERSION = 'staging';
-      process.env.GCLOUD_STORAGE_BUCKET = 'prod-bucket';
-      process.env.GCLOUD_STORAGE_BUCKET_STAGING = 'staging-bucket';
-
-      const storage = getStorage();
-      assert(storage instanceof CloudStorage);
-      assert.equal(storage._bucket.name, 'staging-bucket');
+      assert.equal(storage._bucket.name, 'test-bucket');
+      assert.equal(storage._version, 'test-version');
     });
 
     afterEach(() => {
       delete process.env.GOOGLE_CLOUD_PROJECT;
-      delete process.env.GAE_VERSION;
       delete process.env.GCLOUD_STORAGE_BUCKET;
-      delete process.env.GCLOUD_STORAGE_BUCKET_STAGING;
     });
   });
 });


### PR DESCRIPTION
The main purpose of this is to stop using GAE_VERSION, to allow it to be
anything and make it easy to deploy multiple versions in parallel.

Use the app version as a path prefix in the single bucket to clearly
separate data from different versions, and remove the need for a staging
bucket. Collisions were already unlikely, but sessions for all
deployments would still be mixed in a single bucket.

While changing things, also add /sessions/ to the path of temporary
results storage, since /files/ is already used for exported reports.