### PR TITLE
Don't add new BCD for features that have already been removed

### DIFF
--- a/add-new-bcd.ts
+++ b/add-new-bcd.ts
@@ -107,7 +107,7 @@ export const traverseFeatures = async (
         for (const statements of Object.values(support)) {
           const supported = (
             Array.isArray(statements) ? statements : [statements]
-          ).some((s) => s.version_added);
+          ).some((s) => s.version_added && !s.version_removed);
           if (supported) {
             await writeFile(thisIdent, obj[i]);
             break;


### PR DESCRIPTION
This PR updates the `add-new-bcd` script to omit adding any features that have been removed from all browsers.  Since they'll eventually be removed again from BCD, there's no point to adding them in the first place.