### PR TITLE
Fix the custom CryptoKey tests

### DIFF
--- a/custom-tests.yaml
+++ b/custom-tests.yaml
@@ -60,7 +60,9 @@ api:
           modulusLength: 4096,
           publicExponent: new Uint8Array([1, 0, 1]),
           hash: 'SHA-256'
-        }, true, ['encrypt', 'decrypt']);
+        }, true, ['encrypt', 'decrypt']).then(function(pair) {
+          return pair.publicKey;
+        });
     offlineAudioContext:
       type: instance
       src: |-


### PR DESCRIPTION
crypto.subtle.generateKey() returns a promise that resolves to two
keys in a dictionary, so extract one of them.
