### PR TITLE
Handle LegacyNoInterfaceObject

### DIFF
--- a/build.ts
+++ b/build.ts
@@ -777,6 +777,13 @@ const buildIDLTests = (ast, globals, scopes) => {
       continue;
     }
 
+    // If [LegacyNoInterfaceObject] is used on the interface and there aren't
+    // any custom tests, build no tests for this interface.
+    const noInterfaceObject = getExtAttr(iface, 'LegacyNoInterfaceObject');
+    if (noInterfaceObject && !(iface.name in customTests.api)) {
+      continue;
+    }
+
     const exposureSet = getExposureSet(iface, scopes);
     const isGlobal = !!getExtAttr(iface, 'Global');
     const customIfaceTest = getCustomTestAPI(iface.name);

--- a/custom-idl/file-system-api.idl
+++ b/custom-idl/file-system-api.idl
@@ -15,7 +15,7 @@ interface mixin LocalFileSystem {
 };
 Window includes LocalFileSystem;
 
-[Exposed=Window,Worker]
+[Exposed=(Window,Worker), LegacyNoInterfaceObject]
 interface Metadata {
  readonly attribute object modificationTime;
  readonly attribute unsigned long long size;


### PR DESCRIPTION
The effect of this is to remove the tests for Metadata, which don't work
because this interface has [LegacyNoInterfaceObject] in Chromium.
Writing custom tests is hard because it requires accessing the local
file system and calling getMetadata() on an entry.