### PR TITLE
Add back removed bits of CanMakePaymentEvent as custom IDL

### DIFF
--- a/custom-idl/payment-handler.idl
+++ b/custom-idl/payment-handler.idl
@@ -9,9 +9,14 @@ partial interface ServiceWorkerGlobalScope {
   attribute EventHandler onabortpayment;
 };
 
-// https://github.com/w3c/payment-handler/pull/170
 partial interface CanMakePaymentEvent {
+  // https://github.com/w3c/payment-handler/pull/170
   readonly attribute FrozenArray<PaymentDetailsModifier> modifiers;
+
+  // https://github.com/w3c/payment-handler/pull/404
+  readonly attribute USVString topOrigin;
+  readonly attribute USVString paymentRequestOrigin;
+  readonly attribute FrozenArray<PaymentMethodData> methodData;
 };
 
 // https://github.com/w3c/payment-handler/pull/389


### PR DESCRIPTION
These are still in Chrome, planned to be removed in 111:
https://groups.google.com/a/chromium.org/g/blink-dev/c/AM2bwKxXacQ/m/2V91nC9JHQAJ
