### PR TITLE
Remove more nulls from custom tests

### DIFF
--- a/build.js
+++ b/build.js
@@ -241,7 +241,7 @@ const compileTestCode = (test) => {
   if (test.inherit) {
     return `Object.prototype.hasOwnProperty.call(${test.owner}, "${property}")`;
   }
-  if (test.owner === 'self') {
+  if (test.owner === 'self' || test.owner === 'document.body.style') {
     return `"${property}" in ${test.owner}`;
   }
   return `"${test.owner.replace(

--- a/custom-tests.yaml
+++ b/custom-tests.yaml
@@ -309,6 +309,10 @@ api:
       var instance = canvas.createPattern(document.getElementById('resource-image-black'), 'repeat');
   CanvasRenderingContext2D:
     __base: |-
+      if (!('document' in self)) {
+        // XXX Implement worker tests for CanvasRenderingContext2D
+        return {result: null, message: 'Testing CanvasRenderingContext2D in workers is not yet implemented'};
+      }
       var canvas = document.createElement('canvas');
       if (!canvas) {
         return false;
@@ -880,7 +884,9 @@ api:
   History:
     __base: var instance = history;
   HTMLAllCollection:
-    __base: var instance = document.all;
+    __base: |-
+      // XXX document.all seems to be falsy, at least in Chrome
+      var instance = document.all;
     __test: return bcd.testObjectName(instance, 'HTMLAllCollection');
   HTMLAnchorElement:
     __base: var instance = document.createElement('a');
@@ -1187,7 +1193,12 @@ api:
   ImageBitmap:
     __resources:
       - image-black
-    __base: var instance = createImageBitmap(document.getElementById('resource-image-black'));
+    __base: |-
+      if (!('document' in self)) {
+        // XXX Implement worker tests for ImageBitmap
+        return {result: null, message: 'Testing ImageBitmap in workers is not yet implemented'};
+      }
+      var instance = createImageBitmap(document.getElementById('resource-image-black'));
   ImageCapture:
     __base: |-
       <%api.MediaDevices:mediaDevices%>
@@ -1257,6 +1268,9 @@ api:
       if (!reusableInstances.audioContext) {
         return false;
       }
+      if (!('createMediaElementSource' in reusableInstances.audioContext)) {
+        return false;
+      }
       var instance = reusableInstances.audioContext.createMediaElementSource(document.getElementById('resource-audio-blip'));
   MediaEncryptedEvent:
     __base: |-
@@ -1287,7 +1301,11 @@ api:
   MediaSession:
     __base: var instance = navigator.mediaSession;
   MediaSource:
-    __base: var instance = new MediaSource();
+    __base: |-
+      if (!('MediaSource' in self)) {
+        return false;
+      }
+      var instance = new MediaSource();
     isTypeSupported: return 'isTypeSupported' in MediaSource;
   MediaStream:
     __base: |-
@@ -1328,6 +1346,9 @@ api:
     __base: |-
       <%api.MediaStream:mediaStream%>
       if (!reusableInstances.audioContext) {
+        return false;
+      }
+      if (!('createMediaStreamTrackSource' in reusableInstances.audioContext)) {
         return false;
       }
       var promise = mediaStream.then(function(ms) {
@@ -1418,10 +1439,11 @@ api:
       var instance = new Notification('');
   NotificationEvent:
     __base: |-
+      <%api.Notification:notification%>
       if (!('NotificationEvent' in self)) {
         return false;
       }
-      var instance = new NotificationEvent('notificationclick');
+      var instance = new NotificationEvent('notificationclick', {notification});
   OfflineAudioCompletionEvent:
     __resources:
       - audioContext
@@ -2330,6 +2352,9 @@ api:
       try {
         instance = new WebGLContextEvent('webglcontextlost');
       } catch(e) {
+        if (!('document' in self)) {
+          return false;
+        }
         try {
           instance = document.createEvent('WebGLContextEvent');
         } catch(e) {

--- a/result-stats.ts
+++ b/result-stats.ts
@@ -91,14 +91,10 @@ const getStats = (data: Report, featureQuery: string[]): any => {
     testResults.filter((r) => r.result).map((r) => r.name)
   );
   const unsupportedFeatures = dedupeArray(
-    testResults
-      .filter((r) => r.result === false && !supportedFeatures.includes(r.name))
-      .map((r) => r.name)
+    testResults.filter((r) => r.result === false).map((r) => r.name)
   );
   const unknownFeatures = dedupeArray(
-    testResults
-      .filter((r) => r.result === null && !unsupportedFeatures.includes(r.name))
-      .map((r) => r.name)
+    testResults.filter((r) => r.result === null).map((r) => r.name)
   );
 
   const featuresQueried: any[] = [];

--- a/static/resources/harness.js
+++ b/static/resources/harness.js
@@ -153,7 +153,8 @@
           "Arguments can't be empty",
           'undefined is not an object',
           'must be an object',
-          'WRONG_ARGUMENTS_ERR'
+          'WRONG_ARGUMENTS_ERR',
+          'are both null'
         ])
       ) {
         // If it failed to construct and it's not illegal or just needs
@@ -251,8 +252,8 @@
   }
 
   function testCSSProperty(name) {
-    if ("CSS" in window && window.CSS.supports) {
-      return window.CSS.supports(name, "inherit");
+    if ('CSS' in window && window.CSS.supports) {
+      return window.CSS.supports(name, 'inherit');
     }
 
     var attrs = [name];
@@ -268,14 +269,14 @@
   }
 
   function testCSSPropertyValue(name, value) {
-    if ("CSS" in window && window.CSS.supports) {
+    if ('CSS' in window && window.CSS.supports) {
       return window.CSS.supports(name, value);
     }
 
     var div = document.createElement('div');
-    div.style[name] = "";
+    div.style[name] = '';
     div.style[name] = value;
-    return div.style.getPropertyValue(name) !== "";
+    return div.style.getPropertyValue(name) !== '';
   }
 
   // Once a test is evaluated and run, it calls this function with the result.


### PR DESCRIPTION
This PR removes a bunch of null results from collector results by adding additionaltests and checks.  This fixes #2052.

In results for Chrome 103, I have confirmed that there are no changes of `true` to `false` that result from these changes.
