### PR TITLE
Ignore IE by default in find-missing-results script

### DIFF
--- a/find-missing-results.ts
+++ b/find-missing-results.ts
@@ -37,7 +37,10 @@ const generateReportMap = (allResults: boolean) => {
   const result: ReportMap = {};
 
   for (const [browserKey, browserData] of Object.entries(browsers)) {
-    if (!allResults && ['nodejs', 'deno', 'oculus'].includes(browserKey)) {
+    if (
+      !allResults &&
+      ['ie', 'nodejs', 'deno', 'oculus'].includes(browserKey)
+    ) {
       continue;
     }
 
@@ -47,12 +50,7 @@ const generateReportMap = (allResults: boolean) => {
     result[browserKey] = releases.sort(compareVersionsSort);
 
     if (!allResults) {
-      if (browserKey == 'ie') {
-        // Ignore super old IE releases
-        result[browserKey] = result[browserKey].filter((v) =>
-          compareVersions(v, '6', '>=')
-        );
-      } else if (browserKey == 'safari') {
+      if (browserKey == 'safari') {
         // Ignore super old Safari releases
         result[browserKey] = result[browserKey].filter((v) =>
           compareVersions(v, '4', '>=')


### PR DESCRIPTION
This PR updates the `find-missing-results` script to ignore IE by default, since we aren't caring about IE data nearly as much.
