### PR TITLE
Remove IDL for LocalMediaStream API

### DIFF
--- a/custom-idl/mediacapture-streams.idl
+++ b/custom-idl/mediacapture-streams.idl
@@ -1,8 +1,3 @@
-[Exposed=Window]
-interface LocalMediaStream : MediaStream {
-  undefined stop();
-};
-
 partial interface MediaStream {
   readonly attribute boolean ended;
   readonly attribute DOMString label;


### PR DESCRIPTION
This PR removes the custom IDL for the LocalMediaStream API.  This API has been previously removed from BCD.
