### PR TITLE
Replace "preview" in BCD if collector has version number

### DIFF
--- a/update-bcd.js
+++ b/update-bcd.js
@@ -351,6 +351,7 @@ const update = (bcd, supportMatrix, filter) => {
       ) {
         const range = inferredStatement.version_added.split('> ≤');
         if (
+          simpleStatement.version_added === 'preview' ||
           compareVersions.compare(
             simpleStatement.version_added.replace('≤', ''),
             range[0],


### PR DESCRIPTION
This PR fixes `update-bcd` to replace any data in BCD marked as `preview` if our data suggests a version number.
