### PR TITLE
Add overrides for api.FontFaceSetLoadEvent

### DIFF
--- a/overrides.json
+++ b/overrides.json
@@ -19,6 +19,6 @@
     false
   ],
   "https://github.com/mdn/browser-compat-data/pull/17365#issuecomment-1216459968",
-  ["api.FontFaceSetLoadEvent", "chrome", "35", true],
-  ["api.FontFaceSetLoadEvent.fontfaces", "chrome", "35", true]
+  ["api.FontFaceSetLoadEvent", "chrome", "35-57", true],
+  ["api.FontFaceSetLoadEvent.fontfaces", "chrome", "35-57", true]
 ]

--- a/overrides.json
+++ b/overrides.json
@@ -17,5 +17,8 @@
     "chrome",
     "60",
     false
-  ]
+  ],
+  "https://github.com/mdn/browser-compat-data/pull/17365#issuecomment-1216459968",
+  ["api.FontFaceSetLoadEvent", "chrome", "35", true],
+  ["api.FontFaceSetLoadEvent.fontfaces", "chrome", "35", true]
 ]


### PR DESCRIPTION
This PR adds overrides for `api.FontFaceSetLoadEvent` in response to https://github.com/mdn/browser-compat-data/pull/17365.
