### PR TITLE
Fix api.CSSKeyframesRule, which is currently invalid JS

### DIFF
--- a/custom-tests.yaml
+++ b/custom-tests.yaml
@@ -438,8 +438,7 @@ api:
     __resources:
       - createStyleSheet
     __base: |-
-      var stylesheet = reusableInstances.createStyleSheet('@keyframes test {0% {
-      top: 0 } 100% { top: 100px; }} @-webkit-keyframes test {0% { top: 0 } 100% { top: 100px; }} @-moz-keyframes test {0% { top: 0 } 100% { top: 100px; }} @-o-keyframes test {0% { top: 0 } 100% { top: 100px; }}');
+      var stylesheet = reusableInstances.createStyleSheet('@keyframes test {0% {top: 0 } 100% { top: 100px; }} @-webkit-keyframes test {0% { top: 0 } 100% { top: 100px; }} @-moz-keyframes test {0% { top: 0 } 100% { top: 100px; }} @-o-keyframes test {0% { top: 0 } 100% { top: 100px; }}');
       var instance = stylesheet.cssRules.item(0);
   CSSMediaRule:
     __resources:


### PR DESCRIPTION
This contains a new line within a JS string, which is syntactically invalid, and results in every browser giving null for this test.