### PR TITLE
Update CSS property testing

### DIFF
--- a/build.ts
+++ b/build.ts
@@ -867,29 +867,6 @@ const buildIDL = (specIDLs: IDLFiles, customIDLs: IDLFiles) => {
   return buildIDLTests(ast, globals, scopes);
 };
 
-// https://drafts.csswg.org/cssom/#css-property-to-idl-attribute
-const cssPropertyToIDLAttribute = (
-  property: string,
-  lowercaseFirst?: boolean
-) => {
-  let output = '';
-  let uppercaseNext = false;
-  if (lowercaseFirst) {
-    property = property.substr(1);
-  }
-  for (const c of property) {
-    if (c === '-') {
-      uppercaseNext = true;
-    } else if (uppercaseNext) {
-      uppercaseNext = false;
-      output += c.toUpperCase();
-    } else {
-      output += c;
-    }
-  }
-  return output;
-};
-
 const buildCSS = (specCSS, customCSS) => {
   const properties = new Map();
 
@@ -1091,7 +1068,6 @@ export {
   buildIDLTests,
   buildIDL,
   validateIDL,
-  cssPropertyToIDLAttribute,
   buildCSS,
   buildJS
 };

--- a/build.ts
+++ b/build.ts
@@ -943,7 +943,7 @@ const buildCSS = (specCSS, customCSS) => {
     ).sort() as any[]) {
       const values = Array.isArray(value) ? value : [value];
       const code = values
-        .map((value) => `bcd.testCSSPropertyValue("${name}", "${value}")`)
+        .map((value) => `bcd.testCSSProperty("${name}", "${value}")`)
         .join(' || ');
       tests[`css.properties.${name}.${key}`] = compileTest({
         raw: {code: code},

--- a/static/resources/harness.js
+++ b/static/resources/harness.js
@@ -454,9 +454,25 @@
     return output;
   }
 
-  function testCSSProperty(name) {
+  /**
+   * Test a CSS property for support
+   *
+   * name (string): The CSS property name
+   * value (string?): The CSS property value
+   *
+   * returns (TestResult): Whether the property is supported; if `value` is present,
+   *   whether that value is supported with the property
+   */
+  function testCSSProperty(name, value) {
     if ('CSS' in window && window.CSS.supports) {
-      return window.CSS.supports(name, 'inherit');
+      return window.CSS.supports(name, value || 'inherit');
+    }
+
+    if (value) {
+      var div = document.createElement('div');
+      div.style[name] = '';
+      div.style[name] = value;
+      return div.style.getPropertyValue(name) !== '';
     }
 
     var attrs = [name];
@@ -469,17 +485,6 @@
     }
 
     return false;
-  }
-
-  function testCSSPropertyValue(name, value) {
-    if ('CSS' in window && window.CSS.supports) {
-      return window.CSS.supports(name, value);
-    }
-
-    var div = document.createElement('div');
-    div.style[name] = '';
-    div.style[name] = value;
-    return div.style.getPropertyValue(name) !== '';
   }
 
   /**
@@ -1368,7 +1373,6 @@
     testObjectName: testObjectName,
     testOptionParam: testOptionParam,
     testCSSProperty: testCSSProperty,
-    testCSSPropertyValue: testCSSPropertyValue,
     addInstance: addInstance,
     addTest: addTest,
     runTests: runTests,

--- a/static/resources/harness.js
+++ b/static/resources/harness.js
@@ -423,38 +423,6 @@
   }
 
   /**
-   * Converts a CSS property name to an equivalent IDL attribute name
-   *
-   * property (string): The CSS property name
-   * lowercaseFirst (boolean?): (XXX Document me!)
-   *
-   * returns (string): The property name, camel-cased and without hyphens
-   */
-  function cssPropertyToIDLAttribute(property, lowercaseFirst) {
-    var output = '';
-    var uppercaseNext = false;
-
-    if (lowercaseFirst) {
-      property = property.substr(1);
-    }
-
-    for (var i = 0; i < property.length; i++) {
-      var c = property[i];
-
-      if (c === '-') {
-        uppercaseNext = true;
-      } else if (uppercaseNext) {
-        uppercaseNext = false;
-        output += c.toUpperCase();
-      } else {
-        output += c;
-      }
-    }
-
-    return output;
-  }
-
-  /**
    * Test a CSS property for support
    *
    * name (string): The CSS property name
@@ -468,23 +436,9 @@
       return window.CSS.supports(name, value || 'inherit');
     }
 
-    if (value) {
-      var div = document.createElement('div');
-      div.style[name] = '';
-      div.style[name] = value;
-      return div.style.getPropertyValue(name) !== '';
-    }
-
-    var attrs = [name];
-    attrs.push(cssPropertyToIDLAttribute(name, name.startsWith('-')));
-    for (var i = 0; i < attrs.length; i++) {
-      var attr = attrs[i];
-      if (attr in document.body.style) {
-        return true;
-      }
-    }
-
-    return false;
+    var div = document.createElement('div');
+    div.style[name] = value || 'inherit';
+    return div.style.getPropertyValue(name) !== '';
   }
 
   /**

--- a/static/resources/harness.js
+++ b/static/resources/harness.js
@@ -432,13 +432,15 @@
    *   whether that value is supported with the property
    */
   function testCSSProperty(name, value) {
+    // Use CSS.supports if available
     if ('CSS' in window && window.CSS.supports) {
       return window.CSS.supports(name, value || 'inherit');
     }
 
+    // Use fallback
     var div = document.createElement('div');
-    div.style[name] = value || 'inherit';
-    return div.style.getPropertyValue(name) !== '';
+    div.setProperty(name, value || 'inherit');
+    return div.getPropertyValue(name);
   }
 
   /**

--- a/unittest/unit/build.ts
+++ b/unittest/unit/build.ts
@@ -24,7 +24,6 @@ import {
   getCustomTestAPI,
   getCustomSubtestsAPI,
   getCustomResourcesAPI,
-  cssPropertyToIDLAttribute,
   buildCSS,
   getCustomTestCSS,
   buildJS
@@ -580,14 +579,6 @@ return canvas.getContext('webgl2') || canvas.getContext('webgl') || canvas.getCo
         exposure: ['Window']
       });
     });
-  });
-
-  it('cssPropertyToIDLAttribute', () => {
-    assert.equal(cssPropertyToIDLAttribute('line-height'), 'lineHeight');
-    assert.equal(
-      cssPropertyToIDLAttribute('-webkit-line-clamp', true),
-      'webkitLineClamp'
-    );
   });
 
   it('buildIDL', () => {

--- a/unittest/unit/build.ts
+++ b/unittest/unit/build.ts
@@ -1710,15 +1710,15 @@ interface Invalid {};
           exposure: ['Window']
         },
         'css.properties.font-family.emoji': {
-          code: 'bcd.testCSSPropertyValue("font-family", "emoji")',
+          code: 'bcd.testCSSProperty("font-family", "emoji")',
           exposure: ['Window']
         },
         'css.properties.font-family.historic': {
-          code: 'bcd.testCSSPropertyValue("font-family", "sans-serif") || bcd.testCSSPropertyValue("font-family", "serif")',
+          code: 'bcd.testCSSProperty("font-family", "sans-serif") || bcd.testCSSProperty("font-family", "serif")',
           exposure: ['Window']
         },
         'css.properties.font-family.system-ui': {
-          code: 'bcd.testCSSPropertyValue("font-family", "system-ui")',
+          code: 'bcd.testCSSProperty("font-family", "system-ui")',
           exposure: ['Window']
         },
         'css.properties.font-weight': {


### PR DESCRIPTION
- Combine testCSSPropertyValue into testCSSProperty
- Greatly simplify CSS property testing
- Remove no-op from build script
- Improve CSS property testing compatibility with older browsers
