### PR TITLE
Trying to add webassembly.features

### DIFF
--- a/custom-tests.yaml
+++ b/custom-tests.yaml
@@ -2535,3 +2535,14 @@ css:
     custom-property: |-
       return CSS.supports('color', 'var(--foo)') || CSS.supports('color',
       'env(--foo)');
+
+webassembly:
+  features:
+    foo:
+      __base: |-
+        var instance = {};
+      __test: return true;
+    bar:
+      __base: |-
+        var instance = {};
+      __test: return false;

--- a/find-missing-features.js
+++ b/find-missing-features.js
@@ -40,7 +40,7 @@ const traverseFeatures = (obj, path, includeAliases) => {
             }
             if (statement.prefix) {
               let name = id;
-              if (path.startsWith('api.')) {
+              if (path.startsWith('webassembly.')) {//??
                 name = name[0].toUpperCase() + name.substr(1);
               }
               aliases.add(statement.prefix + name);
@@ -94,7 +94,8 @@ const getMissing = (
       bcd.javascript.builtins,
       'javascript.builtins.',
       includeAliases
-    )
+    ),
+    ...traverseFeatures(bcd.webassembly.features, 'webassembly.features.', includeAliases),
   ].filter(filterCategory);
   const collectorEntries = Object.keys(tests).filter(filterCategory);
 
@@ -137,8 +138,8 @@ const main = (bcd, tests) => {
           alias: 'c',
           describe: 'The BCD categories to filter',
           type: 'array',
-          choices: ['api', 'css.properties', 'javascript.builtins'],
-          default: ['api', 'css.properties', 'javascript.builtins']
+          choices: ['api', 'css.properties', 'javascript.builtins', 'webassembly.features'],
+          default: ['api', 'css.properties', 'javascript.builtins', 'webassembly.features']
         });
     }
   );

--- a/update-bcd.ts
+++ b/update-bcd.ts
@@ -539,8 +539,8 @@ if (esMain(import.meta)) {
           alias: 'c',
           describe: 'The BCD categories to update',
           type: 'array',
-          choices: ['api', 'css.properties', 'javascript.builtins'],
-          default: ['api', 'css.properties', 'javascript.builtins']
+          choices: ['api', 'css.properties', 'javascript.builtins', 'webassembly.features'],
+          default: ['api', 'css.properties', 'javascript.builtins', 'webassembly.features']
         })
         .option('path', {
           alias: 'p',


### PR DESCRIPTION
Running `npm run update-bcd -- --path=webassembly.features*` doesn't create/modify the files in `browser-compat-data`

(I tried a few other things, but this didn't help either)
