### PR TITLE
Don't generate a test for static Response.json()

### DIFF
--- a/build.js
+++ b/build.js
@@ -643,6 +643,13 @@ const buildIDLMemberTests = (
   const handledMemberNames = new Set();
 
   for (const member of members) {
+    // Skip static Response.json() so it doesn't clobber the test for
+    // Response.prototype.json, see
+    // https://github.com/mdn/browser-compat-data/issues/16613.
+    if (iface.name === 'Response' && member.special === 'static' && member.name === 'json') {
+      continue;
+    }
+
     if (handledMemberNames.has(member.name)) {
       continue;
     }


### PR DESCRIPTION
This fixes an accidentally changed test for this PR:
https://github.com/foolip/mdn-bcd-collector/pull/2054

See https://github.com/mdn/browser-compat-data/issues/16613.
