### PR TITLE
Restore the css.properties.custom-property custom test

### DIFF
--- a/custom-css.json
+++ b/custom-css.json
@@ -650,6 +650,7 @@
         "wait"
       ]
     },
+    "custom-property": {},
     "display": {
       "__additional_values": {
         "display-outside": ["block", "inline", "run-in"],

--- a/custom-tests.yaml
+++ b/custom-tests.yaml
@@ -1,3 +1,5 @@
+# Custom tests here also need to be in @webref/idl or custom-idl/, see
+# https://github.com/foolip/mdn-bcd-collector/issues/1944.
 api:
   __resources:
     audio-blip:
@@ -2506,6 +2508,8 @@ api:
       <%api.XPathExpression:exp%>
       var instance = exp.evaluate(document, 0, null);
 
+# Custom tests here also need to be in @webref/css or custom-css.json, see
+# https://github.com/foolip/mdn-bcd-collector/issues/1944.
 css:
   properties:
     custom-property: |-


### PR DESCRIPTION
The way this works is confusing, an issue was filed:
https://github.com/foolip/mdn-bcd-collector/issues/1944