### PR TITLE
Remove IDL for BlobBuilder

### DIFF
--- a/custom-idl/file-writer-api.idl
+++ b/custom-idl/file-writer-api.idl
@@ -1,15 +1,6 @@
 // https://www.w3.org/TR/2012/WD-file-writer-api-20120417/
 
 [Exposed=Window,Worker]
-interface BlobBuilder {
-  constructor();
-  Blob getBlob (optional DOMString contentType);
-  undefined append (DOMString text, optional DOMString endings);
-  undefined append (Blob data);
-  undefined append (ArrayBuffer data);
-};
-
-[Exposed=Window,Worker]
 interface FileSaver : EventTarget {
   constructor(Blob data);
   undefined abort ();


### PR DESCRIPTION
This PR removes the IDL for the BlobBuilder API.  This API has previously been removed from BCD.
