### PR TITLE
Fix ImageBitmap custom tests

### DIFF
--- a/custom-tests.yaml
+++ b/custom-tests.yaml
@@ -1344,7 +1344,7 @@ api:
         // XXX Implement worker tests for ImageBitmap
         return {result: null, message: 'Testing ImageBitmap in workers is not yet implemented'};
       }
-      var instance = createImageBitmap(document.getElementById('resource-image-black'));
+      var promise = createImageBitmap(document.getElementById('resource-image-black'));
   ImageCapture:
     __base: |-
       <%api.MediaDevices:mediaDevices%>


### PR DESCRIPTION
createImageBitmap() returns a promise, not an ImageBitmap directly.
