### PR TITLE
Correct required version of Node.js

### DIFF
--- a/README.md
+++ b/README.md
@@ -12,7 +12,7 @@ This project is © 2020-2022 Google LLC, Mozilla Corporation and Gooborg Studios
 
 ## Setup
 
-This project requires Node.js 16 or greater.
+This project requires Node.js 16.15.0 or greater.
 
 ```sh
 npm install

--- a/package.json
+++ b/package.json
@@ -10,7 +10,7 @@
     "url": "https://github.com/foolip/mdn-bcd-collector.git"
   },
   "engines": {
-    "node": ">=16"
+    "node": ">=16.15.0"
   },
   "scripts": {
     "prepare": "node scripts.js prepare",


### PR DESCRIPTION
This project relies on JSON modules, and that functionality was made
available to Node.js projects in version 16.15.0 [1]. The code cannot be
executed with any earlier release of Node.js (see the sample terminal
output below). Update the project documentation to specify this
requirement.

    $ node --version
    v16.14.2
    $ npm start

    > mdn-bcd-collector@6.1.2 start
    > node app.js

    node:internal/errors:464
        ErrorCaptureStackTrace(err);
        ^

    TypeError [ERR_UNKNOWN_FILE_EXTENSION]: Unknown file extension ".json" for /tmp/mdn-bcd-collector/node_modules/@mdn/browser-compat-data/data.json
        at new NodeError (node:internal/errors:371:5)
        at Object.getFileProtocolModuleFormat [as file:] (node:internal/modules/esm/get_format:87:11)
        at defaultGetFormat (node:internal/modules/esm/get_format:102:38)
        at defaultLoad (node:internal/modules/esm/load:21:14)
        at ESMLoader.load (node:internal/modules/esm/loader:359:26)
        at ESMLoader.moduleProvider (node:internal/modules/esm/loader:280:58)
        at new ModuleJob (node:internal/modules/esm/module_job:66:26)
        at ESMLoader.#createModuleJob (node:internal/modules/esm/loader:297:17)
        at ESMLoader.getModuleJob (node:internal/modules/esm/loader:261:34)
        at async ModuleWrap.<anonymous> (node:internal/modules/esm/module_job:81:21) {
      code: 'ERR_UNKNOWN_FILE_EXTENSION'
    }

    $ node --version
    v16.15.0
    $ npm start

    > mdn-bcd-collector@6.1.2 start
    > node app.js

    (node:22859) ExperimentalWarning: Importing JSON modules is an experimental feature. This feature could change at any time
    (Use `node --trace-warnings ...` to show where the warning was created)
    info: Listening on port 8080 (HTTP)
    info: Press Ctrl+C to quit.

[1] https://github.com/nodejs/node/blob/main/doc/changelogs/CHANGELOG_V16.md#2022-04-26-version-16150-gallium-lts-danielleadams