### PR TITLE
Show BCD version when browser version isn't in BCD

### DIFF
--- a/app.js
+++ b/app.js
@@ -97,6 +97,7 @@ app.use(express.static('static'));
 app.use(express.static('generated'));
 
 app.locals.appVersion = appVersion;
+app.locals.bcdVersion = bcd.__meta.version;
 
 // Get user agent
 app.use((req, res, next) => {

--- a/views/layout.ejs
+++ b/views/layout.ejs
@@ -47,7 +47,7 @@ See LICENSE.txt for copyright details
       <p><a href="https://github.com/foolip/mdn-bcd-collector/blob/main/CHANGELOG.md">v<%- appVersion %></a></p>
       <a href="https://github.com/foolip/mdn-bcd-collector"><span class="mdi mdi-github"> GitHub</span></a>
       <a href="/"><span class="mdi mdi-home"> Home</span></a>
-      <p id="browserinfo" <% if (!browser.inBcd) { %>class="error"<% } %>><% if (browser.browser.name) { %>Detected Browser: <%- browser.browser.name %> <%- browser.version %> <% if (!browser.inBcd) { %>(not in BCD)<% } %><% } else {%>Could not determine browser<% } %></p>
+      <p id="browserinfo" <% if (!browser.inBcd) { %>class="error"<% } %>><% if (browser.browser.name) { %>Detected Browser: <%- browser.browser.name %> <%- browser.version %> <% if (!browser.inBcd) { %>(not in BCD v<%- bcdVersion %>)<% } %><% } else {%>Could not determine browser<% } %></p>
     </footer>
 
     <%- script %>


### PR DESCRIPTION
This PR adds the BCD version to the message indicating that the browser version isn't in BCD.  This is helpful to inform users that the browser version may not be in BCD simply because the current collector version does not have an updated BCD version.
