### PR TITLE
Avoid generating tests for [HTMLConstructor] constructors

### DIFF
--- a/build.js
+++ b/build.js
@@ -395,9 +395,14 @@ const flattenMembers = (iface) => {
   for (const member of iface.members.filter((member) => !member.name)) {
     switch (member.type) {
       case 'constructor':
-        // Test generation doesn't use constructor arguments, so they aren't
-        // copied
-        members.push({name: iface.name, type: 'constructor'});
+        // Don't generate tests for [HTMLConstructor]. These are for custom
+        // elements, not for constructor the elements themselves:
+        // https://html.spec.whatwg.org/multipage/dom.html#html-element-constructors
+        if (!getExtAttr(member, 'HTMLConstructor')) {
+          // Test generation doesn't use constructor arguments, so they aren't
+          // copied
+          members.push({name: iface.name, type: 'constructor'});
+        }
         break;
       case 'iterable':
         members.push(

--- a/unittest/unit/build.js
+++ b/unittest/unit/build.js
@@ -984,6 +984,23 @@ describe('build', () => {
       });
     });
 
+    it('interface with [HTMLConstructor] constructor operation', () => {
+      const ast = WebIDL2.parse(
+        `[Exposed=Window]
+           interface HTMLButtonElement {
+             [HTMLConstructor] constructor();
+           };`
+      );
+
+      assert.deepEqual(buildIDLTests(ast, [], scopes), {
+        'api.HTMLButtonElement': {
+          code: '"HTMLButtonElement" in self',
+          exposure: ['Window']
+        }
+        // no constructor test
+      });
+    });
+
     it('iterable interface', () => {
       const ast = WebIDL2.parse(
         `[Exposed=Window]


### PR DESCRIPTION
This is to avoid adding these features to BCD:
https://github.com/mdn/browser-compat-data/pull/17651
