### PR TITLE
Remove IDL for SVG features removed from BCD

### DIFF
--- a/custom-idl/SVG.idl
+++ b/custom-idl/SVG.idl
@@ -20,10 +20,7 @@ interface SVGPoint {
 
 [Exposed=Window] interface SVGMeshElement : SVGGeometryElement {};
 [Exposed=Window] interface SVGSolidcolorElement : SVGElement {};
-[Exposed=Window] interface SVGStylable {};
-[Exposed=Window] interface SVGTransformable {};
 [Exposed=Window] interface SVGUnknownElement {};
-[Exposed=Window] interface SVGViewSpec {};
 
 // SVGZoomAndPan has been both an interface and a mixin in implementations.
 // Cover all bases:
@@ -41,7 +38,6 @@ interface mixin ZoomAndPan {
 };
 SVGSVGElement includes ZoomAndPan;
 SVGViewElement includes ZoomAndPan;
-SVGViewSpec includes ZoomAndPan;
 
 typedef object SVGPathSegClosePath;
 typedef object SVGPathSegMovetoAbs;
@@ -243,29 +239,11 @@ partial interface SVGSVGElement {
   readonly attribute float pixelUnitToMillimeterY;
   readonly attribute float screenPixelToMillimeterX;
   readonly attribute float screenPixelToMillimeterY;
-  readonly attribute boolean useCurrentView;
-  readonly attribute SVGViewSpec currentView;
 };
 
 // https://www.w3.org/TR/SVG11/text.html#InterfaceSVGTRefElement
 [Exposed=Window]
 interface SVGTRefElement : SVGTextPositioningElement {
-};
-
-// https://www.w3.org/TR/SVG11/types.html#InterfaceSVGTests
-[Exposed=Window]
-interface SVGTests {
-  readonly attribute SVGStringList requiredFeatures;
-  readonly attribute SVGStringList requiredExtensions;
-  readonly attribute SVGStringList systemLanguage;
-
-  boolean hasExtension(DOMString extension);
-};
-
-// https://www.w3.org/TR/SVG11/types.html#InterfaceSVGURIReference
-[Exposed=Window]
-interface SVGURIReference {
-  readonly attribute SVGAnimatedString href;
 };
 
 // https://www.w3.org/TR/SVG11/fonts.html#InterfaceSVGVKernElement


### PR DESCRIPTION
This PR removes the IDL for SVG features that have been removed from BCD.
