### PR TITLE
Update Selenium script

### DIFF
--- a/selenium.ts
+++ b/selenium.ts
@@ -53,7 +53,7 @@ const seleniumUrls = {
   lambdatest: 'https://${username}:${key}@hub.lambdatest.com/wd/hub'
 };
 
-// Custom tests that use getUserMedia() make Edge 12-18 and Firefox 34-53 block.
+// Custom tests that use getUserMedia() make Chrome 25-26, Edge 12-18 and Firefox 34-53 block.
 const gumTests = [
   'ImageCapture',
   'MediaStream',
@@ -64,8 +64,8 @@ const gumTests = [
 
 const ignore = {
   chrome: {
-    25: ['api.MediaStreamAudioDestinationNode'],
-    26: ['api.MediaStreamAudioDestinationNode']
+    25: gumTests,
+    26: gumTests
   },
   edge: {
     12: gumTests,

--- a/selenium.ts
+++ b/selenium.ts
@@ -482,7 +482,7 @@ const run = async (browser, version, os, ctx, task) => {
     await driver.wait(until.elementLocated(By.id('status')), 30000);
     statusEl = await driver.findElement(By.id('status'));
     try {
-      await driver.wait(until.elementTextContains(statusEl, 'upload'), 60000);
+      await driver.wait(until.elementTextContains(statusEl, 'upload'), 90000);
     } catch (e) {
       if ((e as Error).name == 'TimeoutError') {
         throw new Error(

--- a/selenium.ts
+++ b/selenium.ts
@@ -194,22 +194,31 @@ const getOsesToTest = (service, os) => {
       ];
       break;
     case 'macOS':
-      osesToTest =
-        service === 'saucelabs'
-          ? [['macOS', '10.14']]
-          : service === 'lambdatest'
-          ? [
-              ['macOS', 'Monterey'],
-              ['macOS', 'Big Sur'],
-              ['macOS', 'Mojave'],
-              ['OS X', 'El Capitan']
-            ]
-          : [
-              ['OS X', 'Monterey'],
-              ['OS X', 'Big Sur'],
-              ['OS X', 'Mojave'],
-              ['OS X', 'El Capitan']
-            ];
+      switch (service) {
+        case 'saucelabs':
+          osesToTest = [
+            ['macOS', '13'],
+            ['macOS', '10.14']
+          ];
+          break;
+        case 'lambdatest':
+          osesToTest = [
+            ['macOS', 'Ventura'],
+            ['macOS', 'Monterey'],
+            ['macOS', 'Big Sur'],
+            ['macOS', 'Mojave'],
+            ['OS X', 'El Capitan']
+          ];
+          break;
+        default:
+          osesToTest = [
+            ['OS X', 'Ventura'],
+            ['OS X', 'Monterey'],
+            ['OS X', 'Big Sur'],
+            ['OS X', 'Mojave'],
+            ['OS X', 'El Capitan']
+          ];
+      }
       break;
     default:
       throw new Error(`Unknown/unsupported OS: ${os}`);

--- a/selenium.ts
+++ b/selenium.ts
@@ -203,7 +203,6 @@ const getOsesToTest = (service, os) => {
           break;
         case 'lambdatest':
           osesToTest = [
-            ['macOS', 'Ventura'],
             ['macOS', 'Monterey'],
             ['macOS', 'Big Sur'],
             ['macOS', 'Mojave'],
@@ -213,7 +212,6 @@ const getOsesToTest = (service, os) => {
         default:
           // BrowserStack
           osesToTest = [
-            ['OS X', 'Ventura'],
             ['OS X', 'Monterey'],
             ['OS X', 'Big Sur'],
             ['OS X', 'Mojave'],


### PR DESCRIPTION
- Add macOS Ventura to Selenium
- Fix Selenium capabilities
- Revert "Add macOS Ventura to Selenium"
- Increase test timeout duration in Selenium script
- Ignore all user media tests in Chrome 25-26
