### PR TITLE
Revert "Don't include static members with the same name as non-static members"

### DIFF
--- a/build.js
+++ b/build.js
@@ -267,27 +267,20 @@ const compileTest = (test) => {
 
 const mergeMembers = (target, source) => {
   // Check for duplicate members across partials/mixins.
-  const targetMembers = new Set(target.members.map((m) => m.name));
-  const sourceMembers = new Set();
+  const targetMembers = new Set(
+    target.members.map((m) => m.name + (m.special === 'static' ? 'static' : ''))
+  );
   for (const member of source.members) {
-    if (targetMembers.has(member.name)) {
-      const targetMember = target.members.find((m) => m.name);
-      // Static members may have the same name as a non-static member.
-      // If target has static member with same name, remove from target.
-      // If source has static member with same name, don't merge into target.
-      if (targetMember.special === 'static') {
-        target.members.pop(target.members.indexOf(targetMember));
-      } else if (member.special !== 'static') {
-        throw new Error(
-          `Duplicate definition of ${target.name}.${member.name}`
-        );
-      }
-    } else {
-      sourceMembers.add(member);
+    if (
+      targetMembers.has(
+        member.name + (member.special === 'static' ? 'static' : '')
+      )
+    ) {
+      throw new Error(`Duplicate definition of ${target.name}.${member.name}`);
     }
   }
   // Now merge members.
-  target.members.push(...sourceMembers);
+  target.members.push(...source.members);
 };
 
 const flattenIDL = (specIDLs, customIDLs) => {


### PR DESCRIPTION
Reverts foolip/mdn-bcd-collector#2076