### PR TITLE
Support testing document.all

### DIFF
--- a/custom-tests.yaml
+++ b/custom-tests.yaml
@@ -949,7 +949,6 @@ api:
     __base: var instance = history;
   HTMLAllCollection:
     __base: |-
-      // XXX document.all seems to be falsy, at least in Chrome
       var instance = document.all;
     __test: return bcd.testObjectName(instance, 'HTMLAllCollection');
   HTMLAnchorElement:

--- a/static/resources/harness.js
+++ b/static/resources/harness.js
@@ -177,7 +177,9 @@
   }
 
   function testObjectName(instance, names) {
-    if (!instance) {
+    // Do not reject "falsey" values generally in order to support
+    // `document.all`
+    if (instance === null || instance === undefined) {
       return false;
     }
 


### PR DESCRIPTION
I validated this by running the collector locally and comparing the impact it has on the results. Only the results for `document.all` were affected, however, I have not generated a self-signed certificate, so this is only a limited view.