### PR TITLE
Remove custom event handler properties on Element

### DIFF
--- a/custom-idl/html.idl
+++ b/custom-idl/html.idl
@@ -113,16 +113,6 @@ partial interface Document {
   any registerElement(DOMString type, optional ElementRegistrationOptions options = {});
 };
 
-partial interface Element {
-  // https://github.com/whatwg/html/issues/667
-  attribute EventHandler onsearch;
-
-  // event handler attributes in the wrong place
-  attribute EventHandler oncopy;
-  attribute EventHandler oncut;
-  attribute EventHandler onpaste;
-};
-
 partial interface mixin GlobalEventHandlers {
   // https://github.com/mozilla/gecko-dev/blob/ffdb6a4d934b3f5294f18cf0e1df618109ccb36b/dom/webidl/EventHandler.webidl#L47
   attribute EventHandler ondragexit;


### PR DESCRIPTION
This IDL will generate additional tests which could provide information
about what BCD should say if combined with other tests, but as actually
used now they alone would be used and will probaly be wrong.

See https://github.com/foolip/mdn-bcd-collector/issues/2636.
