### PR TITLE
Add custom test for Location.toString()

### DIFF
--- a/custom-tests.yaml
+++ b/custom-tests.yaml
@@ -1303,6 +1303,11 @@ api:
       var instance = reusableInstances.webGL.getExtension('KHR_parallel_shader_compile');
   Location:
     __base: var instance = location;
+    toString: |-
+      if (!('toString' in instance)) {
+        return {result: false, message: 'toString is not defined'};
+      }
+      return instance.toString() == instance.href;
   MediaCapabilities:
     __base: var instance = navigator.mediaCapabilities;
   MediaDeviceInfo:
@@ -2646,7 +2651,11 @@ api:
     __base: var instance = self;
   WorkerLocation:
     __base: var instance = location;
-    toString: return instance.toString() == instance.href;
+    toString: |-
+      if (!('toString' in instance)) {
+        return {result: false, message: 'toString is not defined'};
+      }
+      return instance.toString() == instance.href;
   WorkerNavigator:
     __base: var instance = navigator;
   WritableStreamDefaultController:


### PR DESCRIPTION
This PR adds a custom test for `location.toString()` and updates the test for the `WorkerLocation` interface to match.
