### PR TITLE
Extend script to update BCD w/results from Oculus

### DIFF
--- a/ua-parser.js
+++ b/ua-parser.js
@@ -37,6 +37,9 @@ const parseUA = (userAgent, browsers) => {
     case 'mobile_safari':
       data.browser.id = 'safari';
       break;
+    case 'oculus_browser':
+      data.browser.id = 'oculus';
+      break;
     case 'samsung_browser':
       data.browser.id = 'samsunginternet';
       break;


### PR DESCRIPTION
The `us-parser-js` module identifies the Oculus browser with the name
"Oculus Browser," while the BCD project refers to the browser as
"oculus." Extend the custom parsing logic to perform this translation so
that results captured from the Oculus browser are properly integrated
into BCD.