### PR TITLE
Add 3rd argument to FontFace constructor

### DIFF
--- a/custom-tests.yaml
+++ b/custom-tests.yaml
@@ -799,7 +799,7 @@ api:
         }
       }
   FontFace:
-    __base: var instance = new FontFace('Material Design Icons', 'url(/fonts/materialdesignicons-webfont.woff)');
+    __base: var instance = new FontFace('Material Design Icons', 'url(/fonts/materialdesignicons-webfont.woff)', {});
   FontFaceSet:
     __base: |-
       var instance;


### PR DESCRIPTION
This is required by early versions of Chrome.
