### PR TITLE
Convert find-missing-results to TypeScript

### DIFF
--- a/package.json
+++ b/package.json
@@ -28,7 +28,7 @@
     "selenium": "node selenium.js",
     "update-bcd": "ts-node update-bcd.ts",
     "find-missing-features": "node find-missing-features.js",
-    "find-missing-results": "node find-missing-results.js",
+    "find-missing-results": "ts-node find-missing-results.ts",
     "add-new-bcd": "node add-new-bcd.js",
     "release": "node release.js"
   },

--- a/update-bcd.ts
+++ b/update-bcd.ts
@@ -447,7 +447,9 @@ export const update = (
 // |paths| can be files or directories. Returns an object mapping
 // from (absolute) path to the parsed file content.
 /* c8 ignore start */
-export const loadJsonFiles = async (paths: string[]): Promise<any> => {
+export const loadJsonFiles = async (
+  paths: string[]
+): Promise<{[filename: string]: any}> => {
   // Ignores .DS_Store, .git, etc.
   const dotFilter = (item) => {
     const basename = path.basename(item);


### PR DESCRIPTION
This PR converts the `find-missing-results` script to TypeScript.
