### PR TITLE
Set experimental to "true" for new features by default

### DIFF
--- a/add-new-bcd.ts
+++ b/add-new-bcd.ts
@@ -44,7 +44,7 @@ const template = {
       samsunginternet_android: 'mirror',
       webview_android: 'mirror'
     },
-    status: {experimental: false, standard_track: true, deprecated: false}
+    status: {experimental: true, standard_track: true, deprecated: false}
   }
 };
 


### PR DESCRIPTION
This PR updates the `add-new-bcd` script to set `experimental` to `true` by default.  If experimental should be false, the fix script will take care of it.
