### PR TITLE
Use <stop> instead of <path> for SVGAnimatedNumber custom test

### DIFF
--- a/custom-tests.yaml
+++ b/custom-tests.yaml
@@ -1783,8 +1783,8 @@ api:
       var instance = el.x;
   SVGAnimatedNumber:
     __base: |-
-      <%api.SVGGeometryElement:el%>
-      var instance = el.pathLength;
+      <%api.SVGStopElement:el%>
+      var instance = el.offset;
   SVGAnimatedNumberList:
     __base: |-
       <%api.SVGFEConvolveMatrixElement:el%>


### PR DESCRIPTION
IE/Edge don't support the pathLength property, leading to false
negatives with this test.
