### PR TITLE
Don't run tests on Windows

### DIFF
--- a/.github/workflows/pull_request.yml
+++ b/.github/workflows/pull_request.yml
@@ -9,8 +9,6 @@ jobs:
           runs-on: ubuntu-latest
         - name: macOS
           runs-on: macos-latest
-        - name: Windows
-          runs-on: windows-latest
     name: Test (${{ matrix.name }})
     runs-on: ${{ matrix.runs-on }}
     steps:


### PR DESCRIPTION
Tests on Windows commonly crash due to timeouts.  This PR removes Windows from the test matrix.