### PR TITLE
Update testConstructor() to catch Safari error message

### DIFF
--- a/static/resources/harness.js
+++ b/static/resources/harness.js
@@ -149,6 +149,7 @@
         stringIncludes(err.message, 'Argument not optional') ||
         stringIncludes(err.message, "Arguments can't be empty") ||
         stringIncludes(err.message, 'undefined is not an object') ||
+        stringIncludes(err.message, 'must be an object') ||
         stringIncludes(err.message, 'WRONG_ARGUMENTS_ERR')
       ) {
         // If it failed to construct and it's not illegal or just needs


### PR DESCRIPTION
This PR fixes `testConstructor()` to catch an additional error message returned by constructors, specifically one that Safari now throws when attempting to construct a `ByteLengthQueuingStrategy`.  Fixes the bug found in https://github.com/mdn/browser-compat-data/pull/15975.﻿
