### PR TITLE
Remove IDL for CSS features removed from BCD

### DIFF
--- a/custom-idl/cssom.idl
+++ b/custom-idl/cssom.idl
@@ -89,22 +89,6 @@ partial interface Document {
 
 // Non-standard stuff
 
-// https://github.com/mozilla/gecko-dev/blob/358fbca0398ac651f5ea6030be39b1870ec180a5/dom/webidl/CSS2Properties.webidl.in
-[Exposed=Window]
-interface CSS2Properties : CSSStyleDeclaration {};
-
-partial interface CSSStyleDeclaration {
-  // https://github.com/WebKit/WebKit/blob/2ebcb2f801bc60264b1a154a7970e2581a438db2/Source/WebCore/css/CSSStyleDeclaration.idl#L45
-  DOMString getPropertyShorthand(DOMString property);
-
-  // https://github.com/WebKit/WebKit/blob/2ebcb2f801bc60264b1a154a7970e2581a438db2/Source/WebCore/css/CSSStyleDeclaration.idl#L46
-  boolean isPropertyImplicit(DOMString property);
-};
-
-// https://github.com/mozilla/gecko-dev/blob/358fbca0398ac651f5ea6030be39b1870ec180a5/dom/webidl/CSSMozDocumentRule.webidl
-[Exposed=Window]
-interface CSSMozDocumentRule : CSSConditionRule {};
-
 partial interface Document {
   // https://www.w3.org/Bugs/Public/show_bug.cgi?id=29471
   attribute DOMString? selectedStyleSheetSet;
@@ -117,16 +101,6 @@ partial interface Document {
   readonly attribute long width;
   // https://developer.mozilla.org/en-US/docs/Web/API/Document/height
   readonly attribute long height;
-};
-
-[Exposed=Window] interface MSCurrentStyleCSSProperties {};
-[Exposed=Window] interface MSStyleCSSProperties {};
-
-partial interface Element {
-  // https://docs.microsoft.com/en-us/previous-versions/windows/internet-explorer/ie-developer/platform-apis/aa703980(v=vs.85)
-  readonly attribute MSCurrentStyleCSSProperties? currentStyle;
-  // https://docs.microsoft.com/en-us/previous-versions/windows/internet-explorer/ie-developer/platform-apis/aa703996(v=vs.85)
-  readonly attribute MSStyleCSSProperties? runtimeStyle;
 };
 
 partial interface Window {


### PR DESCRIPTION
This PR removes the custom IDL for CSS features that have been removed for BCD or are proprietary features that haven't been added to BCD.
