### PR TITLE
Remove flag data for default-enabled features

### DIFF
--- a/unittest/unit/bcd.test.js
+++ b/unittest/unit/bcd.test.js
@@ -79,6 +79,32 @@ export default {
         }
       }
     },
+    UnflaggedInterface: {
+      __compat: {
+        support: {
+          chrome: [
+            {
+              version_added: '83',
+              flags: {},
+              notes: 'Not supported on Windows XP.'
+            }
+          ]
+        }
+      }
+    },
+    UnprefixedInterface: {
+      __compat: {
+        support: {
+          chrome: [
+            {
+              version_added: '83',
+              prefix: 'webkit',
+              notes: 'Not supported on Windows XP.'
+            }
+          ]
+        }
+      }
+    },
     NullAPI: {
       __compat: {support: {chrome: {version_added: '80'}}}
     },

--- a/unittest/unit/find-missing-features.js
+++ b/unittest/unit/find-missing-features.js
@@ -30,6 +30,8 @@ describe('find-missing-features', () => {
         'api.DummyAPI',
         'api.DummyAPI.dummy',
         'api.ExperimentalInterface',
+        'api.UnflaggedInterface',
+        'api.UnprefixedInterface',
         'api.NullAPI',
         'api.RemovedInterface',
         'api.SuperNewInterface',
@@ -56,6 +58,9 @@ describe('find-missing-features', () => {
         'api.DummyAPI.dummy',
         'api.ExperimentalInterface',
         'api.TryingOutInterface',
+        'api.UnflaggedInterface',
+        'api.UnprefixedInterface',
+        'api.webkitUnprefixedInterface',
         'api.NullAPI',
         'api.RemovedInterface',
         'api.SuperNewInterface',
@@ -85,6 +90,8 @@ describe('find-missing-features', () => {
           'api.DummyAPI',
           'api.DummyAPI.dummy',
           'api.ExperimentalInterface',
+          'api.UnflaggedInterface',
+          'api.UnprefixedInterface',
           'api.NullAPI',
           'api.RemovedInterface',
           'api.SuperNewInterface',
@@ -92,7 +99,7 @@ describe('find-missing-features', () => {
           'css.properties.font-style',
           'javascript.builtins.Date'
         ],
-        total: 19
+        total: 21
       };
 
       assert.deepEqual(getMissing(bcd, tests), expected);
@@ -128,11 +135,13 @@ describe('find-missing-features', () => {
           'api.DummyAPI',
           'api.DummyAPI.dummy',
           'api.ExperimentalInterface',
+          'api.UnflaggedInterface',
+          'api.UnprefixedInterface',
           'api.NullAPI',
           'api.RemovedInterface',
           'api.SuperNewInterface'
         ],
-        total: 14
+        total: 16
       });
     });
 
@@ -148,6 +157,8 @@ describe('find-missing-features', () => {
           'api.DummyAPI',
           'api.DummyAPI.dummy',
           'api.ExperimentalInterface',
+          'api.UnflaggedInterface',
+          'api.UnprefixedInterface',
           'api.NullAPI',
           'api.RemovedInterface',
           'api.SuperNewInterface',
@@ -155,7 +166,7 @@ describe('find-missing-features', () => {
           'css.properties.font-style',
           'javascript.builtins.Date'
         ],
-        total: 19
+        total: 21
       });
 
       assert.isTrue(

--- a/unittest/unit/update-bcd.ts
+++ b/unittest/unit/update-bcd.ts
@@ -68,6 +68,16 @@ const reports: Report[] = [
           result: true
         },
         {
+          name: 'api.UnflaggedInterface',
+          exposure: 'Window',
+          result: null
+        },
+        {
+          name: 'api.UnprefixedInterface',
+          exposure: 'Window',
+          result: null
+        },
+        {
           name: 'api.NullAPI',
           exposure: 'Window',
           result: null
@@ -148,6 +158,16 @@ const reports: Report[] = [
           result: true
         },
         {
+          name: 'api.UnflaggedInterface',
+          exposure: 'Window',
+          result: true
+        },
+        {
+          name: 'api.UnprefixedInterface',
+          exposure: 'Window',
+          result: true
+        },
+        {
           name: 'api.NewInterfaceNotInBCD',
           exposure: 'Window',
           result: false
@@ -223,6 +243,16 @@ const reports: Report[] = [
         },
         {
           name: 'api.ExperimentalInterface',
+          exposure: 'Window',
+          result: true
+        },
+        {
+          name: 'api.UnflaggedInterface',
+          exposure: 'Window',
+          result: true
+        },
+        {
+          name: 'api.UnprefixedInterface',
           exposure: 'Window',
           result: true
         },
@@ -353,6 +383,8 @@ describe('BCD updater', () => {
           ['api.AudioContext.close', false],
           ['api.DeprecatedInterface', true],
           ['api.ExperimentalInterface', true],
+          ['api.UnflaggedInterface', null],
+          ['api.UnprefixedInterface', null],
           ['api.NullAPI', null],
           ['api.RemovedInterface', true],
           ['api.SuperNewInterface', false],
@@ -374,6 +406,8 @@ describe('BCD updater', () => {
           ['api.AudioContext.close', false],
           ['api.DeprecatedInterface', true],
           ['api.ExperimentalInterface', true],
+          ['api.UnflaggedInterface', true],
+          ['api.UnprefixedInterface', true],
           ['api.NewInterfaceNotInBCD', false],
           ['api.NullAPI', null],
           ['api.RemovedInterface', false],
@@ -505,6 +539,34 @@ describe('BCD updater', () => {
                 new Map([
                   ['82', null],
                   ['83', true],
+                  ['84', true],
+                  ['85', true]
+                ])
+              ]
+            ])
+          ],
+          [
+            'api.UnflaggedInterface',
+            new Map([
+              [
+                'chrome',
+                new Map([
+                  ['82', null],
+                  ['83', null],
+                  ['84', true],
+                  ['85', true]
+                ])
+              ]
+            ])
+          ],
+          [
+            'api.UnprefixedInterface',
+            new Map([
+              [
+                'chrome',
+                new Map([
+                  ['82', null],
+                  ['83', null],
                   ['84', true],
                   ['85', true]
                 ])
@@ -648,6 +710,8 @@ describe('BCD updater', () => {
         chrome: [{version_added: '0> ≤83', version_removed: '85'}]
       },
       'api.ExperimentalInterface': {chrome: [{version_added: '0> ≤83'}]},
+      'api.UnflaggedInterface': {chrome: [{version_added: '0> ≤84'}]},
+      'api.UnprefixedInterface': {chrome: [{version_added: '0> ≤84'}]},
       'api.NewInterfaceNotInBCD': {chrome: [{version_added: '85'}]},
       'api.NullAPI': {chrome: []},
       'api.RemovedInterface': {
@@ -787,6 +851,31 @@ describe('BCD updater', () => {
                     version_added: '50',
                     version_removed: '70',
                     alternative_name: 'TryingOutInterface',
+                    notes: 'Not supported on Windows XP.'
+                  }
+                ]
+              }
+            }
+          },
+          UnflaggedInterface: {
+            __compat: {
+              support: {
+                chrome: {
+                  version_added: '≤84'
+                }
+              }
+            }
+          },
+          UnprefixedInterface: {
+            __compat: {
+              support: {
+                chrome: [
+                  {
+                    version_added: '≤84'
+                  },
+                  {
+                    version_added: '83',
+                    prefix: 'webkit',
                     notes: 'Not supported on Windows XP.'
                   }
                 ]

--- a/update-bcd.ts
+++ b/update-bcd.ts
@@ -363,10 +363,18 @@ export const update = (
           inferredStatement.version_added =
             inferredStatement.version_added.replace('0> ', '');
         }
-        allStatements.unshift(inferredStatement);
+        // Remove flag data for features which are enabled by default.
+        //
+        // See https://github.com/mdn/browser-compat-data/pull/16637
+        const nonFlagStatements = allStatements.filter(
+          (statement) => !('flags' in statement)
+        );
         entry.__compat.support[browser] =
-          allStatements.length === 1 ? allStatements[0] : allStatements;
+          nonFlagStatements.length === 0
+            ? inferredStatement
+            : [inferredStatement].concat(nonFlagStatements);
         modified = true;
+
         continue;
       }
 


### PR DESCRIPTION
A recent change in the BCD project policy stipulates that information
about feature flags should be removed whenever a feature becomes
supported by default [1]. Modify the `update-bcd` script to honor the
new policy whenever new test results trigger that condition.

Include a test for the case where positive test results are added for a
feature that is already supported via a prefix. This patch intentionally
doesn't change that behavior because prefixes "are part of the web
platform that web developers have to deal with." [2] The test is to
prevent regressions and emphasize the intention.

[1] https://github.com/mdn/browser-compat-data/pull/16637
[2] https://matrix.to/#/!cGYYDEJwjktUBMSTQT:mozilla.org/$JTWeMpzNMULBTZcx-pWFnUNX7DIzE5xPySd70Kpr-MU?via=mozilla.org&via=matrix.org&via=igalia.com),