### PR TITLE
Remove custom tests for CSSConditionRule and CSSGroupingRule

### DIFF
--- a/custom-tests.yaml
+++ b/custom-tests.yaml
@@ -396,10 +396,6 @@ api:
       - cryptoKey
     __base: |-
       var promise = reusableInstances.cryptoKey;
-  CSSConditionRule:
-    __resources:
-      - createStyleSheet
-    __base: <%api.CSSMediaRule:instance%>
   CSSCounterStyleRule:
     __resources:
       - createStyleSheet
@@ -418,10 +414,6 @@ api:
     __base: |-
       var stylesheet = reusableInstances.createStyleSheet('@font-feature-values Font {@styleset {nice-style: 12;}}');
       var instance = stylesheet.cssRules.item(0);
-  CSSGroupingRule:
-    __resources:
-      - createStyleSheet
-    __base: <%api.CSSMediaRule:instance%>
   CSSImportRule:
     __resources:
       - createStyleSheet


### PR DESCRIPTION
These are abstract base classes that were added to the prototype chain
after some of the interfaces that inherit from them. Creating instances
for these leads to detected support before the interfaces were actually
supported.

Simple prototype testing is appropriate in this case, although it's
possible some browser supported the interfaces without exposing the
interface objects. Regardless of how this is testing, it will need to be
manually scrutinized when updating the data.
