### PR TITLE
Prefix NodeJS built-in imports with `node:`

### DIFF
--- a/add-new-bcd.js
+++ b/add-new-bcd.js
@@ -43,9 +43,9 @@ const recursiveAdd = (ident, i, data, obj) => {
   const part = ident[i];
 
   data[part] =
-    i + 1 < ident.length
-      ? recursiveAdd(ident, i + 1, part in data ? data[part] : {}, obj)
-      : Object.assign({}, obj);
+    i + 1 < ident.length ?
+      recursiveAdd(ident, i + 1, part in data ? data[part] : {}, obj) :
+      Object.assign({}, obj);
 
   return data;
 };

--- a/add-new-bcd.js
+++ b/add-new-bcd.js
@@ -1,7 +1,8 @@
 'use strict';
 
+import path from 'node:path';
+
 import fs from 'fs-extra';
-import path from 'path';
 import esMain from 'es-main';
 
 import {getMissing} from './find-missing-features.js';
@@ -42,9 +43,9 @@ const recursiveAdd = (ident, i, data, obj) => {
   const part = ident[i];
 
   data[part] =
-    i + 1 < ident.length ?
-      recursiveAdd(ident, i + 1, part in data ? data[part] : {}, obj) :
-      Object.assign({}, obj);
+    i + 1 < ident.length
+      ? recursiveAdd(ident, i + 1, part in data ? data[part] : {}, obj)
+      : Object.assign({}, obj);
 
   return data;
 };

--- a/app.js
+++ b/app.js
@@ -14,6 +14,9 @@
 
 'use strict';
 
+import https from 'node:https';
+import http from 'node:http';
+
 import fs from 'fs-extra';
 import querystring from 'querystring';
 import bcd from '@mdn/browser-compat-data';
@@ -21,8 +24,6 @@ const bcdBrowsers = bcd.browsers;
 import esMain from 'es-main';
 import express from 'express';
 import cookieParser from 'cookie-parser';
-import https from 'https';
-import http from 'http';
 import uniqueString from 'unique-string';
 import expressLayouts from 'express-ejs-layouts';
 import yargs from 'yargs';
@@ -59,9 +60,9 @@ const appVersion = await getAppVersion();
 
 const secrets = await fs.readJson(
   new URL(
-    process.env.NODE_ENV === 'test' ?
-      './secrets.sample.json' :
-      './secrets.json',
+    process.env.NODE_ENV === 'test'
+      ? './secrets.sample.json'
+      : './secrets.json',
     import.meta.url
   )
 );
@@ -235,9 +236,9 @@ app.all('/export', (req, res, next) => {
 
 app.all('/tests/*', (req, res) => {
   const ident = req.params['0'].replace(/\//g, '.');
-  const ignoreIdents = req.query.ignore ?
-    req.query.ignore.split(',').filter((s) => s) :
-    [];
+  const ignoreIdents = req.query.ignore
+    ? req.query.ignore.split(',').filter((s) => s)
+    : [];
   const foundTests = tests.getTests(ident, req.query.exposure, ignoreIdents);
   if (foundTests && foundTests.length) {
     res.render('tests', {

--- a/app.js
+++ b/app.js
@@ -60,9 +60,9 @@ const appVersion = await getAppVersion();
 
 const secrets = await fs.readJson(
   new URL(
-    process.env.NODE_ENV === 'test'
-      ? './secrets.sample.json'
-      : './secrets.json',
+    process.env.NODE_ENV === 'test' ?
+      './secrets.sample.json' :
+      './secrets.json',
     import.meta.url
   )
 );
@@ -236,9 +236,9 @@ app.all('/export', (req, res, next) => {
 
 app.all('/tests/*', (req, res) => {
   const ident = req.params['0'].replace(/\//g, '.');
-  const ignoreIdents = req.query.ignore
-    ? req.query.ignore.split(',').filter((s) => s)
-    : [];
+  const ignoreIdents = req.query.ignore ?
+    req.query.ignore.split(',').filter((s) => s) :
+    [];
   const foundTests = tests.getTests(ident, req.query.exposure, ignoreIdents);
   if (foundTests && foundTests.length) {
     res.render('tests', {

--- a/build.js
+++ b/build.js
@@ -31,9 +31,9 @@ import customIDL from './custom-idl/index.js';
 const customTests = YAML.parse(
   await fs.readFile(
     new URL(
-      process.env.NODE_ENV === 'test'
-        ? './unittest/unit/custom-tests.test.yaml'
-        : './custom-tests.yaml',
+      process.env.NODE_ENV === 'test' ?
+        './unittest/unit/custom-tests.test.yaml' :
+        './custom-tests.yaml',
       import.meta.url
     ),
     'utf8'
@@ -91,9 +91,9 @@ const getCustomTestAPI = (name, member, type) => {
 
   if (name in customTests.api) {
     const testbase =
-      '__base' in customTests.api[name]
-        ? customTests.api[name].__base.replace(/\n/g, '\n  ') + '\n  '
-        : '';
+      '__base' in customTests.api[name] ?
+        customTests.api[name].__base.replace(/\n/g, '\n  ') + '\n  ' :
+        '';
     const promise = testbase.includes('var promise');
     const callback = testbase.includes('callback(');
 
@@ -102,23 +102,23 @@ const getCustomTestAPI = (name, member, type) => {
         test = testbase + customTests.api[name].__test;
       } else {
         const returnValue = '!!instance';
-        test = testbase
-          ? testbase +
-            (promise
-              ? `return promise.then(function(instance) {
+        test = testbase ?
+          testbase +
+            (promise ?
+              `return promise.then(function(instance) {
     return ${returnValue};
-  });`
-              : callback
-              ? `function callback(instance) {
+  });` :
+              callback ?
+              `function callback(instance) {
     try {
       success(${returnValue});
     } catch(e) {
       fail(e);
     }
   };
-  return 'callback';`
-              : `return ${returnValue};`)
-          : false;
+  return 'callback';` :
+              `return ${returnValue};`) :
+          false;
       }
     } else {
       if (
@@ -136,23 +136,23 @@ const getCustomTestAPI = (name, member, type) => {
           test = false;
         } else {
           const returnValue = `'${member}' in instance`;
-          test = testbase
-            ? testbase +
-              (promise
-                ? `return promise.then(function(instance) {
+          test = testbase ?
+            testbase +
+              (promise ?
+                `return promise.then(function(instance) {
     return ${returnValue};
-  });`
-                : callback
-                ? `function callback(instance) {
+  });` :
+                callback ?
+                `function callback(instance) {
     try {
       success(${returnValue});
     } catch(e) {
       fail(e);
     }
   };
-  return 'callback';`
-                : `return ${returnValue};`)
-            : false;
+  return 'callback';` :
+                `return ${returnValue};`) :
+            false;
         }
       }
     }
@@ -178,9 +178,9 @@ const getCustomSubtestsAPI = (name) => {
 
   if (name in customTests.api) {
     const testbase =
-      '__base' in customTests.api[name]
-        ? customTests.api[name].__base.replace(/\n/g, '\n  ') + '\n  '
-        : '';
+      '__base' in customTests.api[name] ?
+        customTests.api[name].__base.replace(/\n/g, '\n  ') + '\n  ' :
+        '';
     if ('__additional' in customTests.api[name]) {
       for (const subtest of Object.entries(
         customTests.api[name].__additional
@@ -678,9 +678,9 @@ const buildIDLMemberTests = (
       }
     }
 
-    const name = isEventHandler
-      ? `${member.name.replace(/^on/, '')}_event`
-      : member.name;
+    const name = isEventHandler ?
+      `${member.name.replace(/^on/, '')}_event` :
+      member.name;
 
     tests[name] = compileTest({
       raw: {

--- a/build.js
+++ b/build.js
@@ -14,12 +14,13 @@
 
 'use strict';
 
+import path from 'node:path';
+import {fileURLToPath} from 'node:url';
+
 import css from '@webref/css';
 import esMain from 'es-main';
 import fs from 'fs-extra';
 import idl from '@webref/idl';
-import path from 'path';
-import {fileURLToPath} from 'url';
 import sass from 'sass';
 import * as WebIDL2 from 'webidl2';
 import * as YAML from 'yaml';
@@ -30,9 +31,9 @@ import customIDL from './custom-idl/index.js';
 const customTests = YAML.parse(
   await fs.readFile(
     new URL(
-      process.env.NODE_ENV === 'test' ?
-        './unittest/unit/custom-tests.test.yaml' :
-        './custom-tests.yaml',
+      process.env.NODE_ENV === 'test'
+        ? './unittest/unit/custom-tests.test.yaml'
+        : './custom-tests.yaml',
       import.meta.url
     ),
     'utf8'
@@ -90,9 +91,9 @@ const getCustomTestAPI = (name, member, type) => {
 
   if (name in customTests.api) {
     const testbase =
-      '__base' in customTests.api[name] ?
-        customTests.api[name].__base.replace(/\n/g, '\n  ') + '\n  ' :
-        '';
+      '__base' in customTests.api[name]
+        ? customTests.api[name].__base.replace(/\n/g, '\n  ') + '\n  '
+        : '';
     const promise = testbase.includes('var promise');
     const callback = testbase.includes('callback(');
 
@@ -101,23 +102,23 @@ const getCustomTestAPI = (name, member, type) => {
         test = testbase + customTests.api[name].__test;
       } else {
         const returnValue = '!!instance';
-        test = testbase ?
-          testbase +
-            (promise ?
-              `return promise.then(function(instance) {
+        test = testbase
+          ? testbase +
+            (promise
+              ? `return promise.then(function(instance) {
     return ${returnValue};
-  });` :
-              callback ?
-              `function callback(instance) {
+  });`
+              : callback
+              ? `function callback(instance) {
     try {
       success(${returnValue});
     } catch(e) {
       fail(e);
     }
   };
-  return 'callback';` :
-              `return ${returnValue};`) :
-          false;
+  return 'callback';`
+              : `return ${returnValue};`)
+          : false;
       }
     } else {
       if (
@@ -135,23 +136,23 @@ const getCustomTestAPI = (name, member, type) => {
           test = false;
         } else {
           const returnValue = `'${member}' in instance`;
-          test = testbase ?
-            testbase +
-              (promise ?
-                `return promise.then(function(instance) {
+          test = testbase
+            ? testbase +
+              (promise
+                ? `return promise.then(function(instance) {
     return ${returnValue};
-  });` :
-                callback ?
-                `function callback(instance) {
+  });`
+                : callback
+                ? `function callback(instance) {
     try {
       success(${returnValue});
     } catch(e) {
       fail(e);
     }
   };
-  return 'callback';` :
-                `return ${returnValue};`) :
-            false;
+  return 'callback';`
+                : `return ${returnValue};`)
+            : false;
         }
       }
     }
@@ -177,9 +178,9 @@ const getCustomSubtestsAPI = (name) => {
 
   if (name in customTests.api) {
     const testbase =
-      '__base' in customTests.api[name] ?
-        customTests.api[name].__base.replace(/\n/g, '\n  ') + '\n  ' :
-        '';
+      '__base' in customTests.api[name]
+        ? customTests.api[name].__base.replace(/\n/g, '\n  ') + '\n  '
+        : '';
     if ('__additional' in customTests.api[name]) {
       for (const subtest of Object.entries(
         customTests.api[name].__additional
@@ -677,9 +678,9 @@ const buildIDLMemberTests = (
       }
     }
 
-    const name = isEventHandler ?
-      `${member.name.replace(/^on/, '')}_event` :
-      member.name;
+    const name = isEventHandler
+      ? `${member.name.replace(/^on/, '')}_event`
+      : member.name;
 
     tests[name] = compileTest({
       raw: {

--- a/custom-idl/index.js
+++ b/custom-idl/index.js
@@ -15,7 +15,7 @@
 'use strict';
 
 import fs from 'fs-extra';
-import path from 'path';
+import path from 'node:path';
 import * as WebIDL2 from 'webidl2';
 
 // Load text (UTF-8) files from a directory and return an object mapping each

--- a/exporter.js
+++ b/exporter.js
@@ -74,9 +74,9 @@ const createBody = (meta) => {
     }` +
     `\nHash Digest: ${meta.digest}` +
     `\nTest URLs: ${meta.urls.join(', ')}` +
-    (meta.version.includes('-')
-      ? '\n\n**WARNING:** this PR was created from a development/staging version!'
-      : '')
+    (meta.version.includes('-') ?
+      '\n\n**WARNING:** this PR was created from a development/staging version!' :
+      '')
   );
 };
 

--- a/exporter.js
+++ b/exporter.js
@@ -17,7 +17,8 @@
 // This module is responsible for getting results/reports out of the collector
 // web service into JSON files that can be used by update-bcd.js.
 
-import crypto from 'crypto';
+import crypto from 'node:crypto';
+
 import slugify from 'slugify';
 import stringify from 'json-stable-stringify';
 import bcd from '@mdn/browser-compat-data';
@@ -73,9 +74,9 @@ const createBody = (meta) => {
     }` +
     `\nHash Digest: ${meta.digest}` +
     `\nTest URLs: ${meta.urls.join(', ')}` +
-    (meta.version.includes('-') ?
-      '\n\n**WARNING:** this PR was created from a development/staging version!' :
-      '')
+    (meta.version.includes('-')
+      ? '\n\n**WARNING:** this PR was created from a development/staging version!'
+      : '')
   );
 };
 

--- a/find-missing-features.js
+++ b/find-missing-features.js
@@ -1,8 +1,9 @@
 'use strict';
 
+import {fileURLToPath} from 'node:url';
+
 import esMain from 'es-main';
 import fs from 'fs-extra';
-import {fileURLToPath} from 'url';
 import yargs from 'yargs';
 import {hideBin} from 'yargs/helpers';
 

--- a/scripts.js
+++ b/scripts.js
@@ -12,9 +12,10 @@
 // See the License for the specific language governing permissions and
 // limitations under the License.
 
+import fs from 'node:fs';
+
 import childProcess from 'child_process';
 import esMain from 'es-main';
-import fs from 'fs';
 import yargs from 'yargs';
 import {hideBin} from 'yargs/helpers';
 

--- a/selenium.js
+++ b/selenium.js
@@ -12,6 +12,9 @@
 // See the License for the specific language governing permissions and
 // limitations under the License.
 
+import path from 'node:path';
+import {fileURLToPath} from 'node:url';
+
 import {
   Browser,
   Builder,
@@ -27,8 +30,6 @@ import compareVersions from 'compare-versions';
 import fetch from 'node-fetch';
 import esMain from 'es-main';
 import fs from 'fs-extra';
-import path from 'path';
-import {fileURLToPath} from 'url';
 import chalk from 'chalk-template';
 import {Listr} from 'listr2';
 import yargs from 'yargs';
@@ -181,16 +182,16 @@ const getOsesToTest = (service, os) => {
       break;
     case 'macOS':
       osesToTest =
-        service === 'saucelabs' ?
-          [['macOS', '10.14']] :
-          service === 'lambdatest' ?
-          [
+        service === 'saucelabs'
+          ? [['macOS', '10.14']]
+          : service === 'lambdatest'
+          ? [
               ['macOS', 'Monterey'],
               ['macOS', 'Big Sur'],
               ['macOS', 'Mojave'],
               ['OS X', 'El Capitan']
-            ] :
-          [
+            ]
+          : [
               ['OS X', 'Monterey'],
               ['OS X', 'Big Sur'],
               ['OS X', 'Mojave'],

--- a/selenium.js
+++ b/selenium.js
@@ -182,16 +182,16 @@ const getOsesToTest = (service, os) => {
       break;
     case 'macOS':
       osesToTest =
-        service === 'saucelabs'
-          ? [['macOS', '10.14']]
-          : service === 'lambdatest'
-          ? [
+        service === 'saucelabs' ?
+          [['macOS', '10.14']] :
+          service === 'lambdatest' ?
+          [
               ['macOS', 'Monterey'],
               ['macOS', 'Big Sur'],
               ['macOS', 'Mojave'],
               ['OS X', 'El Capitan']
-            ]
-          : [
+            ] :
+          [
               ['OS X', 'Monterey'],
               ['OS X', 'Big Sur'],
               ['OS X', 'Mojave'],

--- a/storage.js
+++ b/storage.js
@@ -14,7 +14,8 @@
 
 'use strict';
 
-import assert from 'assert';
+import assert from 'node:assert/strict';
+
 import fs from 'fs-extra';
 import {Storage} from '@google-cloud/storage';
 
@@ -29,7 +30,9 @@ class CloudStorage {
 
   async put(sessionId, key, value) {
     assert(sessionId.length > 0);
-    const name = `${this._version}/sessions/${sessionId}/${encodeURIComponent(key)}`;
+    const name = `${this._version}/sessions/${sessionId}/${encodeURIComponent(
+      key
+    )}`;
     const file = this._bucket.file(name);
     const data = JSON.stringify(value);
     await file.save(data);

--- a/unittest/puppeteer/harness.js
+++ b/unittest/puppeteer/harness.js
@@ -14,9 +14,10 @@
 
 'use strict';
 
+import {fileURLToPath} from 'node:url';
+
 import {assert} from 'chai';
 import fs from 'fs-extra';
-import {fileURLToPath} from 'url';
 import puppeteer from 'puppeteer';
 
 import {app} from '../../app.js';

--- a/update-bcd.js
+++ b/update-bcd.js
@@ -184,14 +184,14 @@ const inferSupportStatements = (versionMap) => {
       if (!lastStatement) {
         statements.push({
           version_added:
-            lastWasNull || lastKnown.support === false
-              ? `${lastKnown.version}> ≤${version}`
-              : version
+            lastWasNull || lastKnown.support === false ?
+              `${lastKnown.version}> ≤${version}` :
+              version
         });
       } else if (!lastStatement.version_added) {
-        lastStatement.version_added = lastWasNull
-          ? `${lastKnown.version}> ≤${version}`
-          : version;
+        lastStatement.version_added = lastWasNull ?
+          `${lastKnown.version}> ≤${version}` :
+          version;
       } else if (lastStatement.version_removed) {
         // added back again
         statements.push({
@@ -208,9 +208,9 @@ const inferSupportStatements = (versionMap) => {
         lastStatement.version_added &&
         !lastStatement.version_removed
       ) {
-        lastStatement.version_removed = lastWasNull
-          ? `${lastKnown.version}> ≤${version}`
-          : version;
+        lastStatement.version_removed = lastWasNull ?
+          `${lastKnown.version}> ≤${version}` :
+          version;
       } else if (!lastStatement) {
         statements.push({version_added: false});
       }
@@ -375,9 +375,9 @@ const update = (bcd, supportMatrix, filter) => {
         )
       ) {
         simpleStatement.version_added =
-          typeof inferredStatement.version_added === 'string'
-            ? inferredStatement.version_added.replace('0> ', '')
-            : inferredStatement.version_added;
+          typeof inferredStatement.version_added === 'string' ?
+            inferredStatement.version_added.replace('0> ', '') :
+            inferredStatement.version_added;
         modified = true;
       }
 

--- a/update-bcd.js
+++ b/update-bcd.js
@@ -3,6 +3,9 @@
 
 'use strict';
 
+import path from 'node:path';
+import {fileURLToPath} from 'node:url';
+
 import assert from 'assert';
 import compareVersions from 'compare-versions';
 import esMain from 'es-main';
@@ -10,8 +13,6 @@ import fs from 'fs-extra';
 import klaw from 'klaw';
 import minimatch from 'minimatch';
 const {Minimatch} = minimatch;
-import path from 'path';
-import {fileURLToPath} from 'url';
 import yargs from 'yargs';
 import {hideBin} from 'yargs/helpers';
 
@@ -183,14 +184,14 @@ const inferSupportStatements = (versionMap) => {
       if (!lastStatement) {
         statements.push({
           version_added:
-            lastWasNull || lastKnown.support === false ?
-              `${lastKnown.version}> ≤${version}` :
-              version
+            lastWasNull || lastKnown.support === false
+              ? `${lastKnown.version}> ≤${version}`
+              : version
         });
       } else if (!lastStatement.version_added) {
-        lastStatement.version_added = lastWasNull ?
-          `${lastKnown.version}> ≤${version}` :
-          version;
+        lastStatement.version_added = lastWasNull
+          ? `${lastKnown.version}> ≤${version}`
+          : version;
       } else if (lastStatement.version_removed) {
         // added back again
         statements.push({
@@ -207,9 +208,9 @@ const inferSupportStatements = (versionMap) => {
         lastStatement.version_added &&
         !lastStatement.version_removed
       ) {
-        lastStatement.version_removed = lastWasNull ?
-          `${lastKnown.version}> ≤${version}` :
-          version;
+        lastStatement.version_removed = lastWasNull
+          ? `${lastKnown.version}> ≤${version}`
+          : version;
       } else if (!lastStatement) {
         statements.push({version_added: false});
       }
@@ -374,9 +375,9 @@ const update = (bcd, supportMatrix, filter) => {
         )
       ) {
         simpleStatement.version_added =
-          typeof inferredStatement.version_added === 'string' ?
-            inferredStatement.version_added.replace('0> ', '') :
-            inferredStatement.version_added;
+          typeof inferredStatement.version_added === 'string'
+            ? inferredStatement.version_added.replace('0> ', '')
+            : inferredStatement.version_added;
         modified = true;
       }
 


### PR DESCRIPTION
This PR prefixes all imports for NodeJS built-ins with `node:` to clarify imports better.
