### PR TITLE
Update template compat statement for add-new-bcd

### DIFF
--- a/add-new-bcd.ts
+++ b/add-new-bcd.ts
@@ -31,17 +31,18 @@ const template = {
   __compat: {
     support: {
       chrome: {version_added: null},
-      chrome_android: {version_added: null},
-      edge: {version_added: null},
+      chrome_android: 'mirror',
+      edge: 'mirror',
       firefox: {version_added: null},
-      firefox_android: {version_added: null},
-      ie: {version_added: null},
-      opera: {version_added: null},
-      opera_android: {version_added: null},
+      firefox_android: 'mirror',
+      ie: {version_added: false},
+      oculus: 'mirror',
+      opera: 'mirror',
+      opera_android: 'mirror',
       safari: {version_added: null},
-      safari_ios: {version_added: null},
-      samsunginternet_android: {version_added: null},
-      webview_android: {version_added: null}
+      safari_ios: 'mirror',
+      samsunginternet_android: 'mirror',
+      webview_android: 'mirror'
     },
     status: {experimental: false, standard_track: true, deprecated: false}
   }


### PR DESCRIPTION
This PR updates the template for the `add-new-bcd` script to automatically mirror derivative browsers, including Oculus, and set IE to false for new features.