### PR TITLE
Correct reference to project license

### DIFF
--- a/README.md
+++ b/README.md
@@ -8,7 +8,7 @@ See [DESIGN.md](./DESIGN.md) for details of how this service works.
 
 ## Copyright
 
-This project is © 2020-2022 Google LLC, Mozilla Corporation and Gooborg Studios, Apache License 2.0. See LICENSE.txt for more details.
+This project is © 2020-2022 Google LLC, Mozilla Corporation and Gooborg Studios, Apache License 2.0. See the LICENSE file for more details.
 
 ## Setup
 

--- a/add-new-bcd.ts
+++ b/add-new-bcd.ts
@@ -3,7 +3,7 @@
 // Adds missing entries to BCD that have support in some browser version
 //
 // © Gooborg Studios, Google LLC
-// See LICENSE.txt for copyright details
+// See the LICENSE file for copyright details
 //
 
 import {Identifier} from '@mdn/browser-compat-data/types';

--- a/app.js
+++ b/app.js
@@ -3,7 +3,7 @@
 // Main app backend for the website
 //
 // © Google LLC, Gooborg Studios
-// See LICENSE.txt for copyright details
+// See the LICENSE file for copyright details
 //
 
 import https from 'node:https';

--- a/app.yaml
+++ b/app.yaml
@@ -3,7 +3,7 @@
 # Google App Engine configuration for the collector
 #
 # © Google LLC, Gooborg Studios
-# See LICENSE.txt for copyright details
+# See the LICENSE file for copyright details
 #
 
 runtime: nodejs16

--- a/build.js
+++ b/build.js
@@ -3,7 +3,7 @@
 // Script to build all of the tests from the IDL and custom CSS/JS files
 //
 // © Google LLC, Gooborg Studios, Mozilla Corporation, Apple Inc
-// See LICENSE.txt for copyright details
+// See the LICENSE file for copyright details
 //
 
 import path from 'node:path';

--- a/custom-idl/index.js
+++ b/custom-idl/index.js
@@ -3,7 +3,7 @@
 // Loader script to load the custom IDL to supplement @webref/idl
 //
 // © Google LLC, Gooborg Studios
-// See LICENSE.txt for copyright details
+// See the LICENSE file for copyright details
 //
 
 import fs from 'fs-extra';

--- a/custom-tests.yaml
+++ b/custom-tests.yaml
@@ -3,7 +3,7 @@
 # Custom test code to override auto-generated test code
 #
 # © Gooborg Studios, Mozilla Corporation, Google LLC, Apple Inc
-# See LICENSE.txt for copyright details
+# See the LICENSE file for copyright details
 #
 
 # Custom tests here also need to be in @webref/idl or custom-idl/, see

--- a/exporter.js
+++ b/exporter.js
@@ -4,7 +4,7 @@
 // web service into JSON files that can be used by update-bcd.ts.
 //
 // © Google LLC, Gooborg Studios
-// See LICENSE.txt for copyright details
+// See the LICENSE file for copyright details
 //
 
 import crypto from 'node:crypto';

--- a/find-missing-features.ts
+++ b/find-missing-features.ts
@@ -3,7 +3,7 @@
 // Script to find features that are in the collector or BCD but not the other
 //
 // © Gooborg Studios, Google LLC
-// See LICENSE.txt for copyright details
+// See the LICENSE file for copyright details
 //
 
 import {CompatData, CompatStatement} from '@mdn/browser-compat-data/types';

--- a/find-missing-results.ts
+++ b/find-missing-results.ts
@@ -3,7 +3,7 @@
 // Script to find browser versions that don't have a result file in mdn-bcd-results
 //
 // © Gooborg Studios
-// See LICENSE.txt for copyright details
+// See the LICENSE file for copyright details
 //
 
 import {CompatData} from '@mdn/browser-compat-data/types';

--- a/logger.js
+++ b/logger.js
@@ -3,7 +3,7 @@
 // Logging output module to log to either the console or GAE cloud
 //
 // © Google LLC, Gooborg Studios
-// See LICENSE.txt for copyright details
+// See the LICENSE file for copyright details
 //
 
 import winston from 'winston';

--- a/release.js
+++ b/release.js
@@ -3,7 +3,7 @@
 // Script to perform a new mdn-bcd-collector release
 //
 // © Gooborg Studios, Google LLC
-// See LICENSE.txt for copyright details
+// See the LICENSE file for copyright details
 //
 
 import chalk from 'chalk-template';

--- a/result-stats.ts
+++ b/result-stats.ts
@@ -3,7 +3,7 @@
 // Script to print statistics about a results file
 //
 // © Gooborg Studios
-// See LICENSE.txt for copyright details
+// See the LICENSE file for copyright details
 //
 
 import path from 'node:path';

--- a/results.js
+++ b/results.js
@@ -3,7 +3,7 @@
 // Module to parse and handle test results
 //
 // © Google LLC, Gooborg Studios
-// See LICENSE.txt for copyright details
+// See the LICENSE file for copyright details
 //
 
 const parseShortString = (value, desc) => {

--- a/scripts.js
+++ b/scripts.js
@@ -3,7 +3,7 @@
 // A main entry point to run various scripts in a cross-platform friendly way
 //
 // © Mozilla Corporation, Google LLC, Gooborg Studios
-// See LICENSE.txt for copyright details
+// See the LICENSE file for copyright details
 //
 
 import fs from 'node:fs';

--- a/selenium-keepalive.js
+++ b/selenium-keepalive.js
@@ -3,7 +3,7 @@
 // Sets HTTP keep-alive for faster Selenium tests
 //
 // © BrowserStack, Gooborg Studios
-// See LICENSE.txt for copyright details
+// See the LICENSE file for copyright details
 //
 
 import http from 'http';

--- a/selenium.js
+++ b/selenium.js
@@ -3,7 +3,7 @@
 // Script to collect results from various browsers using Selenium webdriver
 //
 // © Gooborg Studios, Google LLC
-// See LICENSE.txt for copyright details
+// See the LICENSE file for copyright details
 //
 
 import path from 'node:path';

--- a/static/resources/custom-tests/api/AudioWorkletNode/WhiteNoiseProcessor.js
+++ b/static/resources/custom-tests/api/AudioWorkletNode/WhiteNoiseProcessor.js
@@ -4,7 +4,7 @@
 // https://developer.mozilla.org/en-US/docs/Web/API/AudioWorkletNode
 //
 // © Mozilla Corporation, Gooborg Studios
-// See LICENSE.txt for copyright details
+// See the LICENSE file for copyright details
 //
 
 /* global AudioWorkletProcessor, registerProcessor */

--- a/static/resources/harness.js
+++ b/static/resources/harness.js
@@ -3,7 +3,7 @@
 // Helpers and functions for running the tests in the browser
 //
 // © Google LLC, Gooborg Studios, Mozilla Corporation, Apple Inc
-// See LICENSE.txt for copyright details
+// See the LICENSE file for copyright details
 //
 
 /* global console, document, window, location, navigator, XMLHttpRequest,

--- a/static/resources/serviceworker.js
+++ b/static/resources/serviceworker.js
@@ -3,7 +3,7 @@
 // JavaScript to run tests within service workers
 //
 // © Gooborg Studios, Google LLC
-// See LICENSE.txt for copyright details
+// See the LICENSE file for copyright details
 //
 
 /* global self, caches, Request, Response, bcd */

--- a/static/resources/sharedworker.js
+++ b/static/resources/sharedworker.js
@@ -3,7 +3,7 @@
 // JavaScript to run tests within shared workers
 //
 // © Mozilla Corporation, Gooborg Studios
-// See LICENSE.txt for copyright details
+// See the LICENSE file for copyright details
 //
 
 /* global self, bcd */

--- a/static/resources/worker.js
+++ b/static/resources/worker.js
@@ -3,7 +3,7 @@
 // JavaScript to run tests within workers
 //
 // © Gooborg Studios
-// See LICENSE.txt for copyright details
+// See the LICENSE file for copyright details
 //
 
 /* global self, bcd */

--- a/static/unittest/index.html
+++ b/static/unittest/index.html
@@ -3,7 +3,7 @@ mdn-bcd-collector: static/unittest/index.html
 Unittests for harness.js
 
 © Google LLC, Gooborg Studios
-See LICENSE.txt for copyright details
+See the LICENSE file for copyright details
 -->
 
 <!DOCTYPE html>

--- a/static/unittest/test.js
+++ b/static/unittest/test.js
@@ -3,7 +3,7 @@
 // Unittests for harness.js
 //
 // © Google LLC, Gooborg Studios
-// See LICENSE.txt for copyright details
+// See the LICENSE file for copyright details
 //
 
 /* global mocha, chai, sinon, describe, it, beforeEach, afterEach, window,

--- a/storage.js
+++ b/storage.js
@@ -3,7 +3,7 @@
 // Module to handle temporary storage for the web app, locally or in GAE
 //
 // © Google LLC, Gooborg Studios
-// See LICENSE.txt for copyright details
+// See the LICENSE file for copyright details
 //
 
 import assert from 'node:assert/strict';

--- a/style.scss
+++ b/style.scss
@@ -3,7 +3,7 @@
 // Styling for the web app
 //
 // © Gooborg Studios, Google LLC
-// See LICENSE.txt for copyright details
+// See the LICENSE file for copyright details
 //
 
 @use 'sass:map';

--- a/tests.js
+++ b/tests.js
@@ -3,7 +3,7 @@
 // Module for handling the tests for the web app
 //
 // © Google LLC, Gooborg Studios
-// See LICENSE.txt for copyright details
+// See the LICENSE file for copyright details
 //
 
 import didYouMean from 'didyoumean';

--- a/types/types.d.ts
+++ b/types/types.d.ts
@@ -3,7 +3,7 @@
 // TypeScript definitions for the collector
 //
 // © Gooborg Studios
-// See LICENSE.txt for copyright details
+// See the LICENSE file for copyright details
 //
 
 import {BrowserName} from '@mdn/browser-compat-data/types';

--- a/ua-parser.js
+++ b/ua-parser.js
@@ -3,7 +3,7 @@
 // Module to parse user agent strings and compare them with BCD browser data
 //
 // © Gooborg Studios, Google LLC
-// See LICENSE.txt for copyright details
+// See the LICENSE file for copyright details
 //
 
 import compareVersions from 'compare-versions';

--- a/unittest/app/app.js
+++ b/unittest/app/app.js
@@ -3,7 +3,7 @@
 // Unittest for the main app backend
 //
 // © Gooborg Studios, Google LLC
-// See LICENSE.txt for copyright details
+// See the LICENSE file for copyright details
 //
 
 import chai, {assert, expect} from 'chai';

--- a/unittest/puppeteer/harness.js
+++ b/unittest/puppeteer/harness.js
@@ -3,7 +3,7 @@
 // Unittest for testing harness.js in multiple browsers
 //
 // © Google LLC, Gooborg Studios, Mozilla Corporation
-// See LICENSE.txt for copyright details
+// See the LICENSE file for copyright details
 //
 
 import {fileURLToPath} from 'node:url';

--- a/unittest/unit/bcd.test.js
+++ b/unittest/unit/bcd.test.js
@@ -3,7 +3,7 @@
 // Unittest helper containing pseudo BCD
 //
 // © Gooborg Studios
-// See LICENSE.txt for copyright details
+// See the LICENSE file for copyright details
 //
 
 export default {

--- a/unittest/unit/build.js
+++ b/unittest/unit/build.js
@@ -3,7 +3,7 @@
 // Unittest for the test build script
 //
 // © Google LLC, Gooborg Studios, Apple Inc
-// See LICENSE.txt for copyright details
+// See the LICENSE file for copyright details
 //
 
 import chai, {assert} from 'chai';

--- a/unittest/unit/custom-tests.test.yaml
+++ b/unittest/unit/custom-tests.test.yaml
@@ -3,7 +3,7 @@
 # Unittest helper containing pseudo custom tests
 #
 # © Gooborg Studios
-# See LICENSE.txt for copyright details
+# See the LICENSE file for copyright details
 #
 
 api:

--- a/unittest/unit/exporter.js
+++ b/unittest/unit/exporter.js
@@ -3,7 +3,7 @@
 // Unittest for the results exporter script
 //
 // © Google LLC, Gooborg Studios
-// See LICENSE.txt for copyright details
+// See the LICENSE file for copyright details
 //
 
 import chai, {assert, expect} from 'chai';

--- a/unittest/unit/find-missing-features.js
+++ b/unittest/unit/find-missing-features.js
@@ -3,7 +3,7 @@
 // Unittest for the missing features finder script
 //
 // © Gooborg Studios, Google LLC
-// See LICENSE.txt for copyright details
+// See the LICENSE file for copyright details
 //
 
 import {assert} from 'chai';

--- a/unittest/unit/results.js
+++ b/unittest/unit/results.js
@@ -3,7 +3,7 @@
 // Unittest for the results parsing script
 //
 // © Google LLC, Gooborg Studios
-// See LICENSE.txt for copyright details
+// See the LICENSE file for copyright details
 //
 
 import {assert} from 'chai';

--- a/unittest/unit/storage.js
+++ b/unittest/unit/storage.js
@@ -3,7 +3,7 @@
 // Unittest for the temporary storage handler
 //
 // © Google LLC, Gooborg Studios
-// See LICENSE.txt for copyright details
+// See the LICENSE file for copyright details
 //
 
 import {assert} from 'chai';

--- a/unittest/unit/tests.js
+++ b/unittest/unit/tests.js
@@ -3,7 +3,7 @@
 // Unittest for the Tests class
 //
 // © Google LLC, Gooborg Studios
-// See LICENSE.txt for copyright details
+// See the LICENSE file for copyright details
 //
 
 import {assert} from 'chai';

--- a/unittest/unit/ua-parser.js
+++ b/unittest/unit/ua-parser.js
@@ -3,7 +3,7 @@
 // Unittest for the user agent parser
 //
 // © Gooborg Studios
-// See LICENSE.txt for copyright details
+// See the LICENSE file for copyright details
 //
 
 import {assert} from 'chai';

--- a/unittest/unit/update-bcd.ts
+++ b/unittest/unit/update-bcd.ts
@@ -3,7 +3,7 @@
 // Unittest for the BCD updater script
 //
 // © Google LLC, Gooborg Studios
-// See LICENSE.txt for copyright details
+// See the LICENSE file for copyright details
 //
 
 import {Report} from '../../types/types.js';

--- a/update-bcd.ts
+++ b/update-bcd.ts
@@ -6,7 +6,7 @@
 // for documentation on the approach taken in this script.
 //
 // © Google LLC, Gooborg Studios
-// See LICENSE.txt for copyright details
+// See the LICENSE file for copyright details
 //
 
 import {

--- a/views/error.ejs
+++ b/views/error.ejs
@@ -3,7 +3,7 @@ mdn-bcd-collector: views/error.ejs
 Page to display whenever an error occurs
 
 © Gooborg Studios
-See LICENSE.txt for copyright details
+See the LICENSE file for copyright details
 -->
 
 <%- contentFor('body') %>

--- a/views/export.ejs
+++ b/views/export.ejs
@@ -3,7 +3,7 @@ mdn-bcd-collector: views/export.ejs
 Page to display when exporting test results
 
 © Google LLC, Gooborg Studios
-See LICENSE.txt for copyright details
+See the LICENSE file for copyright details
 -->
 
 <%- contentFor('body') %>

--- a/views/index.ejs
+++ b/views/index.ejs
@@ -3,7 +3,7 @@ mdn-bcd-collector: views/index.ejs
 Website home page
 
 © Google LLC, Gooborg Studios, Mozilla Corporation
-See LICENSE.txt for copyright details
+See the LICENSE file for copyright details
 -->
 
 <%- contentFor('body') %>

--- a/views/layout.ejs
+++ b/views/layout.ejs
@@ -3,7 +3,7 @@ mdn-bcd-collector: views/layout.ejs
 Main page layout
 
 © Gooborg Studios, Google LLC
-See LICENSE.txt for copyright details
+See the LICENSE file for copyright details
 -->
 
 <!DOCTYPE html>

--- a/views/testnotfound.ejs
+++ b/views/testnotfound.ejs
@@ -3,7 +3,7 @@ mdn-bcd-collector: views/testnotfound.ejs
 Page to display when a test isn't found
 
 © Gooborg Studios
-See LICENSE.txt for copyright details
+See the LICENSE file for copyright details
 -->
 
 <%- contentFor('body') %>

--- a/views/tests.ejs
+++ b/views/tests.ejs
@@ -3,7 +3,7 @@ mdn-bcd-collector: views/tests.ejs
 Page for running the specified tests
 
 © Gooborg Studios, Google LLC
-See LICENSE.txt for copyright details
+See the LICENSE file for copyright details
 -->
 
 <%- contentFor('body') %>


### PR DESCRIPTION
This patch was generated from the following command:

    $ git ls-files -z | xargs --null sed -i 's/See LICENSE\.txt/See the LICENSE file/g'