### PR TITLE
Fix custom test for SVGAnimatedRect

### DIFF
--- a/custom-tests.yaml
+++ b/custom-tests.yaml
@@ -1950,7 +1950,7 @@ api:
       var instance = el.preserveAspectRatio;
   SVGAnimatedRect:
     __base: |-
-      <%api.SVGViewElement:el%>
+      <%api.SVGSVGElement:el%>
       var instance = el.viewBox;
   SVGAnimatedString:
     __base: |-


### PR DESCRIPTION
This PR fixes the custom test for the `SVGAnimatedRect` API, following up to https://github.com/mdn/browser-compat-data/pull/17424.
