### PR TITLE
Add back MessageEvent.userActivation custom IDL

### DIFF
--- a/custom-idl/html.idl
+++ b/custom-idl/html.idl
@@ -614,6 +614,11 @@ partial interface Location {
   stringifier;
 };
 
+partial interface MessageEvent {
+  // https://github.com/whatwg/html/pull/4009
+  readonly attribute UserActivation? userActivation;
+};
+
 partial interface MouseEvent {
   // https://github.com/whatwg/html/pull/1942
   readonly attribute DOMString? region;


### PR DESCRIPTION
It's supported in Chrome:
https://mdn-bcd-collector.appspot.com/tests/api/MessageEvent/userActivation
