### PR TITLE
Remove IDL for proprietary IDBDatabase.createMutableFile

### DIFF
--- a/custom-idl/IndexedDB.idl
+++ b/custom-idl/IndexedDB.idl
@@ -1,8 +1,3 @@
-partial interface IDBDatabase {
-  // https://github.com/mozilla/gecko-dev/blob/0dfbe5a699cc6c73cf8c14d1aa10ba10ef3ec8fa/dom/webidl/IDBDatabase.webidl#L43
-  IDBRequest createMutableFile(DOMString name, optional DOMString type);
-};
-
 [Exposed=(Window,Worker)] interface IDBDatabaseException {};
 [Exposed=(Window,Worker)] interface IDBEnvironment {};
 


### PR DESCRIPTION
This PR removes the IDL definitions for `IDBDatabase.createMutableFile`, which is a proprietary Gecko feature that isn't already in BCD and shouldn't be added to BCD as a result.
