### PR TITLE
Re-enable BatteryManager API tests

### DIFF
--- a/custom-tests.yaml
+++ b/custom-tests.yaml
@@ -263,14 +263,13 @@ api:
       decodeAudioData.returns_promise: |-
         <%api.BaseAudioContext:ctx%>
         return ctx.decodeAudioData.length === 1;
-  # XXX Freezes in many versions of Chrome and Firefox
-  # BatteryManager:
-  #   __base: |-
-  #     if (!('getBattery' in navigator)) {
-  #       return {result: false, message: 'navigator.getBattery() is not defined'};
-  #     };
-  #     var promise = navigator.getBattery();
-  #     promise.then(function() {});
+  BatteryManager:
+    __base: |-
+      if (!('getBattery' in navigator)) {
+        return {result: false, message: 'navigator.getBattery() is not defined'};
+      };
+      var promise = navigator.getBattery();
+      promise.then(function() {});
   BeforeInstallPromptEvent:
     __base: |-
       try {


### PR DESCRIPTION
Since tests can now time out to prevent freezing the collector, this can now be enabled.

(cherry picked from commit 03b6ac5f0326f94f1c10174abf450e14bcc39d8d)
