### PR TITLE
Remove IDL for CanvasCaptureMediaStream API

### DIFF
--- a/custom-idl/mediacapture-fromelement.idl
+++ b/custom-idl/mediacapture-fromelement.idl
@@ -1,7 +1,0 @@
-// https://github.com/mozilla/gecko-dev/blob/9399e5832979755cd340383f4ca4069dd5fc7774/dom/webidl/CanvasCaptureMediaStream.webidl
-// Like https://w3c.github.io/mediacapture-fromelement/#the-canvascapturemediastreamtrack but without "Track"
-[Exposed=Window]
-interface CanvasCaptureMediaStream : MediaStream {
-  readonly attribute HTMLCanvasElement canvas;
-  undefined requestFrame();
-};


### PR DESCRIPTION
This PR removes the custom IDL for the CanvaasCaptureMediaStream API.  This API is non-standard and is not presently in BCD, so it should not be added.
