### PR TITLE
Don't include static members with the same name as non-static members

### DIFF
--- a/build.js
+++ b/build.js
@@ -265,20 +265,23 @@ const compileTest = (test) => {
 
 const mergeMembers = (target, source) => {
   // Check for duplicate members across partials/mixins.
-  const targetMembers = new Set(
-    target.members.map((m) => m.name + (m.special === 'static' ? 'static' : ''))
-  );
+  const targetMembers = new Set(target.members.map((m) => m.name));
+  const sourceMembers = new Set();
   for (const member of source.members) {
-    if (
-      targetMembers.has(
-        member.name + (member.special === 'static' ? 'static' : '')
-      )
-    ) {
-      throw new Error(`Duplicate definition of ${target.name}.${member.name}`);
+    if (targetMembers.has(member.name)) {
+      // Static members may have the same name as a non-static member.
+      // If any are found, ignore and don't add to the members to merge.
+      if (!(member.special === 'static')) {
+        throw new Error(
+          `Duplicate definition of ${target.name}.${member.name}`
+        );
+      }
+    } else {
+      sourceMembers.add(member);
     }
   }
   // Now merge members.
-  target.members.push(...source.members);
+  target.members.push(...sourceMembers);
 };
 
 const flattenIDL = (specIDLs, customIDLs) => {

--- a/build.js
+++ b/build.js
@@ -269,9 +269,13 @@ const mergeMembers = (target, source) => {
   const sourceMembers = new Set();
   for (const member of source.members) {
     if (targetMembers.has(member.name)) {
+      const targetMember = target.members.find((m) => m.name);
       // Static members may have the same name as a non-static member.
-      // If any are found, ignore and don't add to the members to merge.
-      if (!(member.special === 'static')) {
+      // If target has static member with same name, remove from target.
+      // If source has static member with same name, don't merge into target.
+      if (targetMember.special === 'static') {
+        target.members.pop(target.members.indexOf(targetMember));
+      } else if (member.special !== 'static') {
         throw new Error(
           `Duplicate definition of ${target.name}.${member.name}`
         );


### PR DESCRIPTION
This PR is a follow-up to #2054.  Instead of simply ignoring static members with the same name as non-static members, this PR adjusts the logic to ensure they aren't included in the merged member output at all.  Closes #2061.
