### PR TITLE
Require all CSS property values to be supported for multi-value entries

### DIFF
--- a/build.ts
+++ b/build.ts
@@ -918,7 +918,7 @@ const buildCSS = (specCSS, customCSS) => {
       const values = Array.isArray(value) ? value : [value];
       const code = values
         .map((value) => `bcd.testCSSPropertyValue("${name}", "${value}")`)
-        .join(' || ');
+        .join(' && ');
       tests[`css.properties.${name}.${key}`] = compileTest({
         raw: {code: code},
         exposure: ['Window']


### PR DESCRIPTION
This code was added here:
https://github.com/foolip/mdn-bcd-collector/pull/1805

The test for css.properties.text-align.flow_relative_values_start_and_end is:
bcd.testCSSPropertyValue("text-align", "start") || bcd.testCSSPropertyValue("text-align", "end")

With this change, it will instead require both values to be supported.
