### PR TITLE
Stop using DocumentAndElementEventHandlers

### DIFF
--- a/custom-idl/clipboard-apis.idl
+++ b/custom-idl/clipboard-apis.idl
@@ -1,4 +1,4 @@
-partial interface mixin DocumentAndElementEventHandlers {
+partial interface mixin GlobalEventHandlers {
   // https://github.com/w3c/clipboard-apis/issues/25
   attribute EventHandler onbeforecopy;
   attribute EventHandler onbeforecut;

--- a/custom-idl/html.idl
+++ b/custom-idl/html.idl
@@ -253,14 +253,6 @@ partial interface mixin GlobalEventHandlers {
   attribute EventHandler onshow;
 };
 
-// DocumentAndElementEventHandlers here is used for things that have been on
-// GlobalEventHandlers but are now on Window, as it is the complementary set.
-// https://trac.webkit.org/changeset/267791/webkit
-partial interface mixin DocumentAndElementEventHandlers {
-  attribute EventHandler onrejectionhandled;
-  attribute EventHandler onunhandledrejection;
-};
-
 partial interface HashChangeEvent {
   undefined initHashChangeEvent();
 };


### PR DESCRIPTION
Use GlobalEventHandlers instead in one case, and for the promise events
just remove the custom IDL as we'd never add anything to BCD for that.
