### PR TITLE
Clearly state support vs. true/false/null

### DIFF
--- a/static/resources/harness.js
+++ b/static/resources/harness.js
@@ -795,7 +795,14 @@
     var resultValue = stringify(result.result);
     var resultValueEl = document.createElement('span');
     resultValueEl.className = 'result-value result-value-' + resultValue;
-    resultValueEl.innerHTML = resultValue;
+    resultValueEl.innerHTML =
+      resultValue === 'true' ?
+        'Supported' :
+        resultValue === 'false' ?
+        'No Support' :
+        resultValue === 'null' ?
+        'Support Unknown' :
+        resultValue;
     resultSummaryEl.appendChild(resultValueEl);
     resultEl.appendChild(resultSummaryEl);
 


### PR DESCRIPTION
This PR replaces the `true/false/null` display with `Supported/No Support/Support Unknown` to make it clearer to end users whether a feature is supported or not.
