### PR TITLE
Fix removal of static members when non-static member is present

### DIFF
--- a/build.js
+++ b/build.js
@@ -276,7 +276,8 @@ const mergeMembers = (target, source) => {
       // If target has static member with same name, remove from target.
       // If source has static member with same name, don't merge into target.
       if (targetMember.special === 'static') {
-        target.members.pop(target.members.indexOf(targetMember));
+        target.members = target.members.filter((m) => m.name !== member.name);
+        sourceMembers.add(member);
       } else if (member.special !== 'static') {
         throw new Error(
           `Duplicate definition of ${target.name}.${member.name}`


### PR DESCRIPTION
This PR is a follow-up to #2076.  It seems as though the `targetMembers` object was treated as a different object than the one in the array, so using `indexOf()` does not work.  This PR tweaks the logic to instead filter out any members with a matching name (and make sure that the correct member was actually added).