### PR TITLE
Delete production smoke test

### DIFF
--- a/.github/workflows/pull_request.yml
+++ b/.github/workflows/pull_request.yml
@@ -30,15 +30,6 @@ jobs:
       - run: npm run format
       - run: npm run build
       - run: npm run unittest
-      # ensure we can start the server without dev dependencies
-      - name: production smoke test
-        run: |
-          npm ci --production
-          cp secrets.sample.json secrets.json
-          npm start &
-          npx wait-on -t 10000 -v http://localhost:8080
-        env:
-          NODE_ENV: production
 env:
   FORCE_COLOR: 3
   BCD_DIR: ./browser-compat-data


### PR DESCRIPTION
It won't work after https://github.com/foolip/mdn-bcd-collector/pull/2590
and until the ts-node dependency is fixed.
