### PR TITLE
Convert find-missing-features to TypeScript

### DIFF
--- a/find-missing-features.ts
+++ b/find-missing-features.ts
@@ -1,10 +1,13 @@
 //
-// mdn-bcd-collector: find-missing-features.js
+// mdn-bcd-collector: find-missing-features.ts
 // Script to find features that are in the collector or BCD but not the other
 //
 // © Gooborg Studios, Google LLC
 // See LICENSE.txt for copyright details
 //
+
+import {CompatData, CompatStatement} from '@mdn/browser-compat-data/types';
+import {Tests} from './types/types.js';
 
 import {fileURLToPath} from 'node:url';
 
@@ -13,15 +16,15 @@ import fs from 'fs-extra';
 import yargs from 'yargs';
 import {hideBin} from 'yargs/helpers';
 
-const traverseFeatures = (obj, path, includeAliases) => {
-  const features = [];
+const traverseFeatures = (obj: any, path: string, includeAliases: boolean) => {
+  const features: string[] = [];
 
   for (const id of Object.keys(obj)) {
     if (!obj[id] || typeof obj[id] !== 'object') {
       continue;
     }
 
-    const compat = obj[id].__compat;
+    const compat: CompatStatement = obj[id].__compat;
     if (compat) {
       features.push(`${path}${id}`);
 
@@ -62,8 +65,8 @@ const traverseFeatures = (obj, path, includeAliases) => {
   return features;
 };
 
-const findMissing = (entries, allEntries) => {
-  const missingEntries = [];
+const findMissing = (entries: string[], allEntries: string[]) => {
+  const missingEntries: string[] = [];
 
   for (const entry of allEntries) {
     if (!entries.includes(entry)) {
@@ -75,10 +78,10 @@ const findMissing = (entries, allEntries) => {
 };
 
 const getMissing = (
-  bcd,
-  tests,
+  bcd: CompatData,
+  tests: Tests,
   direction = 'collector-from-bcd',
-  category = [],
+  category: string[] = [],
   includeAliases = false
 ) => {
   const filterCategory = (item) => {
@@ -112,8 +115,8 @@ const getMissing = (
 };
 
 /* c8 ignore start */
-const main = (bcd, tests) => {
-  const {argv} = yargs(hideBin(process.argv)).command(
+const main = (bcd: CompatData, tests: Tests) => {
+  const {argv}: any = yargs(hideBin(process.argv)).command(
     '$0 [--direction]',
     'Find missing entries between BCD and the collector tests',
     (yargs) => {

--- a/package.json
+++ b/package.json
@@ -27,7 +27,7 @@
     "test": "npm run format && npm run unittest",
     "selenium": "node selenium.js",
     "update-bcd": "ts-node update-bcd.ts",
-    "find-missing-features": "node find-missing-features.js",
+    "find-missing-features": "ts-node find-missing-features.ts",
     "find-missing-results": "ts-node find-missing-results.ts",
     "add-new-bcd": "node add-new-bcd.js",
     "release": "node release.js",

--- a/types/types.d.ts
+++ b/types/types.d.ts
@@ -12,6 +12,13 @@ export type InternalSupportStatement = SupportStatement | 'mirror';
 
 export type Exposure = 'Window' | 'Worker' | 'SharedWorker' | 'ServiceWorker';
 
+export interface Test {
+  code: string;
+  exposure: Exposure[];
+}
+
+export type Tests = Record<string, Test>;
+
 export type TestResultValue = boolean | null;
 
 export interface TestResult {


### PR DESCRIPTION
This PR converts the `find-missing-features` script over to TypeScript.
