### PR TITLE
Move minimatch logic into update-bcd's update() function

### DIFF
--- a/.eslintrc.json
+++ b/.eslintrc.json
@@ -16,14 +16,17 @@
     "max-len": "off",
     "indent": "off",
     "no-else-return": "error",
-    "no-unused-vars": ["error", {"varsIgnorePattern": "^_$"}],
+    "no-unused-vars": "off",
     "prefer-arrow/prefer-arrow-functions": "error",
     "quotes": "off",
     "quote-props": ["error", "as-needed"],
     "require-jsdoc": "off",
     "space-before-function-paren": "off",
     "unicorn/prefer-node-protocol": "error",
-    "@typescript-eslint/no-unused-vars": "off",
+    "@typescript-eslint/no-unused-vars": [
+      "error",
+      {"varsIgnorePattern": "^_$"}
+    ],
     "@typescript-eslint/no-explicit-any": "off",
     "@typescript-eslint/no-empty-function": "off"
   },

--- a/package-lock.json
+++ b/package-lock.json
@@ -40,6 +40,7 @@
         "@browser-logos/internet-explorer_9-11": "1.1.16",
         "@browser-logos/opera": "1.1.11",
         "@browser-logos/safari": "2.1.0",
+        "@types/minimatch": "5.1.2",
         "@types/mocha": "10.0.1",
         "@types/node": "18.11.18",
         "@types/superagent": "4.1.16",
@@ -2586,6 +2587,12 @@
       "version": "1.0.2",
       "resolved": "https://registry.npmjs.org/@types/mdurl/-/mdurl-1.0.2.tgz",
       "integrity": "sha512-eC4U9MlIcu2q0KQmXszyn5Akca/0jrQmwDRgpAMJai7qBWq4amIQhZyNau4VYGtCeALvW1/NtjzJJ567aZxfKA=="
+    },
+    "node_modules/@types/minimatch": {
+      "version": "5.1.2",
+      "resolved": "https://registry.npmjs.org/@types/minimatch/-/minimatch-5.1.2.tgz",
+      "integrity": "sha512-K0VQKziLUWkVKiRVrx4a40iPaxTUefQmjtkQofBkYRcoaaL/8rhwDWww9qWbrgicNOgnpIsMxyNIUM4+n6dUIA==",
+      "dev": true
     },
     "node_modules/@types/minimist": {
       "version": "1.2.2",
@@ -12337,6 +12344,12 @@
       "version": "1.0.2",
       "resolved": "https://registry.npmjs.org/@types/mdurl/-/mdurl-1.0.2.tgz",
       "integrity": "sha512-eC4U9MlIcu2q0KQmXszyn5Akca/0jrQmwDRgpAMJai7qBWq4amIQhZyNau4VYGtCeALvW1/NtjzJJ567aZxfKA=="
+    },
+    "@types/minimatch": {
+      "version": "5.1.2",
+      "resolved": "https://registry.npmjs.org/@types/minimatch/-/minimatch-5.1.2.tgz",
+      "integrity": "sha512-K0VQKziLUWkVKiRVrx4a40iPaxTUefQmjtkQofBkYRcoaaL/8rhwDWww9qWbrgicNOgnpIsMxyNIUM4+n6dUIA==",
+      "dev": true
     },
     "@types/minimist": {
       "version": "1.2.2",

--- a/package.json
+++ b/package.json
@@ -68,6 +68,7 @@
     "@browser-logos/internet-explorer_9-11": "1.1.16",
     "@browser-logos/opera": "1.1.11",
     "@browser-logos/safari": "2.1.0",
+    "@types/minimatch": "5.1.2",
     "@types/mocha": "10.0.1",
     "@types/node": "18.11.18",
     "@types/superagent": "4.1.16",

--- a/unittest/unit/update-bcd.ts
+++ b/unittest/unit/update-bcd.ts
@@ -11,7 +11,6 @@ import {Report} from '../../types/types.js';
 import {assert} from 'chai';
 import sinon from 'sinon';
 import fs from 'fs-extra';
-import minimatch from 'minimatch';
 import {Browsers} from '@mdn/browser-compat-data/types';
 
 import logger from '../../lib/logger.js';
@@ -1593,7 +1592,7 @@ describe('BCD updater', () => {
 
       it('path', () => {
         const filter = {
-          path: new minimatch.Minimatch('css.properties.*')
+          path: 'css.properties.*'
         };
         expectedBcd.css.properties[
           'font-family'


### PR DESCRIPTION
Pull out the handling to the start of the function rather than inside a
loop, and add types to make the separation between main() and update()
filter arguments a bit clearer. Categories are only used for loading the
data, and the filter is now always a string.
