### PR TITLE
Remove custom IDL for onbeforematch on Element

### DIFF
--- a/custom-idl/display-locking.idl
+++ b/custom-idl/display-locking.idl
@@ -1,5 +1,0 @@
-// https://github.com/WICG/display-locking/
-
-partial interface Element {
-  attribute EventHandler onbeforematch;
-};


### PR DESCRIPTION
It's already on GlobalEventHandlers via @webref/idl.
