### PR TITLE
Disable the unsecure warning for now

### DIFF
--- a/views/index.ejs
+++ b/views/index.ejs
@@ -39,7 +39,6 @@ See LICENSE.txt for copyright details
     <% } %>
   </form>
   <%- include('browserinfo') %>
-  <%- include('unsecurewarning') %>
 </div>
 
 <div id="supported-browsers">


### PR DESCRIPTION
The unsecure warning is still displaying even when it shouldn't.  I have a feeling this may be an issue around GAE.  CC @foolip