### PR TITLE
Track all individual minor versions of Safari 15+

### DIFF
--- a/ua-parser.js
+++ b/ua-parser.js
@@ -106,25 +106,17 @@ const parseUA = (userAgent, browsers) => {
   // with this, find the pair of versions in |versions| that sandwiches
   // |version|, and use the first of this pair. For example, given |version|
   // "10.1" and |versions| entries "10.0" and "10.2", return "10.0".
-  if (
-    data.browser.id.startsWith('safari') &&
-    compareVersions.compare(data.version, '15', '>=')
-  ) {
-    // Ignore this step for Safari 15.x and up, as Safari 15+ has more frequent
-    // updates and we want to track all individual minor releases
-    data.inBcd = data.version in browsers[data.browser.id].releases;
-  } else {
-    for (let i = 0; i < versions.length - 1; i++) {
-      const current = versions[i];
-      const next = versions[i + 1];
-      if (
-        compareVersions.compare(data.version, current, '>=') &&
-        compareVersions.compare(data.version, next, '<')
-      ) {
-        data.inBcd = true;
-        data.version = current;
-        break;
-      }
+
+  for (let i = 0; i < versions.length - 1; i++) {
+    const current = versions[i];
+    const next = versions[i + 1];
+    if (
+      compareVersions.compare(data.version, current, '>=') &&
+      compareVersions.compare(data.version, next, '<')
+    ) {
+      data.inBcd = true;
+      data.version = current;
+      break;
     }
   }
 
@@ -133,6 +125,14 @@ const parseUA = (userAgent, browsers) => {
   // and |versions| entries "10.0" and "10.2", return "10.2". Given |version|
   // "11.0", skip.
   if (
+    data.browser.id.startsWith('safari') &&
+    compareVersions.compare(data.version, '15', '>=')
+  ) {
+    // Ignore this step for Safari 15.x and up, as Safari 15+ has more frequent
+    // updates and we want to track all individual minor releases
+    data.version = data.version;
+    data.inBcd = versions.includes(data.version);
+  } else if (
     data.inBcd == false &&
     data.version.split('.')[0] === versions[versions.length - 1].split('.')[0]
   ) {

--- a/ua-parser.js
+++ b/ua-parser.js
@@ -106,16 +106,25 @@ const parseUA = (userAgent, browsers) => {
   // with this, find the pair of versions in |versions| that sandwiches
   // |version|, and use the first of this pair. For example, given |version|
   // "10.1" and |versions| entries "10.0" and "10.2", return "10.0".
-  for (let i = 0; i < versions.length - 1; i++) {
-    const current = versions[i];
-    const next = versions[i + 1];
-    if (
-      compareVersions.compare(data.version, current, '>=') &&
-      compareVersions.compare(data.version, next, '<')
-    ) {
-      data.inBcd = true;
-      data.version = current;
-      break;
+  if (
+    data.browser.id.startsWith('safari') &&
+    compareVersions.compare(data.version, '15', '>=')
+  ) {
+    // Ignore this step for Safari 15.x and up, as Safari 15+ has more frequent
+    // updates and we want to track all individual minor releases
+    data.inBcd = data.version in browsers[data.browser.id].releases;
+  } else {
+    for (let i = 0; i < versions.length - 1; i++) {
+      const current = versions[i];
+      const next = versions[i + 1];
+      if (
+        compareVersions.compare(data.version, current, '>=') &&
+        compareVersions.compare(data.version, next, '<')
+      ) {
+        data.inBcd = true;
+        data.version = current;
+        break;
+      }
     }
   }
 

--- a/ua-parser.js
+++ b/ua-parser.js
@@ -130,7 +130,6 @@ const parseUA = (userAgent, browsers) => {
   ) {
     // Ignore this step for Safari 15.x and up, as Safari 15+ has more frequent
     // updates and we want to track all individual minor releases
-    data.version = data.version;
     data.inBcd = versions.includes(data.version);
   } else if (
     data.inBcd == false &&

--- a/unittest/unit/ua-parser.js
+++ b/unittest/unit/ua-parser.js
@@ -16,7 +16,10 @@ const browsers = {
   edge: {name: 'Edge', releases: {16: {}, 84: {}}},
   firefox: {name: 'Firefox', releases: {3.6: {}}},
   ie: {name: 'Internet Explorer', releases: {8: {}, 11: {}}},
-  safari: {name: 'Safari', releases: {13: {}, 13.1: {}, 14: {}}},
+  safari: {
+    name: 'Safari',
+    releases: {13: {}, 13.1: {}, 14: {}, 15: {}, 15.1: {}, 15.2: {}}
+  },
   safari_ios: {
     name: 'iOS Safari',
     releases: {13: {}, 13.3: {}, 13.4: {}, 14: {}}
@@ -218,7 +221,7 @@ describe('parseUA', () => {
     );
   });
 
-  it('Safari 15 (not in BCD)', () => {
+  it('Safari 15', () => {
     assert.deepEqual(
       parseUA(
         'Mozilla/5.0 (Macintosh; Intel Mac OS X 10_15_6) AppleWebKit/605.1.15 (KHTML, like Gecko) Version/15.0 Safari/605.1.15',
@@ -226,8 +229,56 @@ describe('parseUA', () => {
       ),
       {
         browser: {id: 'safari', name: 'Safari'},
-        version: '15.0',
+        version: '15',
         fullVersion: '15.0',
+        os: {name: 'Mac OS', version: '10.15.6'},
+        inBcd: true
+      }
+    );
+  });
+
+  it('Safari 15.2', () => {
+    assert.deepEqual(
+      parseUA(
+        'Mozilla/5.0 (Macintosh; Intel Mac OS X 10_15_6) AppleWebKit/605.1.15 (KHTML, like Gecko) Version/15.2 Safari/605.1.15',
+        browsers
+      ),
+      {
+        browser: {id: 'safari', name: 'Safari'},
+        version: '15.2',
+        fullVersion: '15.2',
+        os: {name: 'Mac OS', version: '10.15.6'},
+        inBcd: true
+      }
+    );
+  });
+
+  it('Safari 15.3 (not in BCD)', () => {
+    assert.deepEqual(
+      parseUA(
+        'Mozilla/5.0 (Macintosh; Intel Mac OS X 10_15_6) AppleWebKit/605.1.15 (KHTML, like Gecko) Version/15.3 Safari/605.1.15',
+        browsers
+      ),
+      {
+        browser: {id: 'safari', name: 'Safari'},
+        version: '15.3',
+        fullVersion: '15.3',
+        os: {name: 'Mac OS', version: '10.15.6'},
+        inBcd: false
+      }
+    );
+  });
+
+  it('Safari 16 (not in BCD)', () => {
+    assert.deepEqual(
+      parseUA(
+        'Mozilla/5.0 (Macintosh; Intel Mac OS X 10_15_6) AppleWebKit/605.1.15 (KHTML, like Gecko) Version/16.0 Safari/605.1.15',
+        browsers
+      ),
+      {
+        browser: {id: 'safari', name: 'Safari'},
+        version: '16.0',
+        fullVersion: '16.0',
         os: {name: 'Mac OS', version: '10.15.6'},
         inBcd: false
       }


### PR DESCRIPTION
This PR updates the ua-parser script to track all Safari 15+ minor versions as individual releases, rather than mapping down (as needed for Samsung Internet and older Safari releases).
