### PR TITLE
Allow for version ranges for overrides

### DIFF
--- a/unittest/unit/bcd.test.js
+++ b/unittest/unit/bcd.test.js
@@ -117,6 +117,9 @@ export default {
       },
       'font-face': {
         __compat: {support: {chrome: {version_added: null}}}
+      },
+      'font-style': {
+        __compat: {support: {chrome: {version_added: null}}}
       }
     }
   },

--- a/unittest/unit/find-missing-features.js
+++ b/unittest/unit/find-missing-features.js
@@ -35,6 +35,7 @@ describe('find-missing-features', () => {
         'api.SuperNewInterface',
         'css.properties.font-family',
         'css.properties.font-face',
+        'css.properties.font-style',
         'javascript.builtins.Array',
         'javascript.builtins.Date'
       ]);
@@ -60,6 +61,7 @@ describe('find-missing-features', () => {
         'api.SuperNewInterface',
         'css.properties.font-family',
         'css.properties.font-face',
+        'css.properties.font-style',
         'javascript.builtins.Array',
         'javascript.builtins.Date'
       ]);
@@ -72,7 +74,7 @@ describe('find-missing-features', () => {
     });
 
     it('collector <- bcd', () => {
-      assert.deepEqual(getMissing(bcd, tests), {
+      const expected = {
         missingEntries: [
           'api.AbortController.AbortController',
           'api.AbortController.abort',
@@ -87,10 +89,24 @@ describe('find-missing-features', () => {
           'api.RemovedInterface',
           'api.SuperNewInterface',
           'css.properties.font-face',
+          'css.properties.font-style',
           'javascript.builtins.Date'
         ],
-        total: 18
-      });
+        total: 19
+      };
+
+      assert.deepEqual(getMissing(bcd, tests), expected);
+
+      assert.isTrue(console.log.notCalled);
+
+      // Unknown direction defaults to collector <- bcd
+      assert.deepEqual(getMissing(bcd, tests, 'foo-from-bar'), expected);
+
+      assert.isTrue(
+        console.log.calledWith(
+          "Direction 'foo-from-bar' is unknown; defaulting to collector <- bcd"
+        )
+      );
     });
 
     it('bcd <- collector', () => {
@@ -136,9 +152,10 @@ describe('find-missing-features', () => {
           'api.RemovedInterface',
           'api.SuperNewInterface',
           'css.properties.font-face',
+          'css.properties.font-style',
           'javascript.builtins.Date'
         ],
-        total: 18
+        total: 19
       });
 
       assert.isTrue(

--- a/unittest/unit/overrides.test.json
+++ b/unittest/unit/overrides.test.json
@@ -1,6 +1,7 @@
 [
   "Test overrides",
-  ["css.properties.font-family", "safari", "5.1", false, ""],
-  ["css.properties.font-family", "chrome", "83", false, ""],
-  ["css.properties.font-face", "chrome", "*", null, ""]
+  ["css.properties.font-family", "safari", "5.1", false],
+  ["css.properties.font-family", "chrome", "83", false],
+  ["css.properties.font-face", "chrome", "*", null],
+  ["css.properties.font-style", "chrome", "82-84", false]
 ]

--- a/unittest/unit/update-bcd.ts
+++ b/unittest/unit/update-bcd.ts
@@ -91,6 +91,11 @@ const reports: Report[] = [
           name: 'css.properties.font-face',
           exposure: 'Window',
           result: true
+        },
+        {
+          name: 'css.properties.font-style',
+          exposure: 'Window',
+          result: true
         }
       ]
     },
@@ -171,6 +176,11 @@ const reports: Report[] = [
           name: 'css.properties.font-face',
           exposure: 'Window',
           result: true
+        },
+        {
+          name: 'css.properties.font-style',
+          exposure: 'Window',
+          result: true
         }
       ]
     },
@@ -243,6 +253,11 @@ const reports: Report[] = [
         },
         {
           name: 'css.properties.font-face',
+          exposure: 'Window',
+          result: true
+        },
+        {
+          name: 'css.properties.font-style',
           exposure: 'Window',
           result: true
         }
@@ -342,7 +357,8 @@ describe('BCD updater', () => {
           ['api.RemovedInterface', true],
           ['api.SuperNewInterface', false],
           ['css.properties.font-family', true],
-          ['css.properties.font-face', true]
+          ['css.properties.font-face', true],
+          ['css.properties.font-style', true]
         ])
       );
     });
@@ -363,7 +379,8 @@ describe('BCD updater', () => {
           ['api.RemovedInterface', false],
           ['api.SuperNewInterface', false],
           ['css.properties.font-family', true],
-          ['css.properties.font-face', true]
+          ['css.properties.font-face', true],
+          ['css.properties.font-style', true]
         ])
       );
     });
@@ -577,6 +594,20 @@ describe('BCD updater', () => {
                 ])
               ]
             ])
+          ],
+          [
+            'css.properties.font-style',
+            new Map([
+              [
+                'chrome',
+                new Map([
+                  ['82', false],
+                  ['83', false],
+                  ['84', false],
+                  ['85', true]
+                ])
+              ]
+            ])
           ]
         ])
       );
@@ -629,7 +660,8 @@ describe('BCD updater', () => {
         chrome: [{version_added: false}]
       },
       'css.properties.font-family': {chrome: [{version_added: '84'}]},
-      'css.properties.font-face': {chrome: []}
+      'css.properties.font-face': {chrome: []},
+      'css.properties.font-style': {chrome: [{version_added: '85'}]}
     };
 
     const supportMatrix = getSupportMatrix(reports, bcd.browsers, overrides);
@@ -804,6 +836,9 @@ describe('BCD updater', () => {
             },
             'font-face': {
               __compat: {support: {chrome: {version_added: null}}}
+            },
+            'font-style': {
+              __compat: {support: {chrome: {version_added: '85'}}}
             }
           }
         },

--- a/update-bcd.ts
+++ b/update-bcd.ts
@@ -188,11 +188,25 @@ export const getSupportMatrix = (
     if (!versionMap) {
       continue;
     }
+
     if (version === '*') {
+      // All versions of a browser
       for (const v of versionMap.keys()) {
         versionMap.set(v, supported);
       }
+    } else if (version.includes('-')) {
+      // Browser versions between x and y (inclusive)
+      const versions = version.split('-');
+      for (const v of versionMap.keys()) {
+        if (
+          compareVersions.compare(versions[0], v, '<=') &&
+          compareVersions.compare(versions[1], v, '>=')
+        ) {
+          versionMap.set(v, supported);
+        }
+      }
     } else {
+      // Single browser versions
       versionMap.set(version, supported);
     }
   }


### PR DESCRIPTION
This PR adds the ability to provide a version range for overrides (ex. `xx-yy`).  This should help with #2239.