### PR TITLE
Mention what the actual constructor name is if it doesn't match expected

### DIFF
--- a/static/resources/harness.js
+++ b/static/resources/harness.js
@@ -133,32 +133,36 @@
       }
       result.result = true;
     } catch (err) {
-      if (stringIncludes(err.message, [
-            'Illegal constructor',
-            'is not a constructor',
-            'Function expected',
-            'is not defined',
-            "Can't find variable",
-            'NOT_SUPPORTED_ERR'
-          ])) {
+      if (
+        stringIncludes(err.message, [
+          'Illegal constructor',
+          'is not a constructor',
+          'Function expected',
+          'is not defined',
+          "Can't find variable",
+          'NOT_SUPPORTED_ERR'
+        ])
+      ) {
         result.result = false;
-      } else if (stringIncludes(err.message, [
-                   'Not enough arguments',
-                   'argument required',
-                   'arguments required',
-                   'Argument not optional',
-                   "Arguments can't be empty",
-                   'undefined is not an object',
-                   'must be an object',
-                   'WRONG_ARGUMENTS_ERR',
-                   'are both null',
-                   'must be specified',
-                   'is not a valid custom element constructor',
-                   'constructor takes a',
-                   'is not a valid argument count',
-                   'Missing required',
-                   'Cannot read property'
-                 ])) {
+      } else if (
+        stringIncludes(err.message, [
+          'Not enough arguments',
+          'argument required',
+          'arguments required',
+          'Argument not optional',
+          "Arguments can't be empty",
+          'undefined is not an object',
+          'must be an object',
+          'WRONG_ARGUMENTS_ERR',
+          'are both null',
+          'must be specified',
+          'is not a valid custom element constructor',
+          'constructor takes a',
+          'is not a valid argument count',
+          'Missing required',
+          'Cannot read property'
+        ])
+      ) {
         // If it failed to construct and it's not illegal or just needs
         // more arguments, the constructor's good
         result.result = true;
@@ -177,8 +181,10 @@
       return false;
     }
 
-    if (!instance.constructor.name &&
-        Object.prototype.toString.call(instance) === '[object Object]') {
+    if (
+      !instance.constructor.name &&
+      Object.prototype.toString.call(instance) === '[object Object]'
+    ) {
       return {
         result: null,
         message:
@@ -190,9 +196,16 @@
       names = [names];
     }
 
+    var actualName = instance.constructor.name;
+
+    if (!actualName || actualName == 'Function.prototype') {
+      actualName = Object.prototype.toString
+        .call(instance)
+        .replace(/\[object (.*)\]/g, '$1');
+    }
+
     for (var i = 0; i < names.length; i++) {
-      if (instance.constructor.name === names[i] ||
-          Object.prototype.toString.call(instance) === '[object ' + names[i] + ']') {
+      if (actualName === names[i]) {
         return true;
       }
     }
@@ -200,8 +213,10 @@
     return {
       result: false,
       message:
-        'Instance prototype does not match accepted names (' +
+        'Instance prototype does not match accepted names (expected ' +
         names.join(', ') +
+        '; got ' +
+        actualName +
         ')'
     };
   }
@@ -303,8 +318,10 @@
       result.result = null;
       result.message = 'threw ' + stringify(value);
     } else if (value && typeof value === 'object') {
-      if ('name' in value &&
-          stringIncludes(value.name, ['NS_ERROR', 'NotSupported'])) {
+      if (
+        'name' in value &&
+        stringIncludes(value.name, ['NS_ERROR', 'NotSupported'])
+      ) {
         result.result = null;
         result.message = 'threw ' + stringify(value.message);
       } else if ('result' in value) {
@@ -372,9 +389,11 @@
     try {
       var value = eval(test.code);
 
-      if (typeof value === 'object' &&
-          value !== null &&
-          typeof value.then === 'function') {
+      if (
+        typeof value === 'object' &&
+        value !== null &&
+        typeof value.then === 'function'
+      ) {
         value.then(success, fail);
         value['catch'](fail);
       } else if (value !== 'callback') {
@@ -418,10 +437,12 @@
         }
         if (remaining.length > 0 && remaining.length <= 20) {
           consoleLog('Remaining (' + result.info.exposure + '): ' + remaining);
-        } else if ((remaining.length >= 50 &&
-                     remaining.length < 200 &&
-                     remaining.length % 50 == 0) ||
-                   (remaining.length >= 200 && remaining.length % 500 == 0)) {
+        } else if (
+          (remaining.length >= 50 &&
+            remaining.length < 200 &&
+            remaining.length % 50 == 0) ||
+          (remaining.length >= 200 && remaining.length % 500 == 0)
+        ) {
           consoleLog(
             'Remaining (' +
               result.info.exposure +


### PR DESCRIPTION
This PR updates the `testObjectName` method of `harness.js` to report what the actual name of an object is when it doesn't match an expected name.
