### PR TITLE
Fix insecure context warning

### DIFF
--- a/app.js
+++ b/app.js
@@ -77,7 +77,7 @@ const cookieSession = (req, res, next) => {
 };
 
 const checkIfSecure = (req, _, next) => {
-  app.locals.secure = req.secure;
+  app.locals.secure = req.protocol == 'https';
   next();
 };
 


### PR DESCRIPTION
This PR fixes the `not using HTTPS` warning.  Apparently `req.secure` was not set to `true` even when using HTTPS.
