### PR TITLE
Add custom tests for InkPresenter

### DIFF
--- a/custom-tests.yaml
+++ b/custom-tests.yaml
@@ -1366,6 +1366,8 @@ api:
         <%api.CanvasRenderingContext2D:ctx%>
         instance = ctx.createImageData(16, 16);
       }
+  InkPresenter:
+    __base: var promise = navigator.ink.requestPresenter();
   InstallEvent:
     __base: |-
       if (!('InstallEvent' in self)) {


### PR DESCRIPTION
This is needed because the interface has the wrong name in Chromium:
https://bugs.chromium.org/p/chromium/issues/detail?id=1404901
