### PR TITLE
Allow for static members of the same name as non-static members

### DIFF
--- a/build.js
+++ b/build.js
@@ -266,12 +266,12 @@ const compileTest = (test) => {
 const mergeMembers = (target, source) => {
   // Check for duplicate members across partials/mixins.
   const targetMembers = new Set(
-    target.members.map((m) => (m.name + m.special === 'static' ? 'static' : ''))
+    target.members.map((m) => m.name + (m.special === 'static' ? 'static' : ''))
   );
   for (const member of source.members) {
     if (
       targetMembers.has(
-        member.name + member.special === 'static' ? 'static' : ''
+        member.name + (member.special === 'static' ? 'static' : '')
       )
     ) {
       throw new Error(`Duplicate definition of ${target.name}.${member.name}`);

--- a/build.js
+++ b/build.js
@@ -265,9 +265,15 @@ const compileTest = (test) => {
 
 const mergeMembers = (target, source) => {
   // Check for duplicate members across partials/mixins.
-  const targetMembers = new Set(target.members.map((m) => m.name));
+  const targetMembers = new Set(
+    target.members.map((m) => (m.name + m.special === 'static' ? 'static' : ''))
+  );
   for (const member of source.members) {
-    if (targetMembers.has(member.name)) {
+    if (
+      targetMembers.has(
+        member.name + member.special === 'static' ? 'static' : ''
+      )
+    ) {
       throw new Error(`Duplicate definition of ${target.name}.${member.name}`);
     }
   }


### PR DESCRIPTION
This PR allows the IDL to contain static members that use the same name as non-static members, as per the [WebIDL standard](https://webidl.spec.whatwg.org/\#idl-operations:\~:text\=Note%3A%20The%20identifier%20of%20a%20static%20operation%20can%20be%20the%20same%20as%20the%20identifier%20of%20a%20regular%20operation%20defined%20on%20the%20same%20interface.).  This is required to land #2049.

Note: while this logic can theoretically be simplified to `member.name + member.special`, I wanted to limit the scope to just what's allowed in the spec.