### PR TITLE
Remove custom IDL for onbeforexrselect on Element

### DIFF
--- a/custom-idl/dom-overlays.idl
+++ b/custom-idl/dom-overlays.idl
@@ -1,4 +1,0 @@
-// https://bugs.chromium.org/p/chromium/issues/detail?id=1108685
-partial interface Element {
-  attribute EventHandler onbeforexrselect;
-};


### PR DESCRIPTION
It's already on GlobalEventHandlers via @webref/idl.
